### PR TITLE
Fix: order A2/A3 worker return after fast-path close

### DIFF
--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -10,6 +10,7 @@ guide when the failure happens during build, test setup, or simulation.
 | -------- | -------------- |
 | [Device Error Codes](device-error-codes.md) | Runtime and CANN error classification, first-response triage, minimal reproductions, and links to focused diagnostic guides |
 | [Local Runtime Timeouts](local-timeout-defaults.md) | Local and CI timeout defaults, override variables, and the required ordering for onboard watchdogs |
+| [A2/A3 Worker Retirement](a2a3-worker-retirement.md) | Why EXITED is not permission to return, and the group-wide CLOSE / GM-release handoff |
 | [a2a3 AICPU Shared-SO Device Fault](a2a3-507899-aicpu-shared-so-fault.md) | Diagnosing mass `507899`/`507018` cascades caused by an AICPU shared-library device fault |
 | [Sim CPU Oversubscription](sim-oversubscription-hang.md) | Simulation hangs and false timeouts when AICPU and AICore host threads are CPU-starved |
 

--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -10,7 +10,7 @@ guide when the failure happens during build, test setup, or simulation.
 | -------- | -------------- |
 | [Device Error Codes](device-error-codes.md) | Runtime and CANN error classification, first-response triage, minimal reproductions, and links to focused diagnostic guides |
 | [Local Runtime Timeouts](local-timeout-defaults.md) | Local and CI timeout defaults, override variables, and the required ordering for onboard watchdogs |
-| [A2/A3 Worker Retirement](a2a3-worker-retirement.md) | Why EXITED is not permission to return, and the group-wide CLOSE / GM-release handoff |
+| [A2/A3 Worker Retirement](a2a3-worker-retirement.md) ([Chinese translation](../zh-cn/troubleshooting/a2a3-worker-retirement.md)) | Why EXITED is not permission to return, and the group-wide CLOSE / GM-release handoff |
 | [a2a3 AICPU Shared-SO Device Fault](a2a3-507899-aicpu-shared-so-fault.md) | Diagnosing mass `507899`/`507018` cascades caused by an AICPU shared-library device fault |
 | [Sim CPU Oversubscription](sim-oversubscription-hang.md) | Simulation hangs and false timeouts when AICPU and AICore host threads are CPU-starved |
 

--- a/docs/troubleshooting/a2a3-worker-retirement.md
+++ b/docs/troubleshooting/a2a3-worker-retirement.md
@@ -1,0 +1,125 @@
+# A2/A3 worker retirement: CLOSE must precede return
+
+The A2/A3 persistent worker must not return after merely acknowledging EXIT.
+It must wait until the AICPU has closed the group's fast-path register windows
+and explicitly released the workers through global memory (GM).
+
+This applies to both `tensormap_and_ringbuffer` and `host_build_graph`.
+It does not add borrowed-stream/L1 support or change the A5 exit protocol.
+
+## What fast path means here
+
+The AICPU accesses each AICore's register window through MMIO. It writes
+`DATA_MAIN_BASE` to dispatch work and reads `COND` for ACK/FIN status. The
+AICore reads its own dispatch SPR and writes its own COND SPR.
+`FAST_PATH_ENABLE` (offset `0x18`) is written with `0xE` to open and `0xF`
+to close the window. This is a device-side dispatch mechanism, not a torch
+allocator setting, host task-queue option, or ACL event.
+
+## The missing ordering edge
+
+The old protocol established these two chains:
+
+```text
+AICore: observe EXIT -> write COND=EXITED -> return
+AICPU:                 observe EXITED   -> write IDLE -> CLOSE
+```
+
+They have a common predecessor, not an ordering between their tails. The
+following execution was therefore legal in the software protocol:
+
+1. AICore observes EXIT and publishes EXITED.
+2. AICore returns while its fast-path window is still open.
+3. AICPU observes EXITED, writes IDLE, and closes the window.
+
+EXITED proves that the worker has stopped accepting tasks. It cannot also
+prove that the AICPU has finished managing the window: that work occurs
+*after* the ACK. The missing edge is `CLOSE -> worker return`.
+
+A host mutex, an event between streams, or waiting for an entire launch to
+complete cannot retroactively order these two operations inside that launch.
+Multiple in-flight graph executions are not required for this race. Nor does
+an asynchronous error reported at a later native operator prove that the
+native operator caused it.
+
+## Two-phase retirement
+
+Normal shutdown uses the existing all-AICPU-thread completion rendezvous:
+the last participant retires the entire worker group. Retirement proceeds in
+separate passes:
+
+1. Send EXIT to every initialized core before waiting for any ACK.
+2. Collect EXITED from the group, using one shared deadline.
+3. Reset dispatch to IDLE and close every acknowledged window. Read back the
+   MMIO window and complete that read before publishing a GM return gate.
+4. Release-store `AICORE_POST_CLOSE_RELEASE` to each closed core's control word.
+5. AICore observes that word and only then returns.
+
+The A2/A3 onboard worker uses `ld_dev` for an uncached/bypass read and
+`dsb(DSB_DDR)` before return. The simulation uses an atomic acquire load.
+`ld_dev` is not being treated as a general-purpose atomic RMW or as a C++
+acquire operation; this is a single-writer, per-core handoff. The platform's
+MMIO completion ordering and visibility of the GM publication are distinct
+parts of the protocol. A release store alone does not flush posted MMIO.
+
+Emergency shutdown uses the same retirement helper and an ownership latch,
+so normal finalization does not subsequently write to already released
+workers' registers. A core that misses the deadline is not closed or released;
+responsive peers still retire. The existing host recovery path remains
+responsible for unresponsive cores and cores whose windows never opened.
+This patch does not introduce a new reset operation or recovery policy.
+
+## Cache-line and generation ownership
+
+`Handshake` contains two separately aligned 64-byte lines:
+
+| Line | Writer/access | Purpose |
+| ---- | ------------- | ------- |
+| First | Existing cached report/task publication protocol | Startup identity, ready report, dispatch-payload pointer |
+| Second | AICPU atomic stores; AICore bypass reads | Post-close permission to return |
+
+The return gate must not share the line flushed by the AICore's startup or
+exit report. Otherwise a stale cached report writeback could overwrite the
+AICPU's release. No cached writes or cache maintenance may target the gate
+line while it is active. Compile-time layout and trivial-copy assertions
+guard the shared host/AICPU/AICore image.
+
+The boot leader atomically resets the gate before publishing handshake setup
+and before any register window opens. Thus the preceding launch's value of
+1 cannot release a new launch. Reuse assumes the existing runtime lifecycle:
+the previous launch has completed before the same storage is re-armed. This
+is not a claim that one runtime image supports concurrent independent runs.
+
+HBG shares its `Handshake` definition with A5, so that internal image also
+grows from 64 to 128 bytes per worker on A5; the second line remains unused
+there. Host and device binaries must be rebuilt together. The public Python
+API and the A5 execution protocol are unchanged.
+
+## Evidence and reproduction boundaries
+
+The executor regression links each **production** A2/A3 AICore execution loop
+against simulated register storage. With CLOSE deliberately withheld, all
+four AIC/AIV checks fail on the unmodified main implementation at
+`fab1a41e2fd5bbefb9eb18e59609876e63297e98`: the worker returns immediately.
+With the handoff, those checks pass. Companion tests check eventual return,
+32 launches reusing the same gate, group ACK ordering, partial timeout, and
+invalid-target rejection.
+
+```bash
+cmake -S tests/ut/cpp -B tests/ut/cpp/build
+cmake --build tests/ut/cpp/build --parallel 2 \
+  --target test_a2a3_tensormap_and_ringbuffer_retirement test_a2a3_host_build_graph_retirement
+ctest --test-dir tests/ut/cpp/build -R '^test_a2a3_.*_retirement$' --output-on-failure
+```
+
+These are software-ordering tests; they do not emulate silicon register
+retirement hazards. The motivating downstream L1 ACLGraph investigation
+separately found that removing only the post-close wait changed a passing
+1280-replay run into a matching vector timeout at replay 2. The fault PC was
+at the persistent AIV wrapper's end, not inside the later native operator.
+That is downstream integration evidence, not a claim that upstream main
+already supports or reproduces that L1 graph workload. No undocumented
+internal hardware state-machine failure is asserted here.
+
+The PR's validation record distinguishes new upstream tests from this
+historical downstream evidence and lists any unavailable toolchains.

