### PR TITLE
Fix: emit the host_build_graph dep_gen graph where it is captured

### DIFF
--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -96,9 +96,13 @@ nothing to capture-then-reconstruct.
   shared-memory ring, and the drain thread are all skipped
   (`dep_gen_host_graph_active()` tells the runner). Nothing is dropped under
   back-pressure because nothing is streamed.
-- **Output.** The same `deps.json`, written during the device-runner drain.
-  The graph is thread-local, and prepare's host orchestration and the drain that
-  emits it both run on the child progress loop's single thread.
+- **Output.** The same `deps.json`, written at the end of the run's own `bind` —
+  the point where host orchestration completes and the graph is final. The graph
+  is thread-local, so it is written on the thread that captured it rather than
+  waiting for the drain, which the run lane does not pin to that thread: it
+  serializes with a mutex, which gives mutual exclusion but not thread affinity.
+  A consequence worth knowing: a run whose device execution later fails still
+  leaves its `deps.json`, because its orchestration did happen.
 
 ---
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -714,24 +714,18 @@ int DeviceRunner::reap_run() {
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     teardown_shared_collectors_after_run(true);
 
-    // a2a3-only dep_gen teardown: host-orch emits the graph its orchestration
-    // built on this same thread; device-orch stops the collector, reconciles the
-    // ring, and replays the records.
-    if (enable_dep_gen_) {
-        const std::string deps = make_deps_json_path(output_prefix_);
-        if (dep_gen_host_graph_active()) {
-            int rc = dep_gen_host_graph_emit(deps.c_str());
+    // a2a3-only dep_gen teardown, device-orch shape: the collector stops, the
+    // ring reconciles, and the records replay. The host-orch shape emits at the
+    // end of bind instead, where its capture window closes — see
+    // `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+        dep_gen_collector_.quiesce();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const std::string deps = make_deps_json_path(output_prefix_);
+            const auto &records = dep_gen_collector_.records();
+            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (rc != 0) {
-                LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", rc);
-            }
-        } else {
-            dep_gen_collector_.quiesce();
-            if (dep_gen_collector_.reconcile_counters()) {
-                const auto &records = dep_gen_collector_.records();
-                int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-                if (rc != 0) {
-                    LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
-                }
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
             }
         }
     }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -718,23 +718,17 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         pmu_collector_.reconcile_counters();
     }
 
-    // Host-orch emits the graph its orchestration built on this same thread;
-    // device-orch stops the collector, reconciles the ring, and replays.
-    if (enable_dep_gen_) {
-        const std::string deps = make_deps_json_path(output_prefix_);
-        if (dep_gen_host_graph_active()) {
-            int rc = dep_gen_host_graph_emit(deps.c_str());
+    // Device-orch shape: the collector stops, the ring reconciles, and the
+    // records replay. The host-orch shape emits at the end of bind instead, where
+    // its capture window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+        dep_gen_collector_.quiesce();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const std::string deps = make_deps_json_path(output_prefix_);
+            const auto &records = dep_gen_collector_.records();
+            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (rc != 0) {
-                LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", rc);
-            }
-        } else {
-            dep_gen_collector_.quiesce();
-            if (dep_gen_collector_.reconcile_counters()) {
-                const auto &records = dep_gen_collector_.records();
-                int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-                if (rc != 0) {
-                    LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
-                }
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
             }
         }
     }

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -631,24 +631,18 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     read_device_wall_ns();
     teardown_shared_collectors_after_run(true);
 
-    // a5-specific dep_gen teardown: host-orch emits the graph its orchestration
-    // built on this same thread; device-orch stops the collector, reconciles the
-    // ring, and replays the records.
-    if (enable_dep_gen_) {
-        const std::string deps = make_deps_json_path(output_prefix_);
-        if (dep_gen_host_graph_active()) {
-            int emit_rc = dep_gen_host_graph_emit(deps.c_str());
-            if (emit_rc != 0) {
-                LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", emit_rc);
-            }
-        } else {
-            dep_gen_collector_.quiesce();
-            if (dep_gen_collector_.reconcile_counters()) {
-                const auto &records = dep_gen_collector_.records();
-                int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-                if (replay_rc != 0) {
-                    LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
-                }
+    // a5-specific dep_gen teardown, device-orch shape: the collector stops, the
+    // ring reconciles, and the records replay. The host-orch shape emits at the
+    // end of bind instead, where its capture window closes — see
+    // `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+        dep_gen_collector_.quiesce();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const std::string deps = make_deps_json_path(output_prefix_);
+            const auto &records = dep_gen_collector_.records();
+            int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+            if (replay_rc != 0) {
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
             }
         }
     }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -691,23 +691,17 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         pmu_collector_.reconcile_counters();
     }
 
