### PR TITLE
Update: prewarm each chip with one internal TMR task

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -143,6 +143,25 @@ Entries unused for 14 days are pruned. When `build/` is not writable — a wheel
 installed into a read-only `site-packages` — the cache is skipped with a warning
 and every callable is compiled in-process, exactly as before the cache existed.
 
+### Runtime prewarm
+
+Every `Worker` / `ChipWorker` attempts one internal prewarm before the first
+activated run of each chip. On the tensormap-and-ringbuffer runtime, it walks
+the normal host bind, AICPU/AICore handshake, scheduler, one-task dispatch,
+completion, and cleanup paths. The AICPU submits a private zero-argument,
+single-block AIV task instead of invoking the user orchestration entry, and the
+scheduler publishes a zero kernel address so AICore performs only the protocol
+ACK/FIN. Host-build-graph reports the feature unsupported and proceeds directly
+to the official run.
+
+The prewarm does not copy outputs back, write `accepted_state`, advance a
+pipeline lease, or enable runtime diagnostics. It uses the first activated
+callable's host binding; later callables and later rounds do not add another
+attempt. L3 staged frames stay inert until activation.
+
+`--rounds N` still means exactly N official workload runs and N timing rows.
+L3 swimlane files contain only official runs.
+
 Scene tests support advanced CLI options for benchmarking, profiling, and runtime control. These work identically in both pytest and standalone mode.
 
 > "Profiling" is the umbrella for three parallel diagnostics sub-features: `--enable-chip-swimlane` (chip swimlane), `--dump-args` (unified argument dump), and `--enable-pmu` (PMU CSV). They are independent and can be combined.
@@ -172,7 +191,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 
 | Option | Short | Default | Description |
 | ------ | ----- | ------- | ----------- |
-| `--rounds N` | | 1 | Run each case N times (reuses the same Worker across rounds) |
+| `--rounds N` | | 1 | Run each case N times (reuses the same Worker across rounds; the one-time per-chip prewarm is not a round) |
 | `--device IDS` | `-d` | `0` | Single id (`0`), range (`0-7`), or list (`0,2,5`). Sets the device-id pool for L3 cases and the available slots for L2 fanout. |
 | `--max-parallel N` | | `auto` | Max in-flight subprocesses (make-style). `auto` = `min(nproc, len(--device))` on sim, `len(--device)` on hardware. Decouples device-id pool size from parallelism; use to throttle sim on a CPU-constrained runner. |
 | `--runtime NAME` | | (all) | Restrict to one runtime (also used internally as the child-mode marker) |

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -660,15 +660,23 @@ def print_rounds_table(buckets, stream=sys.stdout):
         print("No [STRACE] markers found.", file=stream)
         return
 
-    # Busiest hid = the rounds (decode emits one invocation per token; a static
-    # L2 example emits one per --rounds repetition).
-    _, invs = max(buckets.items(), key=lambda kv: len(kv[1]))
+    # Only a depth-0 chip.run root identifies an official round. Internal
+    # prewarm invocations reuse chip.run.* child spans, so matching children
+    # would add one fake round and contaminate benchmark averages.
+    run_buckets = {
+        hid: [inv for inv in invs if (root := inv.root()) is not None and root.name == _ROUNDS_TABLE_NAMES["run"]]
+        for hid, invs in buckets.items()
+    }
+    run_buckets = {hid: invs for hid, invs in run_buckets.items() if invs}
+    if not run_buckets:
+        print("No official [STRACE] rounds found.", file=stream)
+        return
+
+    # Busiest official hid = the rounds (decode emits one invocation per token;
+    # a static L2 example emits one per --rounds repetition).
+    _, invs = max(run_buckets.items(), key=lambda kv: len(kv[1]))
     invs = sorted(invs, key=lambda i: i.inv)
     rows = [_round_metrics(inv) for inv in invs]
-
-    if not rows:
-        print("No [STRACE] markers found.", file=stream)
-        return
 
     n = len(rows)
     # Host (col 0) is always captured → averaged over all rounds. Every other

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -504,6 +504,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         return -1;
     }
     int32_t run_rc = 0;