--- a/docs/zh-cn/troubleshooting/a2a3-worker-retirement.md
+++ b/docs/zh-cn/troubleshooting/a2a3-worker-retirement.md
@@ -1,0 +1,120 @@
+# A2/A3 worker 退出协议：必须先 CLOSE，再返回
+
+[英文原文](../../troubleshooting/a2a3-worker-retirement.md)
+
+A2/A3 的驻留 worker 不能仅仅因为已经确认收到 EXIT 就直接返回。
+它必须等到 AICPU 关闭该组 worker 的 fast-path 寄存器窗口，
+并通过全局内存（GM）明确发出放行信号后，才能返回。
+
+这一要求同时适用于 `tensormap_and_ringbuffer` 和 `host_build_graph`。
+本修复不新增借用外部 stream（borrowed-stream）/L1 支持，也不改变 A5 的退出协议。
+
+## 这里的 fast path 是什么
+
+AICPU 通过 MMIO 访问每个 AICore 的寄存器窗口：写入 `DATA_MAIN_BASE` 来分发任务，
+读取 `COND` 来获取 ACK/FIN 状态。AICore 则读取自己的任务分发专用寄存器（SPR），
+并写入自己的 COND SPR。
+向 `FAST_PATH_ENABLE`（偏移 `0x18`）写入 `0xE` 表示打开窗口，写入 `0xF` 表示关闭窗口。
+这是设备侧的任务分发机制，不是 torch allocator 配置、主机任务队列选项，也不是 ACL event。
+
+## 旧协议缺少哪条顺序约束
+
+旧协议建立了下面两条执行链：
+
+```text
+AICore: observe EXIT -> write COND=EXITED -> return
+AICPU:                 observe EXITED   -> write IDLE -> CLOSE
+```
+
+两条链存在共同的前序事件，却没有约束各自后续操作之间的先后关系。
+因此，下面的执行顺序并没有违反旧的软件协议：
+
+1. AICore 观察到 EXIT，并发布 EXITED。
+2. AICore 直接返回，此时它的 fast-path 窗口仍然打开。
+3. AICPU 观察到 EXITED，写入 IDLE，然后关闭窗口。
+
+EXITED 只能证明 worker 已经停止接收任务，不能同时证明 AICPU 已经完成窗口管理，
+因为后者发生在收到 ACK **之后**。缺失的顺序约束就是 `CLOSE -> worker return`。
+
+主机侧互斥锁、stream 之间的 event，或者等待整次启动（launch）完成，
+都不能反过来为该次启动内部的这两个操作补上顺序约束。
+发生这个竞态并不要求有多个在途的 graph 执行。
+同样，异步错误最终在后面的某个 native 算子处报出，也不能证明是那个 native 算子导致了错误。
+
+## 两阶段退出协议
+
+正常退出沿用现有的所有 AICPU 线程完成汇合机制：最后到达的参与者负责让整组 worker 退出。
+退出处理分为以下几个独立阶段：
+
+1. 先向所有已经初始化的 core 发送 EXIT，再开始等待任何 ACK。
+2. 使用一个共享的截止时间，收集整组 core 的 EXITED。
+3. 对已经确认退出的 core，将任务分发状态重置为 IDLE，并关闭对应窗口。
+   读回 MMIO 窗口并确保该次读取完成，然后才能通过 GM 发布返回许可。
+4. 以 release 语义，向每个已关闭窗口的 core 的控制字写入 `AICORE_POST_CLOSE_RELEASE`。
+5. AICore 观察到该控制字的放行值之后，才允许返回。
+
+A2/A3 实机上的 worker 使用 `ld_dev` 执行非缓存／绕过缓存的读取，
+并在返回前执行 `dsb(DSB_DDR)`。仿真版本使用具有 acquire 语义的原子读取。
+这里没有把 `ld_dev` 当作通用的原子读－改－写（RMW）操作，也没有把它当作 C++ acquire 操作；
+这里实现的是单写者、逐 core 的交接。
+平台对 MMIO 操作完成顺序的保证，与 GM 放行信号的可见性，是协议中两个不同的部分。
+仅靠 release store 并不能确保已经发出但尚未完成的 MMIO 写入真正完成。
+
+紧急退出使用同一个退出处理函数，并通过退出处理权标记（ownership latch）避免重复处理，
+防止后续正常收尾再次写入已经放行的 worker 的寄存器。
+如果某个 core 未能在截止时间前确认退出，就不会关闭它的窗口，也不会向它发出放行信号；
+其他能够响应的 core 仍然可以完成退出。
+无响应的 core，以及窗口从未成功打开的 core，仍由现有的主机恢复路径负责处理。
+本补丁不引入新的 reset 操作或恢复策略。
+
+## 缓存行隔离与跨次启动的状态归属
+
+`Handshake` 包含两条相互独立、各自按 64 字节对齐的缓存行：
+
+| 缓存行 | 写入方／访问方式 | 用途 |
+| ------ | ---------------- | ---- |
+| 第一条 | 现有的缓存式状态报告／任务发布协议 | 启动身份信息、就绪报告、任务分发载荷指针 |
+| 第二条 | AICPU 原子写入；AICore 绕过缓存读取 | 窗口关闭后的返回许可 |
+
+返回许可控制字不能与 AICore 启动报告或退出报告所刷新的缓存行共用一行。
+否则，旧的缓存报告在回写时，可能覆盖 AICPU 刚刚写入的放行值。
+在该控制字处于使用状态期间，不能对它所在的缓存行进行缓存式写入或缓存维护操作。
+编译期的布局断言和可平凡复制性断言，用于保护主机／AICPU／AICore 共享的数据布局。
+
+负责启动的 leader 会先以原子方式重置返回许可控制字，然后才发布握手初始化信息，
+并且这一重置发生在任何寄存器窗口打开之前。
+因此，前一次启动留下的值 1 不会错误地放行新一次启动。
+这种复用依赖现有 runtime 生命周期的前提：重新初始化同一块存储之前，前一次启动已经完成。
+这并不意味着同一份 runtime 数据支持多个相互独立的运行并发执行。
+
+HBG 与 A5 共用 `Handshake` 定义，所以 A5 上这一内部数据结构也从每个 worker 64 字节增至 128 字节；
+但第二条缓存行在 A5 上仍不使用。
+主机侧和设备侧二进制必须配套重新编译。
+公开的 Python API 和 A5 的执行协议保持不变。
+
+## 验证证据与复现边界
+
+执行器回归测试将两种 runtime 的 **实际生产版本** A2/A3 AICore 执行循环，
+分别与模拟的寄存器存储链接起来。
+在刻意不执行 CLOSE 的情况下，未经修改的 main 实现
+（提交 `fab1a41e2fd5bbefb9eb18e59609876e63297e98`）中的四项 AIC/AIV 检查全部失败：
+worker 会立即返回。
+加入交接协议之后，这些检查通过。
+配套测试还覆盖最终能够返回、连续 32 次启动复用同一返回许可控制字、
+整组 ACK 的顺序约束、部分 core 超时，以及拒绝无效目标。
+
+```bash
+cmake -S tests/ut/cpp -B tests/ut/cpp/build
+cmake --build tests/ut/cpp/build --parallel 2 \
+  --target test_a2a3_tensormap_and_ringbuffer_retirement test_a2a3_host_build_graph_retirement
+ctest --test-dir tests/ut/cpp/build -R '^test_a2a3_.*_retirement$' --output-on-failure
+```
+
+这些测试验证的是软件层面的顺序约束，并不模拟真实芯片在寄存器窗口退出阶段的硬件风险。
+促成本次修复的下游 L1 ACLGraph 排查还提供了另一组独立证据：
+仅移除窗口关闭后的等待，原本能够通过 1280 次 replay 的运行，就在第 2 次 replay 出现了同类 vector timeout。
+故障 PC 位于驻留式 AIV wrapper 的末尾，而不是后续 native 算子内部。
+这是下游集成场景的证据，不代表上游 main 已经支持或能够复现该 L1 graph 工作负载。
+本文也不据此断言任何未公开的硬件内部状态机故障。
+
+PR 的验证记录区分了本次新增的上游测试与上述历史下游证据，并列出了无法使用的工具链。