-    // Host-orch emits the graph its orchestration built on this same thread;
-    // device-orch stops the collector, reconciles the ring, and replays.
-    if (enable_dep_gen_) {
-        const std::string deps = make_deps_json_path(output_prefix_);
-        if (dep_gen_host_graph_active()) {
-            int emit_rc = dep_gen_host_graph_emit(deps.c_str());
-            if (emit_rc != 0) {
-                LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced", emit_rc);
-            }
-        } else {
-            dep_gen_collector_.quiesce();
-            if (dep_gen_collector_.reconcile_counters()) {
-                const auto &records = dep_gen_collector_.records();
-                int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-                if (replay_rc != 0) {
-                    LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
-                }
+    // Device-orch shape: the collector stops, the ring reconciles, and the
+    // records replay. The host-orch shape emits at the end of bind instead, where
+    // its capture window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+        dep_gen_collector_.quiesce();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const std::string deps = make_deps_json_path(output_prefix_);
+            const auto &records = dep_gen_collector_.records();
+            int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+            if (replay_rc != 0) {
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
             }
         }
     }

--- a/src/common/host_build_graph/dep_gen_host_graph.h
+++ b/src/common/host_build_graph/dep_gen_host_graph.h
@@ -37,11 +37,14 @@
  * without it resolves to the no-ops in tests/ut/cpp/stubs/hbg_orch_stubs.cpp.
  *
  * The graph lives in thread-local state, so capture is lock-free and two
- * prepared contexts on different threads cannot overwrite one another. Emit
- * reads the calling thread's state, so a run's orchestration (which builds the
- * graph) and its drain (which emits it) must land on the same thread. The child
- * progress loop satisfies this by being single-threaded; emit returns -3 if the
- * invariant is ever broken.
+ * prepared contexts on different threads cannot overwrite one another. Emit reads
+ * the calling thread's state, and the caller keeps that read on the capturing
+ * thread by emitting at the end of the orchestration's own bind — see
+ * `emit_host_dep_gen_graph` in each platform's c_api_shared.cpp. Emitting later
+ * would not be safe: the run lane serializes with a mutex, which guarantees
+ * mutual exclusion but not thread affinity, so a drain can land on another
+ * thread, and a successor's bind resets the state. Emit returns -3 if a caller
+ * ever reads a thread that did not capture.
  *
  * Per-task producer dedup mirrors append_fanin_or_fail, which keys on the producer's
  * local id; this keys on producer task id. The two agree only because

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -27,6 +27,7 @@
 #include "callable.h"
 #include "call_config.h"
 #include "device_runner_base.h"
+#include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -54,10 +55,42 @@
 // time against `libunified_dlog.so` / `libascendalog.so`.
 extern "C" int dlog_setlevel(int moduleId, int level, int enableEvent);
 
+// Forward-declared for the same reason: the host-orchestrated graph capture lives
+// in the host_build_graph runtime .so, and its header pulls in that runtime's own
+// types. Each platform .so carries weak `false` / `-1` fallbacks for the runtimes
+// that capture on the device instead — see each arch's device_runner.cpp.
+extern "C" bool dep_gen_host_graph_active();
+extern "C" int dep_gen_host_graph_emit(const char *deps_json_path);
+
 using OnboardNativeRunContext = NativeRunContext<DeviceRunnerBase>;
 // Phase entry points validate raw caller storage before beginning object
 // lifetime, so the on-storage magic must remain the leading bytes.
 static_assert(__builtin_offsetof(OnboardNativeRunContext, magic) == 0, "native-run magic must lead runtime storage");
+
+/**
+ * Write a host-orchestrated run's dependency graph, at the point its capture
+ * window closes.
+ *
+ * The graph is complete when bind returns — host_build_graph runs its
+ * orchestrator there — and it lives in state private to the thread that ran it.
+ * Writing it here keeps the write on that thread and ahead of any later capture,
+ * which is what the alternative (writing at drain) cannot promise: a drain may
+ * land on another thread, and a successor's bind resets the capture state.
+ *
+ * The destination comes from this run's own config rather than the runner's,
+ * which a concurrent prepare deliberately leaves untouched.
+ *
+ * A no-op for runtimes that capture on the device: their `dep_gen_host_graph_active`
+ * is the weak `false`, and their graph is emitted from the collector at drain.
+ */
+static void emit_host_dep_gen_graph(const CallConfig &config, const char *trace_attrs) {
+    if (config.enable_dep_gen == 0 || !dep_gen_host_graph_active()) return;
+    const std::string deps_path = make_deps_json_path(config.output_prefix);
+    const int emit_rc = dep_gen_host_graph_emit(deps_path.c_str());
+    if (emit_rc != 0) {
+        LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced (%s)", emit_rc, trace_attrs);
+    }
+}
 
 extern "C" {
 
@@ -824,6 +857,7 @@ int simpler_prepare_run(
             );
         }
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
+        emit_host_dep_gen_graph(state->config, state->trace_attrs);
         rc = runner->prepare_execution(
             state->runtime, state->config, state->descriptor.pipeline_slot, state->identity(),
             &state->prepared_execution

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -26,6 +26,7 @@
 #include "callable.h"
 #include "call_config.h"
 #include "device_runner_base.h"
+#include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -49,6 +50,37 @@ using SimNativeRunContext = NativeRunContext<SimDeviceRunnerBase>;
 // Phase entry points validate raw caller storage before beginning object
 // lifetime, so the on-storage magic must remain the leading bytes.
 static_assert(__builtin_offsetof(SimNativeRunContext, magic) == 0, "native-run magic must lead runtime storage");
+
+// Forward-declared rather than including the host_build_graph header, whose
+// types belong to that runtime .so. Each platform .so carries weak `false` /
+// `-1` fallbacks for the runtimes that capture on the device instead — see each
+// arch's device_runner.cpp.
+extern "C" bool dep_gen_host_graph_active();
+extern "C" int dep_gen_host_graph_emit(const char *deps_json_path);
+
+/**
+ * Write a host-orchestrated run's dependency graph, at the point its capture
+ * window closes.
+ *
+ * The graph is complete when bind returns — host_build_graph runs its
+ * orchestrator there — and it lives in state private to the thread that ran it.
+ * Writing it here keeps the write on that thread and ahead of any later capture,
+ * which is what the alternative (writing at drain) cannot promise: a drain may
+ * land on another thread, and a successor's bind resets the capture state.
+ *
+ * The destination comes from this run's own config rather than the runner's.
+ *
+ * A no-op for runtimes that capture on the device: their `dep_gen_host_graph_active`
+ * is the weak `false`, and their graph is emitted from the collector at drain.
+ */
+static void emit_host_dep_gen_graph(const CallConfig &config, const char *trace_attrs) {
+    if (config.enable_dep_gen == 0 || !dep_gen_host_graph_active()) return;
+    const std::string deps_path = make_deps_json_path(config.output_prefix);
+    const int emit_rc = dep_gen_host_graph_emit(deps_path.c_str());
+    if (emit_rc != 0) {
+        LOG_ERROR("dep_gen host graph emit failed (%d) — deps.json not produced (%s)", emit_rc, trace_attrs);
+    }
+}
 
 extern "C" {
 
@@ -709,6 +741,7 @@ int simpler_prepare_run(
             );
         }
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
+        emit_host_dep_gen_graph(state->config, state->trace_attrs);
         rc = runner->prepare_execution(
             state->runtime, state->config, state->descriptor.pipeline_slot, state->identity(),
             &state->prepared_execution

--- a/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen_thread_affinity.py
+++ b/tests/st/a2a3/host_build_graph/dfx/dep_gen/test_dep_gen_thread_affinity.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""A host_build_graph run emits its own graph even when another thread drains it.
+
+host_build_graph captures the dependency graph while the orchestrator runs on the
+host, inside ``submit`` (bind), and the graph lives in state private to the thread
+that ran it. Emitting it at the end of that same bind is what keeps the write on
+the capturing thread; emitting at drain instead would not, because the run lane
+serializes with a mutex — mutual exclusion, not thread affinity.
+
+This drives the shape that separates the two: ``submit`` at depth one blocks the
+second submission and drains its predecessor before admitting itself, so a second
+thread's submit is what reaps the first thread's run. With the write at drain the
+first run's ``deps.json`` was never produced — emit reported "no capture on this
+thread" (-3) and returned.
+
+Both submissions are ordinary public API on one Worker: ``submit`` returns without
+waiting and admits concurrent callers through an operation lease, so nothing here
+reaches past the supported surface.
+"""
+
+import json
+import threading
+
+import torch
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CallConfig
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, TensorArg, scene_test
+from simpler_setup.scene_test import _build_l2_ref_args, build_output_prefix
+
+KERNELS_BASE = "kernels"
+
+EXPECTED_TASKS = 5
+EXPECTED_EDGES = 6
+
+
+@scene_test(level=2, runtime="host_build_graph")
+class TestDepGenHostGraphThreadAffinity(SceneTestCase):
+    """Submit from one thread, let another thread's submit drain it."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "drained_by_another_thread",
+            "platforms": ["a2a3sim", "a2a3"],
+            "manual": ["a2a3sim"],
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            TensorArg("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            TensorArg("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            TensorArg("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    def test_run(self, st_platform, st_worker, request):
+        # Deliberately does NOT call super().test_run(): the standard loop submits
+        # and waits on one thread, which is the shape that already works.
+        cases = self._matching_cases(st_platform, request)
+        if not cases:
+            return
+        case = cases[0]
+
+        callable_obj = self.build_callable(st_platform)
+        handle = st_worker.register(callable_obj)
+        orch_sig = self.CALLABLE.get("orchestration", {}).get("signature", [])
+
+        def make_config(prefix):
+            config = CallConfig()
+            config.enable_dep_gen = True
+            config.output_prefix = str(prefix)
+            return config
+
+        # The resolved descriptors in chip_args carry addresses into the torch
+        # tensors' storage, so the builder has to outlive the run. Dropping it
+        # frees that storage under the still-pending bind, which is a
+        # heap-use-after-free in the test rather than a finding about the runtime.
+        keepalive = []
+
+        def build_args():
+            args = self.generate_args(case.get("params", {}))
+            chip_args, _names = _build_l2_ref_args(args, orch_sig, st_worker)
+            keepalive.append((args, chip_args))
+            return chip_args
+
+        first_prefix = build_output_prefix(f"{type(self).__name__}_{case['name']}_first")
+        second_prefix = build_output_prefix(f"{type(self).__name__}_{case['name']}_second")
+
+        # This thread orchestrates the first run, so its graph lands in this
+        # thread's capture state. It stays alive for the whole test: a thread that
+        # exited would destroy that state for a different reason.
+        first = st_worker.submit(handle, build_args(), make_config(first_prefix))
+
+        # The second submit blocks at depth one and drains the first run — on this
+        # thread, not the one that orchestrated it.
+        drain_error: list[BaseException] = []
+
+        def submit_from_other_thread():
+            try:
+                st_worker.submit(handle, build_args(), make_config(second_prefix)).wait()
+            except BaseException as exc:  # noqa: BLE001 -- reported on the main thread
+                drain_error.append(exc)
+
+        other = threading.Thread(target=submit_from_other_thread, name="dep-gen-drainer")
+        other.start()
+        other.join(timeout=300)
+        assert not other.is_alive(), "the second submit did not return within 300s"
+        if drain_error:
+            raise drain_error[0]
+        first.wait()
+
+        for label, prefix in (("first", first_prefix), ("second", second_prefix)):
+            deps_path = prefix / "deps.json"
+            assert deps_path.exists(), (
+                f"{label} run: deps.json missing under {prefix}. host_build_graph holds the "
+                f"captured graph in thread-local state between orchestration and emit, so a "
+                f"drain on a different thread finds no capture and writes nothing."
+            )
+            with deps_path.open() as f:
+                deps = json.load(f)
+            assert len(deps.get("tasks", [])) == EXPECTED_TASKS, (
+                f"{label} run: expected {EXPECTED_TASKS} tasks, got {len(deps.get('tasks', []))}"
+            )
+            assert len(deps.get("edges", [])) == EXPECTED_EDGES, (
+                f"{label} run: expected {EXPECTED_EDGES} edges, got {len(deps.get('edges', []))}"
+            )
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## The bug

`host_build_graph` builds its dependency graph while the orchestrator runs on the host — inside a run's **bind** — and holds it in state private to the thread that ran it. The write to `deps.json` happened at **drain** instead, a whole device execution later.

Nothing pins the drain to the capturing thread. `dep_gen_host_graph.h` stated the requirement ("a run's orchestration and its drain must land on the same thread"), but `chip_run_lane.cpp` serializes the lane with a **mutex** — mutual exclusion, not thread affinity. Only the ChipWorker child's single-threaded progress loop happened to satisfy it.

So **a run drained from another thread silently produced no `deps.json`**:

```
[ERROR] dep_gen_host_graph_emit: dep_gen host graph: no capture on this thread —
        deps.json not written to .../..._first_.../deps.json
[ERROR] drain_execution: dep_gen host graph emit failed (-3) — deps.json not produced
```

Reached through ordinary public API. `Worker.submit()` returns without waiting and admits concurrent callers through an operation lease, and at depth one — which is where `host_build_graph` sits, per `submit`'s own docstring — a second submit **drains its predecessor before admitting itself**. So one thread's submit reaps another thread's run.

## The fix

Emit at the end of the run's own bind, the point where the capture window closes. Three properties follow:

- the graph is **final** there (orchestration completed inside bind),
- the write lands on the **thread that built it**, so `-3` is unreachable,
- it **precedes any later capture** that would reset the state.

The destination comes from the run's own `CallConfig` rather than the runner's `output_prefix_`, which a concurrent prepare deliberately leaves untouched (`if (!overlaps_active_run) apply_call_config(...)`).

Device-orchestrated dep_gen is untouched and keeps replaying its ring at drain, where its records first exist. The four reap sites now carry only that shape.

**One behavior change:** a run whose device execution fails still leaves its `deps.json`, because its orchestration did happen. Documented in `docs/dfx/dep-gen.md`.

## Testing

The regression test drives the shape that separates the two placements — submit on one thread, let another thread's submit drain it — and **fails on the unmodified runtime with this exact assertion**:

```
E  AssertionError: first run: deps.json missing under .../..._first_20260905_024704.
   host_build_graph holds the captured graph in thread-local state between
   orchestration and emit, so a drain on a different thread finds no capture
   and writes nothing.
```

The test's `keepalive` is load-bearing and worth calling out: `chip_args` holds addresses **into** the torch tensors' storage, so releasing the builder frees that storage under the still-pending bind. ASAN named it precisely (`c10::StorageImpl::~StorageImpl` ← `THPVariable_subclass_dealloc`) — a heap-use-after-free **in the test**, not a runtime finding. With the builder retained, the same run is memory-clean under ASAN both before and after this change.

Gate on `upstream/main@fab1a41e2` + this commit:

- [x] `tests/st/a2a3/host_build_graph/dfx/dep_gen/` on a2a3sim — 3 passed (was 2 + this one failing pre-fix)
- [x] **ASAN** (`SIMPLER_SANITIZER=asan`, preloaded per `docs/sanitizers.md`) — 1 passed, no report
- [x] DFX channels one per invocation as CI runs them: 12 runs across a2a3sim/a5sim — no failures
- [x] a2a3 **onboard** (real silicon, via `task-submit`): all 7 channels, `ONBOARD_DFX_RC=0`
- [x] `a5sim` sweep — pass; `a2a3sim` sweep — 44 passed, hbg group 28 (was 27)
- [x] cpput 134/134, pyut 2151/2151
- [x] clang-format, cpplint, the four `tests/lint` hooks, ruff, pyright

The one `a2a3sim` failure (`TestSpmdPagedAttentionHighPerf::b4_h32_kv8_s512_bs128_fp16`, `max_diff=0.0625`) is pre-existing and `manual`-only, reproduced identically on a clean base build, so the per-PR lane deselects it.

Found while designing the per-run ownership work for #2078; this is the standalone correctness half of it.