+    const bool internal_prewarm = (runtime->get_run_flags() & RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0;
     // Publish the resolved index so per-thread readers in this `.so` (notably
     // the AICPU phase-record slot) agree with the executor. On sim the basic
     // affinity gate leaves the index unset (-1); without this the sub-phase
@@ -562,10 +563,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 // Build the entry-arg once per run; both the config call below and
                 // the orchestration entry (consumed at orch_args_cached_) use it.
-                orch_args_cached_.create_from_entry_storage(runtime->get_orch_args());
+                if (!internal_prewarm) {
+                    orch_args_cached_.create_from_entry_storage(runtime->get_orch_args());
+                }
 
-                // Validate arg count on every run against the registered SO.
-                if (*p_config_func != nullptr) {
+                // Validate arg count on every official run against the registered SO.
+                if (!internal_prewarm && *p_config_func != nullptr) {
                     OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                     LOG_DEBUG("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                     if (cfg.expected_arg_count > 0) {
@@ -712,12 +715,19 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if SIMPLER_DFX
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
-            framework_bind_runtime(rt);
-            if (*p_bind != nullptr) {
-                (*p_bind)(rt);
-            }
             rt_scope_begin(rt);
-            (*p_func)(orch_args_cached_);
+            if (internal_prewarm) {
+                MixedKernels kernels;
+                kernels.aiv0_kernel_id = 0;
+                CoreTaskArgs args;
+                rt->orchestrator.submit_task(kernels, args);
+            } else {
+                framework_bind_runtime(rt);
+                if (*p_bind != nullptr) {
+                    (*p_bind)(rt);
+                }
+                (*p_func)(orch_args_cached_);
+            }
             rt_scope_end(rt);
 
 #if SIMPLER_DFX
@@ -892,12 +902,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // every subsequent run.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
-            const int32_t callable_id = runtime->get_active_callable_id();
-            framework_bind_runtime(nullptr);
-            if (callable_id >= 0 && callable_id < MAX_REGISTERED_CALLABLE_IDS) {
-                DeviceOrchestrationBindRuntimeFunc bind = orch_so_table_[callable_id].bind;
-                if (bind != nullptr) {
-                    bind(nullptr);
+            if (!internal_prewarm) {
+                const int32_t callable_id = runtime->get_active_callable_id();
+                framework_bind_runtime(nullptr);
+                if (callable_id >= 0 && callable_id < MAX_REGISTERED_CALLABLE_IDS) {
+                    DeviceOrchestrationBindRuntimeFunc bind = orch_so_table_[callable_id].bind;
+                    if (bind != nullptr) {
+                        bind(nullptr);
+                    }
                 }
             }
             runtime_destroy(rt, runtime_arena_);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -898,6 +898,13 @@ extern "C" int prewarm_config_impl(
     return build_and_cache_prebuilt_arena(api, sizing) ? 0 : PTO_RUNTIME_ERR_INTERNAL;
 }
 
+extern "C" int configure_native_run_flags_impl(Runtime *runtime, uint32_t flags) {
+    static_assert(RUNTIME_RUN_FLAG_INTERNAL_PREWARM == PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM);
+    if ((flags & ~RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0) return PTO_RUNTIME_ERR_UNSUPPORTED;
+    if (runtime != nullptr) runtime->set_run_flags(flags);
+    return 0;
+}
+
 /**
  * Validate runtime results and cleanup.
  *
@@ -931,7 +938,8 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
 
     LOG_INFO("ChipTensor leases to process: %d", tensor_lease_count);
 
-    bool skip_tensor_copy_back = execution_rc != 0;
+    const bool internal_prewarm = (runtime->get_run_flags() & RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0;
+    bool skip_tensor_copy_back = execution_rc != 0 || internal_prewarm;
     int32_t runtime_status = 0;
     SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
@@ -964,7 +972,11 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because execution failed");
+        if (internal_prewarm) {
+            LOG_DEBUG("Skipping tensor copy-back for the internal TMR prewarm task");
+        } else {
+            LOG_WARN("Skipping tensor copy-back because execution failed");
+        }
     } else {
         for (int i = 0; i < tensor_lease_count; i++) {
             const TensorLease &lease = tensor_leases[i];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -58,6 +58,7 @@
 
 // Default ready queue shards: one shard per worker thread (total minus orchestrator)
 constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 1;
+constexpr uint32_t RUNTIME_RUN_FLAG_INTERNAL_PREWARM = 1u << 0;
 
 // =============================================================================
 // Data Structures
@@ -202,6 +203,10 @@ struct alignas(64) DeviceRuntimeLaunchDesc {
     // Per-callable_id dispatch. AICPU dispatches via
     // `orch_so_table_[active_callable_id_]`.
     int32_t active_callable_id_;
+
+    // Copied from NativeRunDescriptor.flags during prepare. Device scheduler
+    // reads this to force function_bin_addr=0 for the internal prewarm task.
+    uint32_t run_flags{0};
 };
 
 // =============================================================================
@@ -252,6 +257,8 @@ public:
     size_t aicpu_allowed_cpus_capacity() const {
         return sizeof(dev.aicpu_allowed_cpus) / sizeof(dev.aicpu_allowed_cpus[0]);
     }
+    uint32_t get_run_flags() const { return dev.run_flags; }
+    void set_run_flags(uint32_t flags) { dev.run_flags = flags; }
 
     // =========================================================================
     // Performance Profiling

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1178,6 +1178,7 @@ int32_t SchedulerContext::pre_handshake_init(
     completed_tasks_.store(0, std::memory_order_release);
     orchestrator_done_.store(false, std::memory_order_release);
     func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    run_flags_ = runtime->get_run_flags();
 
     // total_tasks_ must be read before hs_setup_done_ is published: on the
     // decoupled path the orchestrator resets the SM as soon as it observes
@@ -1308,6 +1309,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     }
 
     func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    run_flags_ = runtime->get_run_flags();
 
     return 0;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -181,6 +181,7 @@ private:
     std::atomic<bool> completed_{false};
     std::atomic<bool> fatal_shutdown_started_{false};
     uint64_t *func_id_to_addr_{nullptr};
+    uint32_t run_flags_{0};
 
     // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -126,9 +126,13 @@ void SchedulerContext::build_payload(
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
-    uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
-    const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
-    dispatch_payload.function_bin_addr = callable->resolved_addr();
+    if ((run_flags_ & RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0) {
+        dispatch_payload.function_bin_addr = 0;
+    } else {
+        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
+        dispatch_payload.function_bin_addr = callable->resolved_addr();
+    }
     auto &payload = *slot_state.payload;
     // A claimed early-stage range stays gated even if producer completion flips
     // the shared state before this payload is built. All other dispatches run on

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -508,6 +508,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         return -1;
     }
     int32_t run_rc = 0;
+    const bool internal_prewarm = (runtime->get_run_flags() & RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0;
     // Publish the resolved index so per-thread readers in this `.so` (notably
     // the AICPU phase-record slot) agree with the executor. On sim the basic
     // affinity gate leaves the index unset (-1); without this the sub-phase
@@ -566,10 +567,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 // Build the entry-arg once per run; both the config call below and
                 // the orchestration entry (consumed at orch_args_cached_) use it.
-                orch_args_cached_.create_from_entry_storage(runtime->get_orch_args());
+                if (!internal_prewarm) {
+                    orch_args_cached_.create_from_entry_storage(runtime->get_orch_args());
+                }
 
-                // Validate arg count on every run against the registered SO.
-                if (*p_config_func != nullptr) {
+                // Validate arg count on every official run against the registered SO.
+                if (!internal_prewarm && *p_config_func != nullptr) {
                     OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                     LOG_DEBUG("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                     if (cfg.expected_arg_count > 0) {
@@ -717,12 +720,19 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if SIMPLER_DFX
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
-            framework_bind_runtime(rt);
-            if (*p_bind != nullptr) {
-                (*p_bind)(rt);
-            }
             rt_scope_begin(rt);
-            (*p_func)(orch_args_cached_);
+            if (internal_prewarm) {
+                MixedKernels kernels;
+                kernels.aiv0_kernel_id = 0;
+                CoreTaskArgs args;
+                rt->orchestrator.submit_task(kernels, args);
+            } else {
+                framework_bind_runtime(rt);
+                if (*p_bind != nullptr) {
+                    (*p_bind)(rt);
+                }
+                (*p_func)(orch_args_cached_);
+            }
             rt_scope_end(rt);
 
 #if SIMPLER_DFX
@@ -895,12 +905,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // every subsequent run.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
-            const int32_t callable_id = runtime->get_active_callable_id();
-            framework_bind_runtime(nullptr);
-            if (callable_id >= 0 && callable_id < MAX_REGISTERED_CALLABLE_IDS) {
-                DeviceOrchestrationBindRuntimeFunc bind = orch_so_table_[callable_id].bind;
-                if (bind != nullptr) {
-                    bind(nullptr);
+            if (!internal_prewarm) {
+                const int32_t callable_id = runtime->get_active_callable_id();
+                framework_bind_runtime(nullptr);
+                if (callable_id >= 0 && callable_id < MAX_REGISTERED_CALLABLE_IDS) {
+                    DeviceOrchestrationBindRuntimeFunc bind = orch_so_table_[callable_id].bind;
+                    if (bind != nullptr) {
+                        bind(nullptr);
+                    }
                 }
             }
             runtime_destroy(rt, runtime_arena_);

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -898,6 +898,13 @@ extern "C" int prewarm_config_impl(
     return build_and_cache_prebuilt_arena(api, sizing) ? 0 : PTO_RUNTIME_ERR_INTERNAL;
 }
 
+extern "C" int configure_native_run_flags_impl(Runtime *runtime, uint32_t flags) {
+    static_assert(RUNTIME_RUN_FLAG_INTERNAL_PREWARM == PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM);
+    if ((flags & ~RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0) return PTO_RUNTIME_ERR_UNSUPPORTED;
+    if (runtime != nullptr) runtime->set_run_flags(flags);
+    return 0;
+}
+
 /**
  * Validate runtime results and cleanup.
  *
@@ -931,7 +938,8 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
 
     LOG_INFO("ChipTensor leases to process: %d", tensor_lease_count);
 
-    bool skip_tensor_copy_back = execution_rc != 0;
+    const bool internal_prewarm = (runtime->get_run_flags() & RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0;
+    bool skip_tensor_copy_back = execution_rc != 0 || internal_prewarm;
     int32_t runtime_status = 0;
     SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
@@ -964,7 +972,11 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api, int e
     }
 
     if (skip_tensor_copy_back) {
-        LOG_WARN("Skipping tensor copy-back because execution failed");
+        if (internal_prewarm) {
+            LOG_DEBUG("Skipping tensor copy-back for the internal TMR prewarm task");
+        } else {
+            LOG_WARN("Skipping tensor copy-back because execution failed");
+        }
     } else {
         for (int i = 0; i < tensor_lease_count; i++) {
             const TensorLease &lease = tensor_leases[i];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -57,6 +57,7 @@
 
 // Default ready queue shards: one shard per worker thread (total minus orchestrator)
 constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 1;
+constexpr uint32_t RUNTIME_RUN_FLAG_INTERNAL_PREWARM = 1u << 0;
 
 // =============================================================================
 // Data Structures
@@ -215,6 +216,10 @@ struct alignas(64) DeviceRuntimeLaunchDesc {
     // Per-callable_id dispatch. AICPU dispatches via
     // `orch_so_table_[active_callable_id_]`.
     int32_t active_callable_id_;
+
+    // Copied from NativeRunDescriptor.flags during prepare. Device scheduler
+    // reads this to force function_bin_addr=0 for the internal prewarm task.
+    uint32_t run_flags{0};
 };
 
 // =============================================================================
@@ -265,6 +270,8 @@ public:
     size_t aicpu_allowed_cpus_capacity() const {
         return sizeof(dev.aicpu_allowed_cpus) / sizeof(dev.aicpu_allowed_cpus[0]);
     }
+    uint32_t get_run_flags() const { return dev.run_flags; }
+    void set_run_flags(uint32_t flags) { dev.run_flags = flags; }
 
     // =========================================================================
     // Performance Profiling

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1159,6 +1159,7 @@ int32_t SchedulerContext::pre_handshake_init(
     completed_tasks_.store(0, std::memory_order_release);
     orchestrator_done_.store(false, std::memory_order_release);
     func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    run_flags_ = runtime->get_run_flags();
 
     // total_tasks_ must be read before hs_setup_done_ is published: on the
     // decoupled path the orchestrator resets the SM as soon as it observes
@@ -1282,6 +1283,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
     }
 
     func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    run_flags_ = runtime->get_run_flags();
 
     return 0;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -180,6 +180,7 @@ private:
     std::atomic<bool> orchestrator_done_{false};
     std::atomic<bool> completed_{false};
     uint64_t *func_id_to_addr_{nullptr};
+    uint32_t run_flags_{0};
 
     // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -116,9 +116,13 @@ void SchedulerContext::build_payload(
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
-    uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
-    const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
-    dispatch_payload.function_bin_addr = callable->resolved_addr();
+    if ((run_flags_ & RUNTIME_RUN_FLAG_INTERNAL_PREWARM) != 0) {
+        dispatch_payload.function_bin_addr = 0;
+    } else {
+        uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+        const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
+        dispatch_payload.function_bin_addr = callable->resolved_addr();
+    }
     auto &payload = *slot_state.payload;
     if (SchedulerState::should_gate_early_dispatch(
             force_gate, payload.early_dispatch_state.load(std::memory_order_relaxed)

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -332,6 +332,10 @@ extern "C" int prewarm_config_impl(
     const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 );
 
+// Weak default rejects non-zero flags; TMR links the strong implementation.
+// A null Runtime is a capability probe used before acquiring run resources.
+extern "C" int configure_native_run_flags_impl(Runtime *runtime, uint32_t flags);
+
 // One immutable function table is shared by all runners. Each HostApi value
 // binds it to a specific runner and immutable per-run slot/bank selection.
 static const HostApiOps g_host_api_ops = {
@@ -678,11 +682,13 @@ native_run_context(DeviceContextHandle ctx, RuntimeHandle runtime, const char *o
     return state;
 }
 
-static void
-emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns, const char *trace_attrs) {
+static void emit_native_run_host_wall(
+    uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns, const char *trace_attrs, bool prewarm = false
+) {
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(trace_inv, trace_hid, 0);
-    STRACE_HOST_SPAN_AT_A("chip.run", trace_start_ns, end_ns - trace_start_ns, 0, trace_attrs);
+    const char *name = prewarm ? "chip.prewarm.run" : "chip.run";
+    STRACE_HOST_SPAN_AT_A(name, trace_start_ns, end_ns - trace_start_ns, 0, trace_attrs);
 }
 
 static void emit_native_run_runner_wall(OnboardNativeRunContext *state) {
@@ -736,8 +742,9 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
         state->runner->release_native_run_reservation(state);
         state->runner_reserved = false;
     }
+    const bool prewarm = (state->descriptor.flags & PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM) != 0;
     destroy_native_run_context(state);
-    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, trace_attrs);
+    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, trace_attrs, prewarm);
     if (validation_rc != 0) return validation_rc;
     if (resources_rc != 0) return resources_rc;
     return execution_rc;
@@ -769,6 +776,8 @@ int simpler_prepare_run(
         LOG_ERROR("simpler_prepare_run: runner is unusable after a prior device failure");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    const int flags_rc = configure_native_run_flags_impl(nullptr, descriptor->flags);
+    if (flags_rc != 0) return flags_rc;
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
     if (magic == OnboardNativeRunContext::kMagic) {
@@ -786,6 +795,10 @@ int simpler_prepare_run(
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
         state = new (runtime) OnboardNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
+        if (configure_native_run_flags_impl(&state->runtime, descriptor->flags) != 0) {
+            destroy_native_run_context(state);
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         std::snprintf(
             state->trace_attrs, sizeof(state->trace_attrs),
             "run_id=%llu dispatch_id=%llu slot_id=%u generation=%llu run_epoch=%llu",
@@ -1089,8 +1102,9 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner->release_native_run_reservation(state);
         state->runner_reserved = false;
     }
+    const bool prewarm = (state->descriptor.flags & PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM) != 0;
     destroy_native_run_context(state);
-    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, trace_attrs);
+    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, trace_attrs, prewarm);
     if (validation_rc != 0) return validation_rc;
     if (resources_rc != 0) return resources_rc;
     return launched ? execution_rc : 0;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1273,6 +1273,14 @@ extern "C" __attribute__((weak)) int prewarm_config_impl(
     return 0;
 }
 
+// Runtime-specific NativeRunDescriptor flag hook. The shared platform layer is
+// also linked with host_build_graph, which deliberately does not implement the
+// internal TMR task warm-up. Passing nullptr is a capability probe; a non-null
+// runtime applies the already-probed flags to the per-run device descriptor.
+extern "C" __attribute__((weak)) int configure_native_run_flags_impl(Runtime * /*runtime*/, uint32_t flags) {
+    return flags == 0 ? 0 : PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
 void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_chip_swimlane_enabled(config.enable_chip_swimlane);
     set_dump_args_enabled(config.enable_dump_args);

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -318,6 +318,10 @@ extern "C" int prewarm_config_impl(
     const HostApi *api, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 );
 
+// Weak default rejects non-zero flags; TMR links the strong implementation.
+// A null Runtime is a capability probe used before acquiring run resources.
+extern "C" int configure_native_run_flags_impl(Runtime *runtime, uint32_t flags);
+
 static const HostApiOps g_host_api_ops = {
     .device_malloc = device_malloc,
     .device_free = device_free,
@@ -642,10 +646,11 @@ static SimNativeRunContext *native_run_context(DeviceContextHandle ctx, RuntimeH
     return state;
 }
 
-static void emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns) {
+static void
+emit_native_run_host_wall(uint64_t trace_inv, uint64_t trace_hid, long long trace_start_ns, bool prewarm = false) {
     const long long end_ns = STRACE_NOW_NS();
     STRACE_CONTEXT(trace_inv, trace_hid, 0);
-    STRACE_HOST_SPAN_AT("chip.run", trace_start_ns, end_ns - trace_start_ns, 0);
+    STRACE_HOST_SPAN_AT(prewarm ? "chip.prewarm.run" : "chip.run", trace_start_ns, end_ns - trace_start_ns, 0);
 }
 
 static void emit_native_run_runner_wall(SimNativeRunContext *state) {
@@ -675,8 +680,9 @@ static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, 
         state->runner->release_native_run(state);
         state->runner_claimed = false;
     }
+    const bool prewarm = (state->descriptor.flags & PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM) != 0;
     destroy_native_run_context(state);
-    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns);
+    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, prewarm);
     return validation_rc != 0 ? validation_rc : execution_rc;
 }
 
@@ -706,6 +712,8 @@ int simpler_prepare_run(
         LOG_ERROR("simpler_prepare_run: runner is poisoned by an uncertain partial launch");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    const int flags_rc = configure_native_run_flags_impl(nullptr, descriptor->flags);
+    if (flags_rc != 0) return flags_rc;
     uint64_t magic = 0;
     std::memcpy(&magic, runtime, sizeof(magic));
     if (magic == SimNativeRunContext::kMagic) {
@@ -723,6 +731,10 @@ int simpler_prepare_run(
     const long long trace_start_ns = STRACE_NOW_NS();
     try {
         state = new (runtime) SimNativeRunContext(runner, *config, trace_hid, *descriptor, &g_host_api_ops);
+        if (configure_native_run_flags_impl(&state->runtime, descriptor->flags) != 0) {
+            destroy_native_run_context(state);
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (!runner->try_acquire_native_run(state, state->identity(), &state->launch_permit)) {
             LOG_ERROR("simpler_prepare_run: another native run is active on this device context");
             destroy_native_run_context(state);
@@ -915,8 +927,9 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;
     }
+    const bool prewarm = (state->descriptor.flags & PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM) != 0;
     destroy_native_run_context(state);
-    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns);
+    emit_native_run_host_wall(trace_inv, trace_hid, trace_start_ns, prewarm);
     if (validation_rc != 0) return validation_rc;
     return launched ? execution_rc : 0;
 }

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -714,6 +714,14 @@ extern "C" __attribute__((weak)) int prewarm_config_impl(
     return 0;
 }
 
+// Runtime-specific NativeRunDescriptor flag hook. The shared platform layer is
+// also linked with host_build_graph, which deliberately does not implement the
+// internal TMR task warm-up. Passing nullptr is a capability probe; a non-null
+// runtime applies the already-probed flags to the per-run device descriptor.
+extern "C" __attribute__((weak)) int configure_native_run_flags_impl(Runtime * /*runtime*/, uint32_t flags) {
+    return flags == 0 ? 0 : PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
 void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_chip_swimlane_enabled(config.enable_chip_swimlane);
     set_dump_args_enabled(config.enable_dump_args);

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -12,6 +12,7 @@
 #include "chip_run_lane.h"
 
 #include "chip_worker.h"
+#include "runtime_c_api.h"
 
 #include <algorithm>
 #include <deque>
@@ -49,6 +50,13 @@ struct ChipRunLaneState {
         worker(&worker),
         generations(worker.pipeline_depth(), 0) {}
 
+    static CallConfig make_prewarm_config(const CallConfig &src) {
+        CallConfig prewarm{};
+        prewarm.aicpu_thread_num = src.aicpu_thread_num;
+        prewarm.runtime_env = src.runtime_env;
+        return prewarm;
+    }
+
     [[noreturn]] static void rethrow_as_poisoned(const std::exception_ptr &error) {
         try {
             std::rethrow_exception(error);
@@ -77,6 +85,42 @@ struct ChipRunLaneState {
 
     bool permits_native_successor(const ChipRunState &predecessor, const ChipRunState &successor) const {
         return permits_native_successor(predecessor, successor.config);
+    }
+
+    bool run_prewarm(const std::shared_ptr<ChipRunState> &seed) {
+        if (prewarm_attempted) return true;
+        prewarm_attempted = true;
+        const CallConfig prewarm_config = make_prewarm_config(seed->config);
+        ChipWorkerNativeRun native{};
+        try {
+            native = worker->prepare_native_run_on_slot(
+                seed->callable_id, &seed->args, prewarm_config, seed->lease.slot_id, seed->lease.generation,
+                seed->run_id, seed->dispatch_id, nullptr, 0, false, PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM
+            );
+        } catch (const UnsupportedRuntimeOperation &) {
+            return true;
+        } catch (...) {
+            const std::exception_ptr error = std::current_exception();
+            if (seed->error == nullptr) seed->error = error;
+            poison_with(seed, error);
+            return false;
+        }
+        try {
+            worker->launch_native_run(native);
+            worker->wait_native_run(native);
+            worker->finalize_native_run(native);
+            return true;
+        } catch (...) {
+            const std::exception_ptr error = std::current_exception();
+            try {
+                worker->finalize_native_run(native);
+            } catch (...) {
+                poison_with(seed, std::current_exception());
+            }
+            if (seed->error == nullptr) seed->error = error;
+            poison_with(seed, error);
+            return false;
+        }
     }
 
     void prepare(const std::shared_ptr<ChipRunState> &run) {
@@ -131,6 +175,12 @@ struct ChipRunLaneState {
             return;
         }
         if (run->phase == ChipRunState::Phase::QUEUED) {
+            if (!run_prewarm(run)) {
+                if (run->error == nullptr) run->error = poison;
+                run->phase = ChipRunState::Phase::TERMINAL;
+                fifo.pop_front();
+                return;
+            }
             try {
                 prepare(run);
             } catch (...) {
@@ -262,6 +312,7 @@ struct ChipRunLaneState {
     uint64_t direct_generation{0};
     std::exception_ptr poison;
     bool closed{false};
+    bool prewarm_attempted{false};
 };
 
 ChipRun::ChipRun(std::shared_ptr<ChipRunLaneState> lane, std::shared_ptr<ChipRunState> run) :

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -627,11 +627,11 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run(
 ChipWorkerNativeRun ChipWorker::prepare_native_run_for_lane(
     int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, const PipelineSlotLease &lease,
     uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value,
-    bool pipeline_leased
+    bool pipeline_leased, uint32_t flags
 ) {
     return prepare_native_run_on_slot(
         callable_id, args, config, lease.slot_id, lease.generation, run_id, dispatch_id, accepted_state, accepted_value,
-        pipeline_leased
+        pipeline_leased, flags
     );
 }
 
@@ -643,7 +643,7 @@ bool ChipWorker::supports_concurrent_native_prepare() const {
 ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
     uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state,
-    int32_t accepted_value, bool admit_pipeline_generation
+    int32_t accepted_value, bool admit_pipeline_generation, uint32_t flags
 ) {
     config.validate();
     if (!initialized_) {
@@ -702,7 +702,8 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
         const NativeRunDescriptor descriptor{slot_id,        arena_bank_for_slot(slot_id),
                                              run_id,         generation,
                                              dispatch_id,    run_epoch,
-                                             accepted_state, accepted_value};
+                                             accepted_state, accepted_value,
+                                             flags};
         rc = prepare_run_fn_(device_ctx_, runtime_bufs_[slot_id].data(), callable_id, args, &config, &descriptor);
     } catch (...) {
         std::lock_guard<std::mutex> lk(native_run_mu_);
@@ -721,6 +722,11 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
         if (rc == PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE) {
             throw PreparedRunIncompatible(
                 "native prepare requires depth-one fallback " + format_native_run_identity(run_identity)
+            );
+        }
+        if (rc == PTO_RUNTIME_ERR_UNSUPPORTED) {
+            throw UnsupportedRuntimeOperation(
+                "native prepare is unsupported for this run " + format_native_run_identity(run_identity)
             );
         }
         throw std::runtime_error(

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -379,12 +379,12 @@ private:
     ChipWorkerNativeRun prepare_native_run_on_slot(
         int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, uint32_t slot_id,
         uint64_t generation, uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state,
-        int32_t accepted_value, bool admit_pipeline_generation
+        int32_t accepted_value, bool admit_pipeline_generation, uint32_t flags = 0
     );
     ChipWorkerNativeRun prepare_native_run_for_lane(
         int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config, const PipelineSlotLease &lease,
         uint64_t run_id, uint64_t dispatch_id, volatile int32_t *accepted_state, int32_t accepted_value,
-        bool pipeline_leased
+        bool pipeline_leased, uint32_t flags = 0
     );
     void cleanup_native_runs_noexcept() noexcept;
 

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -104,6 +104,11 @@ enum {
     PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = PTO_RUNTIME_ERR_BASE - 2,
 };
 
+/** Internal NativeRunDescriptor.flags bits. Not part of the PyPTO CallConfig ABI. */
+enum {
+    PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM = 1u << 0,
+};
+
 /** Return values from simpler_poll_run(). */
 enum {
     SIMPLER_NATIVE_RUN_POLL_ERROR = PTO_RUNTIME_ERR_INTERNAL,
@@ -202,6 +207,7 @@ typedef struct NativeRunDescriptor {
     uint64_t run_epoch;
     volatile int32_t *accepted_state;
     int32_t accepted_value;
+    uint32_t flags;
 } NativeRunDescriptor;
 
 /* Per-stage run timing is no longer returned. The platform emits it as

--- a/tests/ut/cpp/common/test_native_run_acceptance.cpp
+++ b/tests/ut/cpp/common/test_native_run_acceptance.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <cstdint>
 
 #include "native_run_context.h"
@@ -39,6 +40,7 @@ NativeRunDescriptor make_descriptor(volatile int32_t *accepted_state) {
     descriptor.pipeline_slot = kPipelineSlot;
     descriptor.accepted_state = accepted_state;
     descriptor.accepted_value = kAcceptedValue;
+    descriptor.flags = 0;
     return descriptor;
 }
 
@@ -57,6 +59,14 @@ LaunchReceipt complete_receipt(const NativeRunIdentity &identity) {
 }
 
 }  // namespace
+
+TEST(NativeRunDescriptorAbi, FlagsSitAfterAcceptedValueAndStayZeroByDefault) {
+    NativeRunDescriptor descriptor{};
+    EXPECT_EQ(descriptor.flags, 0u);
+    descriptor.flags = PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM;
+    EXPECT_EQ(descriptor.flags, PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM);
+    EXPECT_EQ(offsetof(NativeRunDescriptor, flags), offsetof(NativeRunDescriptor, accepted_value) + sizeof(int32_t));
+}
 
 TEST(NativeRunAcceptanceTest, MatchingReceiptStoresTheAcceptedValue) {
     volatile int32_t accepted_state = 0;

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -46,7 +46,10 @@ std::array<int, 2> g_poll_rc{};
 std::array<int, 2> g_wait_rc{};
 std::array<int, 2> g_finalize_rc{};
 std::array<size_t, 2> g_prepare_count{};
+size_t g_prewarm_prepare_count{0};
+std::array<bool, 2> g_prewarm_run{};
 std::array<bool, 2> g_reject_first_prepare{};
+int g_prewarm_prepare_rc{0};
 size_t g_poll_count{0};
 // When nonzero, the poll stub completes the run after this many polls. Only
 // UnboundedWaitBlocksInsteadOfPolling sets it, so that a regression there fails
@@ -65,17 +68,27 @@ int prepare_run(
     void *, void *runtime, int32_t, const void *, const CallConfig *, const NativeRunDescriptor *descriptor
 ) {
     EXPECT_EQ(slot_of(runtime), descriptor->pipeline_slot);
-    g_complete[descriptor->pipeline_slot] = false;
-    g_events.push_back("prepare" + std::to_string(descriptor->pipeline_slot));
-    ++g_prepare_count[descriptor->pipeline_slot];
-    if (g_reject_first_prepare[descriptor->pipeline_slot] && g_prepare_count[descriptor->pipeline_slot] == 1) {
+    const uint32_t slot = descriptor->pipeline_slot;
+    const bool prewarm = (descriptor->flags & PTO_NATIVE_RUN_FLAG_INTERNAL_PREWARM) != 0;
+    g_prewarm_run[slot] = prewarm;
+    if (prewarm) {
+        EXPECT_EQ(descriptor->accepted_state, nullptr);
+        ++g_prewarm_prepare_count;
+        return g_prewarm_prepare_rc;
+    }
+    EXPECT_EQ(descriptor->flags, 0u);
+    g_complete[slot] = false;
+    g_events.push_back("prepare" + std::to_string(slot));
+    ++g_prepare_count[slot];
+    if (g_reject_first_prepare[slot] && g_prepare_count[slot] == 1) {
         return PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
     }
-    return g_prepare_rc[descriptor->pipeline_slot];
+    return g_prepare_rc[slot];
 }
 
 int launch_run(void *, void *runtime) {
     const uint32_t slot = slot_of(runtime);
+    if (g_prewarm_run[slot]) return 0;
     g_events.push_back("launch" + std::to_string(slot));
     return g_launch_rc[slot];
 }
@@ -90,6 +103,7 @@ int poll_run(void *, void *runtime) {
 
 int wait_run(void *, void *runtime) {
     const uint32_t slot = slot_of(runtime);
+    if (g_prewarm_run[slot]) return 0;
     g_events.push_back("wait" + std::to_string(slot));
     {
         std::unique_lock<std::mutex> lk(g_wait_mu);
@@ -105,6 +119,10 @@ int wait_run(void *, void *runtime) {
 
 int finalize_run(void *, void *runtime) {
     const uint32_t slot = slot_of(runtime);
+    if (g_prewarm_run[slot]) {
+        g_prewarm_run[slot] = false;
+        return 0;
+    }
     g_events.push_back("finalize" + std::to_string(slot));
     return g_finalize_rc[slot];
 }
@@ -120,7 +138,10 @@ void prime_worker(ChipWorker &worker) {
     g_wait_rc = {};
     g_finalize_rc = {};
     g_prepare_count = {};
+    g_prewarm_prepare_count = 0;
+    g_prewarm_run = {};
     g_reject_first_prepare = {};
+    g_prewarm_prepare_rc = 0;
     g_poll_count = 0;
     g_poll_completes_after = 0;
     g_supports_successor = true;
@@ -623,5 +644,84 @@ TEST(ChipRunLaneTest, CloseDrainsAndRejectsNewSubmissions) {
     EXPECT_THROW(
         lane.submit(1, args, CallConfig{}, PipelineSlotLease{1, 0, 102}, 102, 102, nullptr, 0, true), std::runtime_error
     );
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, FirstActivationRunsOnePrewarmThenTheOfficialRun) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    volatile int32_t accepted = 0;
+
+    ChipStorageTaskArgs args{};
+    ChipRun first = lane.submit(1, args, CallConfig{}, PipelineSlotLease{0, 0, 101}, 101, 101, &accepted, 1, true);
+    EXPECT_EQ(g_prewarm_prepare_count, 1u);
+    EXPECT_EQ(g_prepare_count[0], 1u);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0"}));
+
+    ChipRun second = submit(lane, 102, 1);
+    EXPECT_EQ(g_prewarm_prepare_count, 1u);
+    EXPECT_EQ(g_prepare_count[1], 1u);
+
+    g_complete[0] = true;
+    EXPECT_TRUE(first.done());
+    g_complete[1] = true;
+    EXPECT_TRUE(second.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, UnactivatedFrameDoesNotPrewarm) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+
+    ChipRun staged = submit(lane, 101, 0, false);
+    EXPECT_EQ(g_prewarm_prepare_count, 0u);
+    EXPECT_EQ(g_prepare_count[0], 0u);
+    EXPECT_TRUE(g_events.empty());
+
+    staged.activate();
+    EXPECT_EQ(g_prewarm_prepare_count, 1u);
+    EXPECT_EQ(g_prepare_count[0], 1u);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0"}));
+
+    g_complete[0] = true;
+    EXPECT_TRUE(staged.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, UnsupportedPrewarmSkipsAndOfficialRunSucceeds) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    g_prewarm_prepare_rc = PTO_RUNTIME_ERR_UNSUPPORTED;
+
+    ChipRun run = submit(lane, 101, 0);
+    EXPECT_EQ(g_prewarm_prepare_count, 1u);
+    EXPECT_EQ(g_prepare_count[0], 1u);
+    EXPECT_TRUE(run.launched());
+    EXPECT_FALSE(lane.poisoned());
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0"}));
+
+    g_complete[0] = true;
+    EXPECT_TRUE(run.done());
+    lane.close();
+    worker.finalize();
+}
+
+TEST(ChipRunLaneTest, PrewarmPrepareFailurePoisonsTheOfficialFirstRun) {
+    ChipWorker worker;
+    prime_worker(worker);
+    ChipRunLane lane(worker);
+    g_prewarm_prepare_rc = -5;
+
+    ChipRun run = submit(lane, 101, 0);
+    EXPECT_TRUE(run.done());
+    EXPECT_TRUE(lane.poisoned());
+    EXPECT_THROW(run.wait_until(ChipRunLane::Deadline::max()), std::runtime_error);
+    EXPECT_EQ(g_prepare_count[0], 0u);
+    EXPECT_THROW(lane.close(), std::runtime_error);
     worker.finalize();
 }

--- a/tests/ut/py/test_strace_timing.py
+++ b/tests/ut/py/test_strace_timing.py
@@ -800,6 +800,41 @@ def test_rounds_table_omits_tmr_only_columns_when_only_host_and_device_exist():
     assert "Avg Device: 22.0 us [2/2]" in rendered
 
 
+def test_rounds_table_excludes_internal_prewarm_invocation():
+    prewarm = (
+        _record(1, 1, "chip.run.runner_run.device_wall", "clk=dev", depth=2, dur=300_000)
+        + _record(1, 1, "chip.prewarm.run", depth=0, dur=400_000)
+        + "\n"
+    )
+    official = []
+    for inv, host_dur, device_dur in ((2, 100_000, 20_000), (3, 120_000, 24_000)):
+        official.append(
+            _record(1, inv, "chip.run", dur=host_dur)
+            + _record(1, inv, "chip.run.runner_run.device_wall", "clk=dev", depth=2, dur=device_dur)
+            + "\n"
+        )
+    buckets = bucket_by_hid(group_invocations(parse_spans([prewarm, *official])))
+    output = StringIO()
+
+    print_rounds_table(buckets, stream=output)
+
+    rendered = output.getvalue()
+    assert "Avg Host: 110.0 us" in rendered
+    assert "Avg Device: 22.0 us [2/2]" in rendered
+    assert "(2 rounds)" in rendered
+    assert "300.0" not in rendered
+
+
+def test_rounds_table_distinguishes_prewarm_only_from_no_markers():
+    lines = [_record(1, 1, "chip.run.bind", depth=1) + _record(1, 1, "chip.prewarm.run", depth=0, dur=400_000) + "\n"]
+    buckets = bucket_by_hid(group_invocations(parse_spans(lines)))
+    output = StringIO()
+
+    print_rounds_table(buckets, stream=output)
+
+    assert output.getvalue() == "No official [STRACE] rounds found.\n"
+
+
 def _run_records(*, run_epoch, prepare, device, release, run_id=0, dispatch_id=0, slot_id=0, pid=7, inv=None):
     """One phased native run's spans, as the `chip.run` tree carries them.
 


### PR DESCRIPTION
## Summary
- run one internal TMR prewarm task before the first activated run of each ChipWorker, so repeated benchmark rounds warm each chip exactly once
- exercise the normal prepare, launch, AICPU/AICore handshake, scheduler dispatch, completion, and finalize path without invoking user orchestration or executing a user kernel
- dispatch a zero function address during prewarm and exclude output copyback, acceptance publication, and pipeline-generation consumption
- support TMR on A2/A3 and A5 for simulator and onboard backends; unsupported runtimes such as HBG skip the internal prewarm
- emit the outer prewarm wall as `chip.prewarm.run`; benchmark round statistics accept only invocations whose depth-0 root is the official `chip.run`
- keep the implementation below PyPTO/scene APIs and retain prewarm visibility in non-round Host trace views

## Validation
- rebased onto upstream `main` at `5d046b19`
- staged pre-commit passed, including clang-format, clang-tidy, cpplint, ruff, and pyright
- `test_strace_timing.py`: 59/59 passed
- focused C++ tests `test_chip_run_lane` and `test_native_run_acceptance`: 2/2 passed
- editable package rebuild passed, compiling packaged A2/A3 and A5 simulator/onboard runtimes
- two-round TMR simulator smoke passed for A2/A3 and A5
- an existing single-card A5 level-4 swimlane log now parses as exactly one official round; no local hardware or multi-card test was run for this update

## Notes
- final diff contains 25 files and one commit
- safe compression moved run-flag zero initialization into the descriptor and simplified the one-time lane state/error path
- no `.claude`, `scene_test.py`, HBG runtime, Qwen example, or PyPTO upper-layer changes are included