--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -23,8 +23,7 @@
  * Implementation: src/platform/shared/aicpu/platform_regs.cpp (shared across all platforms)
  */
 
-#ifndef PLATFORM_AICPU_PLATFORM_REGS_H_
-#define PLATFORM_AICPU_PLATFORM_REGS_H_
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -173,6 +172,19 @@ int32_t platform_finish_aicore_exit(uint64_t reg_addr, uint64_t deadline);
  */
 int32_t platform_deinit_aicore_regs(uint64_t reg_addr);
 
+struct AicoreTeardownControl;
+
+struct AicoreExitTarget {
+    uint64_t reg_addr;
+    AicoreTeardownControl *teardown;
+};
+
+// One caller owns the group after dispatch has stopped. Signal every core,
+// collect every ACK, close every responsive window, then release the workers.
+// Unacknowledged cores retain a closed return gate for host recovery.
+// Returns 0 on success, -1 on timeout or invalid targets; uses one deadline.
+int32_t platform_retire_aicore_group(const AicoreExitTarget *targets, size_t count, uint64_t deadline);
+
 /**
  * Variant-specific AICore deinit wait timeout, in ticks of get_sys_cnt_aicpu.
  *
@@ -199,5 +211,3 @@ uint64_t inner_get_deinit_timeout_ticks();
  * @return Physical core count (exclusive upper bound)
  */
 uint32_t platform_get_physical_cores_count();
-
-#endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a2a3/platform/onboard/aicore/inner_kernel.h
+++ b/src/a2a3/platform/onboard/aicore/inner_kernel.h
@@ -17,12 +17,12 @@
  * running on real Ascend hardware with CANN compiler support.
  */
 
-#ifndef PLATFORM_A2A3_AICORE_INNER_KERNEL_H_
-#define PLATFORM_A2A3_AICORE_INNER_KERNEL_H_
+#pragma once
 
 #include <cstdint>
 
 #include "common/platform_config.h"
+#include "aicore_teardown.h"
 
 // AICore function attribute for CANN compiler
 #ifndef __aicore__
@@ -43,6 +43,15 @@
 
 // OUT_OF_ORDER_FULL_BARRIER - no-op on real hardware (dcci handles full cache coherency)
 #define OUT_OF_ORDER_FULL_BARRIER() ((void)0)
+
+// EXITED acknowledges quiescence, not permission to return. The AICPU owns
+// this isolated line; bypass reads must not allocate a cached handshake copy.
+__aicore__ inline void wait_for_post_close_release(__gm__ uint32_t *release) {
+    while (static_cast<uint32_t>(ld_dev(release, 0)) != AICORE_POST_CLOSE_RELEASE) {
+        SPIN_WAIT_HINT();
+    }
+    dsb(DSB_DDR);
+}
 
 /**
  * Read an AICore register via SPR access
@@ -164,5 +173,3 @@ __aicore__ inline uint32_t get_physical_core_id() { return static_cast<uint32_t>
  * @return Hardware counter value (ticks)
  */
 __aicore__ __attribute__((always_inline)) inline uint64_t get_sys_cnt_aicore() { return get_sys_cnt(); }
-
-#endif  // PLATFORM_A2A3_AICORE_INNER_KERNEL_H_

--- a/src/a2a3/platform/shared/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/shared/aicpu/platform_regs.cpp
@@ -34,6 +34,8 @@
 #include "aicpu/platform_regs.h"
 #include "aicpu/device_time.h"
 #include "common/platform_config.h"
+#include "common/memory_barrier.h"
+#include "aicore_teardown.h"
 
 static uint64_t g_platform_regs = 0;
 static uint64_t g_platform_pmu_reg_addrs = 0;
@@ -80,12 +82,51 @@ int32_t platform_finish_aicore_exit(uint64_t reg_addr, uint64_t deadline) {
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
     // Close fast path control
     write_reg(reg_addr, RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_CLOSE);
+    // Complete the posted MMIO close before a caller publishes a Normal-memory
+    // return gate. A release store alone is not a device-write completion fence.
+    (void)read_reg(reg_addr, RegId::FAST_PATH_ENABLE);
+    rmb();
     return 0;
 }
 
 int32_t platform_deinit_aicore_regs(uint64_t reg_addr) {
     platform_signal_aicore_exit(reg_addr);
     return platform_finish_aicore_exit(reg_addr, platform_aicore_exit_deadline());
+}
+
+int32_t platform_retire_aicore_group(const AicoreExitTarget *targets, size_t count, uint64_t deadline) {
+    if (count > PLATFORM_MAX_CORES || (count != 0 && targets == nullptr)) return -1;
+    for (size_t i = 0; i < count; ++i) {
+        if (targets[i].reg_addr == 0 || targets[i].teardown == nullptr) return -1;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        platform_signal_aicore_exit(targets[i].reg_addr);
+    }
+    wmb();
+
+    bool acknowledged[PLATFORM_MAX_CORES] = {};
+    int32_t rc = 0;
+    for (size_t i = 0; i < count; ++i) {
+        while (read_reg(targets[i].reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {
+            if (get_sys_cnt_aicpu() > deadline) {
+                rc = -1;
+                break;
+            }
+        }
+        acknowledged[i] = read_reg(targets[i].reg_addr, RegId::COND) == AICORE_EXITED_VALUE;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (acknowledged[i]) {
+            acknowledged[i] = platform_finish_aicore_exit(targets[i].reg_addr, deadline) == 0;
+            if (!acknowledged[i]) rc = -1;
+        }
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (acknowledged[i]) {
+            __atomic_store_n(&targets[i].teardown->post_close_release, AICORE_POST_CLOSE_RELEASE, __ATOMIC_RELEASE);
+        }
+    }
+    return rc;
 }
 
 uint32_t platform_get_physical_cores_count() {

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -17,8 +17,7 @@
  * running in host-based simulation environment.
  */
 
-#ifndef PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
-#define PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_
+#pragma once
 
 #include <atomic>
 #include <cstdint>
@@ -26,6 +25,7 @@
 
 #include "aicpu/device_time.h"
 #include "common/platform_config.h"
+#include "aicore_teardown.h"
 
 // AICore function attribute - no-op in simulation
 #ifndef __aicore__
@@ -113,6 +113,12 @@ typedef int mem_dsb_t;
 // Equivalent to dmb ish (aarch64) / mfence (x86).
 #define OUT_OF_ORDER_FULL_BARRIER() __sync_synchronize()
 
+inline void wait_for_post_close_release(uint32_t *release) {
+    while (__atomic_load_n(release, __ATOMIC_ACQUIRE) != AICORE_POST_CLOSE_RELEASE) {
+        SPIN_WAIT_HINT();
+    }
+}
+
 // =============================================================================
 // System Counter Simulation
 // =============================================================================
@@ -187,5 +193,3 @@ inline void write_reg(RegId reg, uint64_t value) {
  * @return Physical core ID for the current simulated core
  */
 inline uint32_t get_physical_core_id() { return sim_get_physical_core_id(); }
-
-#endif  // PLATFORM_A2A3SIM_AICORE_INNER_KERNEL_H_

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -299,4 +299,5 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    wait_for_post_close_release(&my_hank->teardown.post_close_release);
 }

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -352,16 +352,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
     }
 
-    // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
-    // platform_deinit_aicore_regs is idempotent.
-    int32_t shutdown_rc = sched_ctx_.shutdown(thread_idx);
-    if (shutdown_rc != 0 && run_rc == 0) {
-        run_rc = shutdown_rc;
-    }
-
     LOG_INFO("Thread %d: Completed", thread_idx);
 
     completion_gate_.arrive_and_finalize_if_last(aicpu_thread_num_, [&] {
+        // No participant can still dispatch when the group begins retirement.
+        const int32_t shutdown_rc = sched_ctx_.shutdown(runtime);
+        if (shutdown_rc != 0 && run_rc == 0) run_rc = shutdown_rc;
         aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         // Destroy the host_build_graph runtime. sm_handle / rt are recreated
         // every run, so always tear them down here.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -526,36 +526,39 @@ void SchedulerContext::log_chip_swimlane_summary(int32_t thread_idx, int32_t cur
 #endif
 
 // =============================================================================
-// Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
-// Orchestrator threads have core_trackers_[thread_idx].core_num() == 0 -> no-op.
-// platform_deinit_aicore_regs is idempotent; safe to call after early completion.
+// Shutdown: one group-wide retirement after the AICPU thread rendezvous.
+// Emergency shutdown owns the same handoff once; normal finalization must not
+// touch registers of workers it has already released.
 // =============================================================================
-int32_t SchedulerContext::shutdown(int32_t thread_idx) {
-    const int32_t *cores = core_trackers_[thread_idx].core_ids();
-    int32_t core_num = core_trackers_[thread_idx].core_num();
-    if (core_num == 0) return 0;
+int32_t SchedulerContext::shutdown(Runtime *runtime) {
+    if (retirement_started_.load(std::memory_order_acquire)) return 0;
 
 #if SIMPLER_DFX
     if (is_pmu_enabled()) {
-        pmu_aicpu_finalize(cores, core_num);
+        int32_t cores[RUNTIME_MAX_WORKER];
+        int32_t count = 0;
+        for (int32_t i = 0; i < cores_total_num_; ++i) {
+            if (core_exec_states_[i].reg_addr != 0) cores[count++] = i;
+        }
+        if (count != 0) pmu_aicpu_finalize(cores, count);
     }
 #endif
+    return retire_cores(runtime);
+}
 
-    LOG_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
-    int32_t rc = 0;
-    for (int32_t i = 0; i < core_num; i++) {
-        int32_t core_id = cores[i];
-        uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
-        if (reg_addr != 0) {
-            // Timeout means AICore is unresponsive. Log and continue deiniting remaining cores.
-            if (platform_deinit_aicore_regs(reg_addr) != 0) {
-                LOG_ERROR("Thread %d: Core %d deinit timed out", thread_idx, core_id);
-                rc = -1;
-            }
-        } else {
-            LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+int32_t SchedulerContext::retire_cores(Runtime *runtime) {
+    // Normal shutdown runs at the all-thread rendezvous. Emergency shutdown
+    // elects one owner before touching the same register windows.
+    if (retirement_started_.exchange(true, std::memory_order_acq_rel)) return 0;
+    AicoreExitTarget targets[RUNTIME_MAX_WORKER];
+    size_t count = 0;
+    for (int32_t i = 0; i < cores_total_num_; ++i) {
+        if (core_exec_states_[i].reg_addr != 0) {
+            targets[count++] = {core_exec_states_[i].reg_addr, &runtime->get_workers()[i].teardown};
         }
     }
+    const int32_t rc = platform_retire_aicore_group(targets, count, platform_aicore_exit_deadline());
+    if (rc != 0) LOG_ERROR("AICore group retirement timed out");
     return rc;
 }
 
@@ -768,23 +771,10 @@ bool SchedulerContext::assign_cores_to_threads() {
 // deinit their AICore register blocks. Idempotent.
 // =============================================================================
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
-    (void)runtime;  // exit is now delivered via each core's register block, not GM
-    LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    int32_t timeout_count = 0;
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        // platform_deinit_aicore_regs writes DATA_MAIN_BASE=EXIT, which both
-        // releases a core still polling for its window to open and signals it to
-        // exit. Cores never opened (reg_addr==0) are reaped by the host device
-        // reset that follows a handshake failure.
-        if (core_exec_states_[i].reg_addr != 0) {
-            if (platform_deinit_aicore_regs(core_exec_states_[i].reg_addr) != 0) {
-                timeout_count++;
-            }
-        }
-    }
-    if (timeout_count > 0) {
-        LOG_ERROR("Emergency shutdown: %d cores did not acknowledge exit", timeout_count);
-    }
+    // Cores whose register windows never opened remain the host recovery
+    // path's responsibility. Responsive cores use the same return handoff.
+    LOG_WARN("Emergency shutdown: retiring all initialized AICores");
+    (void)retire_cores(runtime);
 }
 
 // =============================================================================
@@ -795,6 +785,7 @@ int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thr
 
     // Zero all per-core execution state before handshake
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
+    retirement_started_.store(false, std::memory_order_relaxed);
 
     // Wire thread configuration that handshake/assign need to read.
     aicpu_thread_num_ = aicpu_thread_num;
@@ -837,6 +828,12 @@ int32_t SchedulerContext::pre_handshake_init(Runtime *runtime, int32_t aicpu_thr
         LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
         return -1;
     }
+    // The prior launch may have left RELEASE=1. Reset through the same atomic
+    // path before publishing hs_setup_done_ and opening any register window.
+    for (int32_t i = 0; i < cores_total_num_; ++i) {
+        __atomic_store_n(&runtime->get_workers()[i].teardown.post_close_release, 0U, __ATOMIC_RELEASE);
+    }
+    wmb();
     aic_count_ = 0;
     aiv_count_ = 0;
     handshake_failed_.store(false, std::memory_order_release);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -150,10 +150,8 @@ public:
     // host_build_graph always reserves it (aicpu_thread_num >= 2 is required).
     int32_t p_thread_idx() const { return p_thread_idx_; }
 
-    // Shutdown AICore registers for this thread's assigned cores.
-    // Also runs PMU finalize (SIMPLER_DFX) before deinit when enabled.
-    // Orchestrator threads (core_trackers_[thread_idx].core_num() == 0) are a no-op.
-    int32_t shutdown(int32_t thread_idx);
+    // Retire all cores after every AICPU participant has stopped dispatching.
+    int32_t shutdown(Runtime *runtime);
 
     // Run all post-attach scheduler bookkeeping, once, on the boot leader:
     //  - publishes core assignments to the perf collector (SIMPLER_DFX)
@@ -224,6 +222,7 @@ private:
     std::atomic<int32_t> completed_tasks_{0};
     int32_t total_tasks_{0};
     std::atomic<bool> completed_{false};
+    std::atomic<bool> retirement_started_{false};
     uint64_t *func_id_to_addr_{nullptr};
 
     // --- Thread/core configuration ---
@@ -276,6 +275,7 @@ private:
     // Emergency shutdown: broadcast exit signal to every handshake'd core and
     // deinit their AICore register blocks. Idempotent.
     void emergency_shutdown(Runtime *runtime);
+    int32_t retire_cores(Runtime *runtime);
 
     __attribute__((noinline, cold)) void fail_scheduler(Runtime *runtime, int32_t thread_idx, int32_t error_code);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -274,4 +274,5 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     // Flush all dirty cache lines to HBM before kernel exit.
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    wait_for_post_close_release(&my_hank->teardown.post_close_release);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -869,21 +869,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
     }
 
-    // Shutdown AICore even when sched_ctx_.completed_ was already true:
-    // platform_deinit_aicore_regs is idempotent, and orchestrator threads have
-    // core_trackers_[thread_idx].core_num() == 0 so they skip the loop harmlessly.
-    // A fatal run is the exception — shutdown() returns immediately there,
-    // because emergency_shutdown() has already quiesced every core.
-    int32_t shutdown_rc = sched_ctx_.shutdown(thread_idx);
-    if (shutdown_rc != 0 && run_rc == 0) {
-        run_rc = shutdown_rc;
-    }
-
     LOG_INFO("Thread %d: Completed", thread_idx);
 
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
     if (prev_finished + 1 == aicpu_thread_num_) {
+        // No participant can still dispatch when the group begins retirement.
+        const int32_t shutdown_rc = sched_ctx_.shutdown(runtime);
+        if (shutdown_rc != 0 && run_rc == 0) run_rc = shutdown_rc;
         aicpu_publish_task_timing_tail_usage(aicpu_thread_num_);
         finished_.store(true, std::memory_order_release);
         // Destroy the runtime context. sm_handle / rt are recreated every run so we

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -603,7 +603,7 @@ Public surface (called from `AicpuExecutor::init/run/deinit`):
 | `init(runtime, aicpu_thread_num, sched_thread_num, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
 | `bind_runtime(rt)` | device-orch only | Wire `sched_` to `rt->scheduler` once the orchestrator thread creates `rt` |
 | `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
-| `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled. No-op on a fatal run — `emergency_shutdown` has already quiesced every core, and PMU finalize is skipped with it |
+| `shutdown(runtime)` | last AICPU thread on exit | Group-wide EXIT / ACK / CLOSE / post-close release; PMU finalize when enabled. No-op after emergency retirement has claimed the handoff. See [worker retirement](../../../../../docs/troubleshooting/a2a3-worker-retirement.md) |
 | `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | orchestrator thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_` (or `emergency_shutdown` on fatal) |
 | `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
 | Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -26,8 +26,7 @@
  * signals AICore via DATA_MAIN_BASE.
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
+#pragma once
 
 #include <stddef.h>  // for offsetof
 #include <stdbool.h>
@@ -45,6 +44,7 @@
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "dispatch_payload.h"
 #include "task_args.h"
+#include "aicore_teardown.h"
 #include "tensormap_and_ringbuffer/entry_args.h"  // EntryArgsStorage
 
 // =============================================================================
@@ -103,7 +103,12 @@ struct Handshake {
     volatile uint64_t task;         // DispatchPayload* published before register window-open
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV (reported by AICore with aicore_done)
     volatile uint32_t physical_core_id;  // Physical core ID (reported by AICore with aicore_done)
+    AicoreTeardownControl teardown;      // Separate from the AICore's cached report line
 } __attribute__((aligned(64)));
+
+static_assert(offsetof(Handshake, teardown) == 64);
+static_assert(sizeof(Handshake) == 128);
+static_assert(std::is_standard_layout_v<Handshake> && std::is_trivially_copyable_v<Handshake>);
 
 enum class TensorReleaseKind {
     Free,
@@ -355,5 +360,3 @@ static_assert(
 // object). Defined per-runtime so the shared device_runner_helpers.cpp copy
 // path stays runtime-agnostic.
 size_t runtime_device_copy_size(const Runtime &rt);
-
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -626,46 +626,39 @@ void SchedulerContext::log_chip_swimlane_summary(int32_t thread_idx, [[maybe_unu
 #endif
 
 // =============================================================================
-// Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
-// Orchestrator threads have core_trackers_[thread_idx].core_num() == 0 -> no-op.
-// platform_deinit_aicore_regs is idempotent; safe to call after early completion.
-//
-// A fatal run returns before any of that: emergency_shutdown() has already
-// broadcast exit to every core and quiesced its register block, so re-running
-// the per-thread path would only re-poll cores that have already stopped. PMU
-// finalize is skipped with it — the host force-resets the card after a fatal
-// run, so counters read here would not survive into the next generation.
+// Shutdown: one group-wide retirement after the AICPU thread rendezvous.
+// Emergency shutdown owns the same handoff once; normal finalization must not
+// touch registers of workers it has already released.
 // =============================================================================
-int32_t SchedulerContext::shutdown(int32_t thread_idx) {
-    if (fatal_shutdown_started_.load(std::memory_order_acquire)) {
-        return 0;
-    }
-
-    const int32_t *cores = core_trackers_[thread_idx].core_ids();
-    int32_t core_num = core_trackers_[thread_idx].core_num();
-    if (core_num == 0) return 0;
+int32_t SchedulerContext::shutdown(Runtime *runtime) {
+    if (retirement_started_.load(std::memory_order_acquire)) return 0;
 
 #if SIMPLER_DFX
     if (is_pmu_enabled()) {
-        pmu_aicpu_finalize(cores, core_num);
+        int32_t cores[RUNTIME_MAX_WORKER];
+        int32_t count = 0;
+        for (int32_t i = 0; i < cores_total_num_; ++i) {
+            if (core_exec_states_[i].reg_addr != 0) cores[count++] = i;
+        }
+        if (count != 0) pmu_aicpu_finalize(cores, count);
     }
 #endif
+    return retire_cores(runtime);
+}
 
-    LOG_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
-    int32_t rc = 0;
-    for (int32_t i = 0; i < core_num; i++) {
-        int32_t core_id = cores[i];
-        uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
-        if (reg_addr != 0) {
-            // Timeout means AICore is unresponsive. Log and continue deiniting remaining cores.
-            if (platform_deinit_aicore_regs(reg_addr) != 0) {
-                LOG_ERROR("Thread %d: Core %d deinit timed out", thread_idx, core_id);
-                rc = -1;
-            }
-        } else {
-            LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+int32_t SchedulerContext::retire_cores(Runtime *runtime) {
+    // Normal shutdown runs at the all-thread rendezvous. Emergency shutdown
+    // elects one owner before touching the same register windows.
+    if (retirement_started_.exchange(true, std::memory_order_acq_rel)) return 0;
+    AicoreExitTarget targets[RUNTIME_MAX_WORKER];
+    size_t count = 0;
+    for (int32_t i = 0; i < cores_total_num_; ++i) {
+        if (core_exec_states_[i].reg_addr != 0) {
+            targets[count++] = {core_exec_states_[i].reg_addr, &runtime->get_workers()[i].teardown};
         }
     }
+    const int32_t rc = platform_retire_aicore_group(targets, count, platform_aicore_exit_deadline());
+    if (rc != 0) LOG_ERROR("AICore group retirement timed out");
     return rc;
 }
 
@@ -1059,36 +1052,10 @@ bool SchedulerContext::begin_emergency_shutdown() {
 }
 
 void SchedulerContext::signal_emergency_shutdown(Runtime *runtime) {
-    (void)runtime;  // exit is now delivered via each core's register block, not GM
-    LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    // Broadcast to every core before joining any of them, so the cores drain
-    // concurrently and a dead core's timeout does not serialize behind the
-    // cores ahead of it. Cores never opened (reg_addr==0) are reaped by the
-    // host device reset that follows.
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        if (core_exec_states_[i].reg_addr != 0) {
-            platform_signal_aicore_exit(core_exec_states_[i].reg_addr);
-        }
-    }
-    // The join is what leaves the card usable for the next process: it quiesces
-    // each core's register block (dispatch idle, fast path closed) once the core
-    // confirms it stopped. Returning while cores still run leaves the card
-    // poisoned past the host's device reset. One deadline covers the whole
-    // group, so a fatal run where every core is dead costs a single deinit
-    // timeout rather than one per core. The wait is an on-device register poll,
-    // so it adds no host or remote operation.
-    const uint64_t exit_deadline = platform_aicore_exit_deadline();
-    int32_t timeout_count = 0;
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        if (core_exec_states_[i].reg_addr != 0) {
-            if (platform_finish_aicore_exit(core_exec_states_[i].reg_addr, exit_deadline) != 0) {
-                timeout_count++;
-            }
-        }
-    }
-    if (timeout_count > 0) {
-        LOG_ERROR("Emergency shutdown: %d cores did not acknowledge exit", timeout_count);
-    }
+    // Cores whose register windows never opened remain the host recovery
+    // path's responsibility. Responsive cores use the same return handoff.
+    LOG_WARN("Emergency shutdown: retiring all initialized AICores");
+    (void)retire_cores(runtime);
 }
 
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
@@ -1107,6 +1074,7 @@ int32_t SchedulerContext::pre_handshake_init(
 
     // Zero all per-core execution state before handshake
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
+    retirement_started_.store(false, std::memory_order_relaxed);
 
     // Wire thread/transition configuration that handshake/assign need to read.
     aicpu_thread_num_ = aicpu_thread_num;
@@ -1150,6 +1118,12 @@ int32_t SchedulerContext::pre_handshake_init(
         LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
         return -1;
     }
+    // The prior launch may have left RELEASE=1. Reset through the same atomic
+    // path before publishing hs_setup_done_ and opening any register window.
+    for (int32_t i = 0; i < cores_total_num_; ++i) {
+        __atomic_store_n(&runtime->get_workers()[i].teardown.post_close_release, 0U, __ATOMIC_RELEASE);
+    }
+    wmb();
     // The blocked 1 AIC : 2 AIV layout requires an exact multiple of 3: cluster ci
     // owns cores {ci, N/3+2ci, N/3+2ci+1}, so a non-zero remainder leaves the tail
     // AIV cores [3*(N/3), N) in no cluster — unhandshaked, their windows never open,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -8,8 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#ifndef SCHEDULER_CONTEXT_H
-#define SCHEDULER_CONTEXT_H
+#pragma once
 
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/platform_regs.h"
@@ -103,10 +102,8 @@ public:
     // Main scheduler thread entry: poll completion + dispatch ready tasks.
     int32_t resolve_and_dispatch(Runtime *runtime, int32_t thread_idx);
 
-    // Shutdown AICore registers for this thread's assigned cores.
-    // Also runs PMU finalize (SIMPLER_DFX) before deinit when enabled.
-    // Orchestrator threads (core_trackers_[thread_idx].core_num() == 0) are a no-op.
-    int32_t shutdown(int32_t thread_idx);
+    // Retire all cores after every AICPU participant has stopped dispatching.
+    int32_t shutdown(Runtime *runtime);
 
     // Run all post-orchestration scheduler bookkeeping:
     //  - publishes core assignments to the perf collector (SIMPLER_DFX)
@@ -180,6 +177,7 @@ private:
     std::atomic<bool> orchestrator_done_{false};
     std::atomic<bool> completed_{false};
     std::atomic<bool> fatal_shutdown_started_{false};
+    std::atomic<bool> retirement_started_{false};
     uint64_t *func_id_to_addr_{nullptr};
 
     // --- Thread/core configuration ---
@@ -225,6 +223,7 @@ private:
     // exit to every handshake'd core. Idempotent.
     bool begin_emergency_shutdown();
     void signal_emergency_shutdown(Runtime *runtime);
+    int32_t retire_cores(Runtime *runtime);
     void emergency_shutdown(Runtime *runtime);
 
     // =========================================================================
@@ -552,5 +551,3 @@ private:
         return func_id_to_addr_[func_id];
     }
 };
-
-#endif  // SCHEDULER_CONTEXT_H

--- a/src/common/host_build_graph/runtime.h
+++ b/src/common/host_build_graph/runtime.h
@@ -37,6 +37,7 @@
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "task_args.h"
+#include "aicore_teardown.h"
 #include "host_build_graph/entry_args.h"  // EntryArgsStorage
 
 // =============================================================================
@@ -69,7 +70,7 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * 4. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core payload
  * 5. Task Execution: AICore reads the cached DispatchPayload and executes
  * 6. Task Completion: AICore writes FIN to COND; AICPU observes completion
- * 7. Shutdown: AICPU writes the exit signal to DATA_MAIN_BASE; AICore exits
+ * 7. Shutdown (A2/A3): EXIT -> EXITED -> window-close -> GM release -> AICore returns
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
  * task execution across multiple cores.
@@ -96,7 +97,12 @@ struct Handshake {
     volatile uint64_t task;         // DispatchPayload* published before register window-open
     volatile CoreType core_type;    // Core type: CoreType::AIC or CoreType::AIV (reported by AICore with aicore_done)
     volatile uint32_t physical_core_id;  // Physical core ID (reported by AICore with aicore_done)
+    AicoreTeardownControl teardown;      // A2/A3 post-close release; unused on A5
 } __attribute__((aligned(64)));
+
+static_assert(offsetof(Handshake, teardown) == 64);
+static_assert(sizeof(Handshake) == 128);
+static_assert(std::is_standard_layout_v<Handshake> && std::is_trivially_copyable_v<Handshake>);
 
 /**
  * simpler::hbg::Tensor pair for tracking host-device memory mappings.

--- a/src/common/task_interface/aicore_teardown.h
+++ b/src/common/task_interface/aicore_teardown.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+constexpr uint32_t AICORE_POST_CLOSE_RELEASE = 1;
+
+// A2/A3: AICPU resets this word before window-open and publishes it only after
+// window-close. AICore bypass-loads it after EXITED; no cached stores or dcci
+// may touch this line while the protocol is active. A5 leaves it unused.
+struct alignas(64) AicoreTeardownControl {
+    uint32_t post_close_release;
+};
+
+static_assert(sizeof(AicoreTeardownControl) == 64);
+static_assert(alignof(AicoreTeardownControl) == 64);
+static_assert(std::is_standard_layout_v<AicoreTeardownControl>);
+static_assert(std::is_trivially_copyable_v<AicoreTeardownControl>);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -408,6 +408,34 @@ endfunction()
 
 enable_testing()
 
+foreach(runtime tensormap_and_ringbuffer host_build_graph)
+    set(retirement_test test_a2a3_${runtime}_retirement)
+    add_executable(${retirement_test}
+        a2a3/test_aicore_retirement.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/${runtime}/aicore/aicore_executor.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/shared/aicpu/platform_regs.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/sim/aicpu/inner_platform_regs.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/aicpu/device_time.cpp
+    )
+    target_include_directories(${retirement_test} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/${runtime}/runtime
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/${runtime}/common
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/${runtime}/orchestration
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/sim/aicore
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/aicpu
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+        ${CMAKE_SOURCE_DIR}/../../../src/common/host_build_graph
+        ${CMAKE_SOURCE_DIR}/../../../src/common
+    )
+    target_link_libraries(${retirement_test} PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+    add_test(NAME ${retirement_test} COMMAND ${retirement_test})
+    set_tests_properties(${retirement_test} PROPERTIES LABELS "no_hardware" TIMEOUT 20)
+endforeach()
+
 # ---------------------------------------------------------------------------
 # Hierarchical runtime tests (src/common/hierarchical/)
 # ---------------------------------------------------------------------------

--- a/tests/ut/cpp/a2a3/test_aicore_retirement.cpp
+++ b/tests/ut/cpp/a2a3/test_aicore_retirement.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+#include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
+#include "aicpu/platform_regs.h"
+#include "runtime.h"
+
+void aicore_execute(Runtime *runtime, int block_idx, CoreType core_type);
+
+namespace {
+alignas(64) std::array<uint32_t, 0x500 / sizeof(uint32_t)> registers{};
+
+uint32_t load_register(RegId reg) {
+    return __atomic_load_n(&registers[reg_offset(reg) / sizeof(uint32_t)], __ATOMIC_ACQUIRE);
+}
+
+void store_register(RegId reg, uint32_t value) {
+    __atomic_store_n(&registers[reg_offset(reg) / sizeof(uint32_t)], value, __ATOMIC_RELEASE);
+}
+
+template <typename Predicate>
+bool wait_until(Predicate predicate, std::chrono::milliseconds budget) {
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (!predicate()) {
+        if (std::chrono::steady_clock::now() >= deadline) return false;
+        std::this_thread::yield();
+    }
+    return true;
+}
+
+// The subprocess bounds a deliberately withheld CLOSE without leaking a
+// blocked worker into the test process. The executor is the production TU.
+void check_no_return_before_close(CoreType core_type) {
+    Runtime runtime;
+    std::atomic<bool> returned{false};
+    store_register(RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_OPEN);
+    store_register(RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
+    std::thread worker([&] {
+        aicore_execute(&runtime, 0, core_type);
+        returned.store(true, std::memory_order_release);
+    });
+    if (!wait_until(
+            [] {
+                return load_register(RegId::COND) == AICORE_EXITED_VALUE;
+            },
+            std::chrono::seconds(5)
+        )) {
+        std::_Exit(2);
+    }
+    const bool returned_early = wait_until(
+        [&] {
+            return returned.load(std::memory_order_acquire);
+        },
+        std::chrono::milliseconds(100)
+    );
+    std::_Exit(returned_early ? 1 : 0);
+}
+
+TEST(AicoreRetirementDeathTest, AivCannotReturnBeforeFastPathClose) {
+    EXPECT_EXIT(check_no_return_before_close(CoreType::AIV), testing::ExitedWithCode(0), "");
+}
+
+TEST(AicoreRetirementDeathTest, AicCannotReturnBeforeFastPathClose) {
+    EXPECT_EXIT(check_no_return_before_close(CoreType::AIC), testing::ExitedWithCode(0), "");
+}
+
+void check_repeated_retirement(CoreType core_type) {
+    Runtime runtime;
+    auto &control = runtime.get_workers()[0].teardown;
+    for (int generation = 0; generation < 32; ++generation) {
+        registers.fill(0);
+        __atomic_store_n(&control.post_close_release, 0U, __ATOMIC_RELEASE);
+        std::atomic<bool> returned{false};
+        store_register(RegId::FAST_PATH_ENABLE, REG_SPR_FAST_PATH_OPEN);
+        store_register(RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
+        std::thread worker([&] {
+            aicore_execute(&runtime, 0, core_type);
+            returned.store(true, std::memory_order_release);
+        });
+        if (!wait_until(
+                [] {
+                    return load_register(RegId::COND) == AICORE_IDLE_VALUE;
+                },
+                std::chrono::seconds(5)
+            ))
+            std::_Exit(2);
+        const AicoreExitTarget target{reinterpret_cast<uint64_t>(registers.data()), &control};
+        if (platform_retire_aicore_group(&target, 1, platform_aicore_exit_deadline()) != 0) std::_Exit(3);
+        if (!wait_until(
+                [&] {
+                    return returned.load(std::memory_order_acquire);
+                },
+                std::chrono::seconds(5)
+            ))
+            std::_Exit(4);
+        worker.join();
+        if (load_register(RegId::FAST_PATH_ENABLE) != REG_SPR_FAST_PATH_CLOSE) std::_Exit(5);
+        if (__atomic_load_n(&control.post_close_release, __ATOMIC_ACQUIRE) != AICORE_POST_CLOSE_RELEASE) {
+            std::_Exit(6);
+        }
+    }
+    std::_Exit(0);
+}
+
+TEST(AicoreRetirementDeathTest, AivReturnsAfterCloseAcrossRepeatedLaunches) {
+    EXPECT_EXIT(check_repeated_retirement(CoreType::AIV), testing::ExitedWithCode(0), "");
+}
+
+TEST(AicoreRetirementDeathTest, AicReturnsAfterCloseAcrossRepeatedLaunches) {
+    EXPECT_EXIT(check_repeated_retirement(CoreType::AIC), testing::ExitedWithCode(0), "");
+}
+
+TEST(AicoreRetirement, GroupWaitsForEveryAckBeforeClosingAnyWindow) {
+    alignas(64) std::array<uint32_t, 0x500 / sizeof(uint32_t)> peer_registers{};
+    AicoreTeardownControl controls[2]{};
+    const AicoreExitTarget targets[] = {
+        {reinterpret_cast<uint64_t>(registers.data()), &controls[0]},
+        {reinterpret_cast<uint64_t>(peer_registers.data()), &controls[1]},
+    };
+    registers.fill(0);
+    for (const auto &target : targets)
+        platform_init_aicore_regs(target.reg_addr);
+    std::atomic<int32_t> result{-2};
+    std::thread retiring([&] {
+        result.store(
+            platform_retire_aicore_group(targets, 2, platform_aicore_exit_deadline()), std::memory_order_release
+        );
+    });
+    EXPECT_TRUE(wait_until(
+        [&] {
+            return read_reg(targets[0].reg_addr, RegId::DATA_MAIN_BASE) == AICORE_EXIT_SIGNAL &&
+                   read_reg(targets[1].reg_addr, RegId::DATA_MAIN_BASE) == AICORE_EXIT_SIGNAL;
+        },
+        std::chrono::seconds(5)
+    ));
+    write_reg(targets[0].reg_addr, RegId::COND, AICORE_EXITED_VALUE);
+    EXPECT_FALSE(wait_until(
+        [&] {
+            return read_reg(targets[0].reg_addr, RegId::FAST_PATH_ENABLE) == REG_SPR_FAST_PATH_CLOSE;
+        },
+        std::chrono::milliseconds(100)
+    ));
+    EXPECT_EQ(__atomic_load_n(&controls[0].post_close_release, __ATOMIC_ACQUIRE), 0U);
+    EXPECT_EQ(__atomic_load_n(&controls[1].post_close_release, __ATOMIC_ACQUIRE), 0U);
+    write_reg(targets[1].reg_addr, RegId::COND, AICORE_EXITED_VALUE);
+    retiring.join();
+    EXPECT_EQ(result.load(std::memory_order_acquire), 0);
+    for (const auto &target : targets) {
+        EXPECT_EQ(read_reg(target.reg_addr, RegId::FAST_PATH_ENABLE), REG_SPR_FAST_PATH_CLOSE);
+        EXPECT_EQ(__atomic_load_n(&target.teardown->post_close_release, __ATOMIC_ACQUIRE), AICORE_POST_CLOSE_RELEASE);
+    }
+}
+
+TEST(AicoreRetirement, MissingAckDoesNotCloseOrReleaseThatCore) {
+    alignas(64) std::array<uint32_t, 0x500 / sizeof(uint32_t)> peer_registers{};
+    AicoreTeardownControl controls[2]{};
+    const AicoreExitTarget targets[] = {
+        {reinterpret_cast<uint64_t>(registers.data()), &controls[0]},
+        {reinterpret_cast<uint64_t>(peer_registers.data()), &controls[1]},
+    };
+    registers.fill(0);
+    for (const auto &target : targets)
+        platform_init_aicore_regs(target.reg_addr);
+    write_reg(targets[1].reg_addr, RegId::COND, AICORE_EXITED_VALUE);
+    EXPECT_EQ(platform_retire_aicore_group(targets, 2, 0), -1);
+    EXPECT_EQ(read_reg(targets[0].reg_addr, RegId::FAST_PATH_ENABLE), REG_SPR_FAST_PATH_OPEN);
+    EXPECT_EQ(__atomic_load_n(&controls[0].post_close_release, __ATOMIC_ACQUIRE), 0U);
+    EXPECT_EQ(read_reg(targets[1].reg_addr, RegId::FAST_PATH_ENABLE), REG_SPR_FAST_PATH_CLOSE);
+    EXPECT_EQ(__atomic_load_n(&controls[1].post_close_release, __ATOMIC_ACQUIRE), AICORE_POST_CLOSE_RELEASE);
+}
+
+TEST(AicoreRetirement, RejectsInvalidGroupBeforeTouchingRegisters) {
+    AicoreTeardownControl control{};
+    registers.fill(0);
+    const AicoreExitTarget targets[] = {
+        {reinterpret_cast<uint64_t>(registers.data()), &control},
+        {0, &control},
+    };
+    EXPECT_EQ(platform_retire_aicore_group(targets, 2, 0), -1);
+    EXPECT_EQ(load_register(RegId::DATA_MAIN_BASE), 0U);
+    EXPECT_EQ(platform_retire_aicore_group(nullptr, 1, 0), -1);
+    EXPECT_EQ(platform_retire_aicore_group(nullptr, 0, 0), 0);
+    EXPECT_EQ(platform_retire_aicore_group(targets, PLATFORM_MAX_CORES + 1, 0), -1);
+}
+}  // namespace
+
+// Only handshake storage is used by these idle-worker tests. Keep host-side
+// orchestration and the profiling service out of this executor-level fixture.
+Runtime::Runtime() { std::memset(get_workers(), 0, sizeof(Handshake) * RUNTIME_MAX_WORKER); }
+
+volatile uint8_t *sim_get_reg_base() { return reinterpret_cast<volatile uint8_t *>(registers.data()); }
+uint32_t sim_get_physical_core_id() { return 0; }
+uint32_t get_aicore_profiling_flag() { return 0; }
+ChipSwimlaneActiveHead *get_chip_swimlane_aicore_head() { return nullptr; }


### PR DESCRIPTION
## Summary

Separate the A2/A3 persistent worker's EXIT acknowledgement from permission to return. The missing ordering edge is **FAST_PATH CLOSE → AICore wrapper return**.

The old protocol only ordered:
```
AICore: observe EXIT → COND=EXITED → return
AICPU:                observe EXITED → IDLE → CLOSE
```
Both tails follow the ACK; neither orders CLOSE before return. A host mutex/event or serial graph replay cannot repair that device-internal ordering.

## Changes

- Retire the whole worker group at the existing all-AICPU-thread completion rendezvous in both TMR and HBG.
- Broadcast EXIT, collect ACKs against one deadline, close/read back the responsive windows, then release their GM return gates.
- Make A2/A3 workers wait for that release through bypass loads before returning.
- Place the gate on a separate 64-byte line and atomically reset it before window-open, preventing report writeback clobber and stale previous-launch release.
- Reuse the handoff for emergency shutdown; do not release an unacknowledged core or touch a released worker's registers again.
- Add production-executor regression tests and an ordering/cache-ownership explanation in `docs/troubleshooting/a2a3-worker-retirement.md`.

HBG shares its internal Handshake with A5: that image grows from 64 to 128 bytes per worker, with the second line unused on A5. Rebuild host/device artifacts together. The A5 execution protocol and public Python API are unchanged.

## Scope and evidence

This is based directly on current upstream main `fab1a41e`, not a transplant of fork-only L1 APIs. Upstream main does not provide the borrowed-stream L1 graph workload that motivated the investigation.

The new tests directly link the production TMR/HBG AICore loops. On unmodified main, all four AIC/AIV "withhold CLOSE" checks fail because the worker returns early; with this patch they pass. The downstream single-variable experiment (removing only the wait: 1280 passing replays → matching timeout at replay 2) is historical integration evidence, **not** a fresh upstream L1 benchmark or a claim about an undocumented silicon state machine.

## Validation

- [x] 14 new protocol cases pass across both production executors: early-return rejection, eventual return, 32 repeated launches per core type, group ACK ordering, partial timeout, invalid targets.
- [x] C++ suite: **136/136 passed**. This older-glibc host needed the local build option `-DCMAKE_CXX_STANDARD_LIBRARIES=-ldl` for an existing unrelated test target.
- [x] Python UT: **2158 passed, 11 skipped**.
- [x] A2/A3 onboard runtimes and A2/A3 + A5 simulation runtimes build successfully.
- [x] TMR/HBG vector onboard smoke passes. Isolated onboard reruns also pass TMR bgemm, both alternating-matmul cases, TMR stream reuse, and HBG early dispatch.
- [x] All applicable pre-commit checks pass, including clang-tidy. The standalone local clang-tidy installation needed matching LLVM 21 resource headers; no checks were skipped.
- [ ] Full simulation scene sweep: unavailable locally because required `g++-15` is missing.
- [ ] Full multi-device onboard sweep: unavailable because only one device is usable.

### Onboard failures are not reported as a clean sweep

The attempted mixed-runtime single-process L2 sweep produced **86 passed, 1 skipped, 10 failed**:

- Its first HBG→TMR transition failure (bgemm, AICPU 507018, run epoch 3) reproduces on the pristine `fab1a41e` baseline with the same three-test prefix: two passes, then the same failure. Patched bgemm passes alone.
- Four more failing cases pass when rerun in isolation, as listed above.
- High-performance paged attention also fails alone on pristine main: the same configuration and task 0 with `S1:running-stalled`, `completed=0/1`. The stuck worker differs (20 patched / 40 baseline); this is not claimed to be an identical core-level trace or a resolved operator bug.
- Four tail `CallableHandle does not belong to this Worker` failures have not been independently attributed; no blanket claim that every cascade is explained.

Onboard validation used A2/A3 device 0 only. The other device was already non-idle and was not used. `task-submit` is absent on this host, so these runs were unlocked. After the final pristine-main highperf timeout, the closing device query showed device 0 at 100% AICore utilization with no listed processes, despite the test runner's recovery probe; no further onboard workloads or additional manual resets were submitted.

Allocator integration, ACL event changes, downstream CSA numerical fixes, throughput claims, and broader recovery/worker-ownership issues are intentionally outside this PR.