### PR TITLE
Add: standalone Qwen3 HBG decode benchmark

### DIFF
--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/README.md
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/README.md
@@ -1,0 +1,93 @@
+# Qwen3-14B Standalone HBG Decode
+
+This example runs a post-prefill Qwen3-14B decode workload through Simpler's
+`host_build_graph` runtime. A caller-provided fixture supplies the KV snapshot
+and golden metadata; decode positions are overwritten on each run, which executes up to 127 decode
+dispatches. Single- and dual-slot execution use separate Python entry points.
+
+## Build the HBG artifact
+
+The input is a generated Qwen decode artifact containing the distributed host
+wrapper and one chip callable. The adapter preserves its in-core programs and
+outlines the 40-layer loop into one bounded decoder-layer Definition:
+
+```bash
+PYTHONPATH=/path/to/pypto/python:/path/to/simpler/python \
+python build_hbg_artifact.py \
+  --artifact-source /path/to/generated/artifact/qualification \
+  --output-dir /path/to/hbg_decode_artifact \
+  --platform a2a3
+```
+
+The source may be an artifact root with a `manifest.json`, or the distributed
+decode directory itself. Both the 25-argument compatibility ABI and the current
+26-argument ABI with `sampled_ids_host` are accepted. The generated manifest
+records the source and output checksums, Definition shape, and whether all
+in-core binaries remain byte-identical.
+Both runners verify the copied metadata, orchestration source/shared library,
+and in-core binary checksums before preparing the runtime.
+
+Each decode frame executes token embedding, records one decoder-layer
+Definition, replays it for the remaining 39 layers, and executes final RMSNorm,
+LM Head, and greedy sampling. Definition record, build, and upload are per-frame
+runtime work and remain inside measured intervals.
+
+## Run the benchmark
+
+`run_standalone_0p1.sh` is environment-driven. Supply the runtime dependencies,
+fixture, model, and HBG artifact explicitly:
+
+```bash
+PYTHON_BIN=/path/to/python \
+PYPTO_ROOT=/path/to/pypto \
+PYPTO_LIB_ROOT=/path/to/pypto-lib \
+PTOAS_ROOT=/path/to/ptoas \
+FIXTURE_ROOT=/path/to/fixture/qualification \
+MODEL_DIR=/path/to/Qwen3-14B \
+ARTIFACT_SOURCE=/path/to/hbg_decode_artifact \
+bash run_standalone_0p1.sh DEVICE_ID OUTPUT_DIR [single|dual] [STEPS]
+```
+
+The default qualification uses zero warmups, one measured request, 127 decode
+dispatches, and steady skip 5. `STEPS` may be reduced for a short correctness
+run. Large model, fixture, artifact, and result files remain outside the source
+repository.
+
+Dual mode shares immutable weights, RoPE, and the autoregressive KV cache. It
+owns separate metadata, logits, hidden-state, and sampled-token storage for
+in-flight frames. The validator requires strict slot alternation, independent
+slot generations, prepared dispatches after the first frame, serialized device
+execution, and the full golden token digest.
+
+## Metrics
+
+- `rts_completion_interval_ms`: consecutive `chip.run` completion timestamps,
+  used as the standalone decode TPOT proxy.
+- `runner_run_ms`: host child span around the runtime call.
+- `effective_ms`: `chip.run.runner_run.device_wall` for HBG.
+- `graph_build_ms`: host `node.graph_build` span.
+- `bind_ms`: HBG `chip.run.bind` span.
+
+The steady set contains 122 rows after skipping the first five dispatches. HBG
+exposes the complete device wall window rather than TMR's separate `.sched`
+subspan, and records that source in `trace_summary.json`.
+With zero steady skip, completion intervals start at the second dispatch.
+A single-dispatch run has zero interval samples and null interval statistics.
+
+The native STRACE log is exported to
+`profile/simpler_strace_timeline.json`, which can be opened in Perfetto.
+
+## Correctness contract
+
+A successful full run requires:
+
+- 127 decode dispatches on the selected slot configuration;
+- monotonically increasing generation and completion order;
+- every sampled token matching the fixture golden;
+- fixture, model, and artifact validation before device execution;
+- aligned native device STRACE spans;
+- an HBG artifact whose Definition contains fewer than 1024 tasks.
+
+The benchmark is a manual hardware entry point. Automated unit tests cover
+slot metadata isolation, HBG STRACE aggregation, artifact ABI validation, and
+source rewriting without requiring model weights or an NPU.

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/benchmark.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/benchmark.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run a frozen Qwen decode sequence through host_build_graph."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.util
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from hbg_common import shared_slot_state, update_slot
+
+BATCH = 16
+STEPS = 127
+SAMPLED_IDS_PAD = 8
+HIDDEN = 5120
+PADDED_VOCAB = 152064
+RING_TASK_WINDOW = 131072
+RING_DEP_POOL = 131072
+RING_HEAP = [1073741824, 1073741824, 1073741824, 8589934592]
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    here = Path(__file__).resolve().parent
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--artifact-work-dir", type=Path, required=True)
+    parser.add_argument("--artifact-source", type=Path)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("single", "dual"), required=True)
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=5)
+    parser.add_argument("--steady-skip", type=int, default=5)
+    parser.add_argument("--inter-run-wait", type=float, default=5.0)
+    parser.add_argument("--profile-only", action="store_true")
+    parser.add_argument("--qualification-steps", type=int)
+    parser.add_argument("--fixture-module", type=Path, default=here / "fixture.py")
+    parser.add_argument("--weights-module", type=Path, default=here / "weights.py")
+    return parser.parse_args()
+
+
+def _base_name(name: str) -> str:
+    return name.split("__ssa_", 1)[0]
+
+
+_shared_slot_state = shared_slot_state
+_update_slot = update_slot
+
+
+def _ordered_args(param_names: list[str], values: dict[str, Any]) -> tuple[Any, ...]:
+    missing = [name for name in param_names if name not in values]
+    if missing:
+        raise ValueError(f"decode artifact parameters have no runtime value: {missing}")
+    return tuple(values[name] for name in param_names)
+
+
+def _run_sequence(  # noqa: PLR0913
+    *,
+    rt: Any,
+    compiled: Any,
+    run_config: Any,
+    param_names: list[str],
+    resident: dict[str, Any],
+    slots: list[dict[str, torch.Tensor]],
+    golden: dict[str, torch.Tensor],
+    mode: str,
+    steps: int,
+    sampled_ids_host_abi: bool,
+    page_size: int,
+    blocks_per_row: int,
+) -> dict[str, Any]:
+    initial_host = torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+    initial_host[:, 0] = golden["decode_input_token_ids"][0]
+    rt.copy_to(
+        resident["initial_tokens"].data_ptr,
+        initial_host.data_ptr(),
+        initial_host.nbytes,
+    )
+    for slot in slots:
+        slot["block_table"].copy_(slot["initial_block_table"])
+    completions = []
+    token_rows: list[list[int]] = []
+    started = time.perf_counter()
+
+    def read_sampled_ids(slot_id: int, step: int) -> list[int]:
+        if sampled_ids_host_abi:
+            host = slots[slot_id]["sampled_ids_host"]
+        else:
+            host = torch.empty((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+            rt.copy_from(
+                host.data_ptr(),
+                resident["sampled"][step % 2].data_ptr,
+                host.nbytes,
+            )
+        return [int(value) for value in host[:, 0].tolist()]
+
+    def submit(step: int):
+        slot_id = 0 if mode == "single" else step % 2
+        _update_slot(slots[slot_id], golden, step, page_size=page_size, blocks_per_row=blocks_per_row)
+        token_input = resident["initial_tokens"] if step == 0 else resident["sampled"][(step - 1) % 2]
+        values = {
+            **resident["weights"],
+            **slots[slot_id],
+            "rope_cos": resident["rope_cos"],
+            "rope_sin": resident["rope_sin"],
+            "k_cache": resident["k_cache"],
+            "v_cache": resident["v_cache"],
+            "out": resident["out"],
+            "sampled_ids_in": token_input,
+            "sampled_ids": resident["sampled"][step % 2],
+            "next_hidden": resident["next_hidden"],
+        }
+        return slot_id, rt.submit(
+            compiled,
+            *_ordered_args(param_names, values),
+            config=run_config,
+        )
+
+    if mode == "single":
+        for step in range(steps):
+            slot_id, handle = submit(step)
+            handle.result()
+            completions.append(time.perf_counter())
+            row = read_sampled_ids(slot_id, step)
+            token_rows.append(row)
+    else:
+        raise ValueError("single runner received dual mode")
+
+    expected: list[list[int]] = golden["decode_output_token_ids"][:steps].tolist()
+    if token_rows != expected:
+        for step, (actual, wanted) in enumerate(zip(token_rows, expected)):
+            if actual != wanted:
+                raise RuntimeError(f"golden token mismatch at decode step {step}: {actual} != {wanted}")
+        raise RuntimeError("golden token sequence mismatch")
+    intervals = [(right - left) * 1000.0 for left, right in zip(completions, completions[1:])]
+    return {
+        "wall_s": time.perf_counter() - started,
+        "completion_intervals_ms": intervals,
+        "token_rows": token_rows,
+        "valid": True,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.mode != "single":
+        raise ValueError("benchmark.py is the single-slot HBG entry point")
+    if args.qualification_steps is not None:
+        if args.profile_only or not 1 <= args.qualification_steps <= STEPS:
+            raise ValueError("qualification_steps must be in [1, 127] and cannot profile")
+        args.warmup_runs = 0
+        args.measured_runs = 1
+        args.inter_run_wait = 0.0
+        decode_steps = args.qualification_steps
+    elif args.profile_only:
+        if args.warmup_runs != 1:
+            raise ValueError("profile-only requires one complete warmup sequence")
+        args.measured_runs = 1
+        decode_steps = STEPS
+    elif args.warmup_runs != 1 or args.measured_runs != 5:
+        raise ValueError("formal execution requires exactly 1 warmup + 5 measured runs")
+    else:
+        decode_steps = STEPS
+    if args.output_dir.exists():
+        raise FileExistsError(args.output_dir)
+    args.output_dir.mkdir(parents=True)
+
+    fixture_module = _load_module(args.fixture_module.resolve(), "_serving_effective_fixture")
+    weights_module = _load_module(args.weights_module.resolve(), "_serving_effective_weights")
+    fixture = fixture_module.load_fixture(
+        args.fixture,
+        expected_versions=None,
+    )
+    fixture.require_executable()
+    fixture.verify_external_inputs(args.model_dir.resolve())
+    golden = fixture.load_golden()
+    layout = fixture.manifest["physical_layout"]
+    page_size = int(layout["page_size"])
+    blocks_per_row = int(fixture.metadata["block_table"].shape[1])
+
+    artifact_source = (args.artifact_source or fixture.artifact_dir).resolve()
+    if args.artifact_work_dir.exists():
+        raise FileExistsError(args.artifact_work_dir)
+    shutil.copytree(artifact_source, args.artifact_work_dir)
+    decode_dir = args.artifact_work_dir
+    artifact_module = _load_module(Path(__file__).with_name("build_hbg_artifact.py"), "_hbg_artifact")
+    artifact_manifest = artifact_module.verify_hbg_artifact(decode_dir)
+    distributed_meta = json.loads((decode_dir / "distributed_meta.json").read_text())
+    param_names = [_base_name(param["name"]) for param in distributed_meta["params"]]
+    if len(param_names) not in {25, 26}:
+        raise ValueError(f"unsupported decode ABI with {len(param_names)} parameters")
+    sampled_ids_host_abi = "sampled_ids_host" in param_names
+
+    from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415
+        DistributedCompiledProgram,
+        DistributedConfig,
+    )
+    from pypto.runtime import RunConfig  # noqa: PLC0415
+
+    distributed = DistributedConfig(
+        device_ids=[args.device_id],
+        runtime="host_build_graph",
+        aicpu_thread_num=0,
+    )
+    compiled = DistributedCompiledProgram.from_dir(
+        decode_dir,
+        platform="a2a3",
+        distributed_config=distributed,
+    )
+    run_config = RunConfig(platform="a2a3", device_id=args.device_id)
+    slots = _shared_slot_state(fixture)
+
+    with compiled.prepare(config=run_config) as rt:
+        device_weights = {}
+        for name, host in weights_module.iter_kernel_weights(args.model_dir.resolve()):
+            device_weights[name] = rt.alloc_tensor(tuple(host.shape), host.dtype, init=host)
+            del host
+            gc.collect()
+        rope_cos_host, rope_sin_host = weights_module.rope_tables(args.model_dir.resolve())
+        rope_cos = rt.alloc_tensor(tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host)
+        rope_sin = rt.alloc_tensor(tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host)
+        del rope_cos_host, rope_sin_host
+        k_cache = fixture.allocate_kv(rt, "key")
+        v_cache = fixture.allocate_kv(rt, "value")
+        resident = {
+            "weights": device_weights,
+            "rope_cos": rope_cos,
+            "rope_sin": rope_sin,
+            "k_cache": k_cache,
+            "v_cache": v_cache,
+            "out": rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32),
+            "next_hidden": rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16),
+            "initial_tokens": rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+            "sampled": [
+                rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+                rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+            ],
+        }
+        runs = []
+        for kind, count in (
+            ("warmup", args.warmup_runs),
+            ("measured", args.measured_runs),
+        ):
+            for run_index in range(count):
+                result = _run_sequence(
+                    rt=rt,
+                    compiled=compiled,
+                    run_config=run_config,
+                    param_names=param_names,
+                    resident=resident,
+                    slots=slots,
+                    golden=golden,
+                    mode=args.mode,
+                    steps=decode_steps,
+                    sampled_ids_host_abi=sampled_ids_host_abi,
+                    page_size=page_size,
+                    blocks_per_row=blocks_per_row,
+                )
+                result.update({"kind": kind, "run": run_index + 1})
+                runs.append(result)
+                is_last = kind == "measured" and run_index + 1 == count
+                if not is_last:
+                    time.sleep(args.inter_run_wait)
+
+    output = {
+        "schema": 1,
+        "campaign_kind": (
+            "qualification"
+            if args.qualification_steps is not None
+            else "diagnostic_profiling"
+            if args.profile_only
+            else "formal_performance"
+        ),
+        "official_performance": not args.profile_only and args.qualification_steps is None,
+        "scenario": {
+            "runtime": "host_build_graph",
+            "mode": args.mode,
+            "batch_size": BATCH,
+            "decode_dispatches": decode_steps,
+            "warmup_runs": args.warmup_runs,
+            "measured_runs": args.measured_runs,
+            "retain_all_measured_runs": True,
+            "steady_skip_dispatches": args.steady_skip,
+            "inter_run_wait_s": args.inter_run_wait,
+            "fixture": str(fixture.root),
+            "fixture_artifact_source": str(fixture.artifact_dir),
+            "artifact_source": str(artifact_source),
+            "artifact_work_dir": str(args.artifact_work_dir),
+            "tmr_reference_ring": {
+                "ring_task_window": RING_TASK_WINDOW,
+                "ring_dep_pool": RING_DEP_POOL,
+                "ring_heap": RING_HEAP,
+                "applicable_to_hbg": False,
+            },
+            "artifact_generation": artifact_manifest["adapter"],
+            "graph_definition": {
+                key: artifact_manifest[key]
+                for key in (
+                    "graph_definition_count",
+                    "graph_definition_invocations_per_frame",
+                    "graph_definition_boundary_tensors",
+                    "graph_definition_boundary_scalars",
+                    "graph_definition_task_count_per_layer",
+                )
+            },
+            "kv_reuse": "decode positions are overwritten before attention reads them",
+        },
+        "runs": runs,
+        "correctness": {
+            "all_runs_valid": all(run["valid"] for run in runs),
+            "cross_run_tokens_identical": len({json.dumps(run["token_rows"]) for run in runs}) == 1,
+            "golden_tokens_identical": True,
+        },
+    }
+    (args.output_dir / "benchmark.json").write_text(
+        json.dumps(output, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/benchmark_dual.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/benchmark_dual.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run a frozen Qwen decode sequence through dual-slot host_build_graph."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import importlib.util
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from hbg_common import shared_slot_state, update_slot
+
+BATCH = 16
+STEPS = 127
+SAMPLED_IDS_PAD = 8
+HIDDEN = 5120
+PADDED_VOCAB = 152064
+RING_TASK_WINDOW = 131072
+RING_DEP_POOL = 131072
+RING_HEAP = [1073741824, 1073741824, 1073741824, 8589934592]
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    here = Path(__file__).resolve().parent
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--model-dir", type=Path, required=True)
+    parser.add_argument("--artifact-work-dir", type=Path, required=True)
+    parser.add_argument("--artifact-source", type=Path)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--mode", choices=("single", "dual"), required=True)
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=5)
+    parser.add_argument("--steady-skip", type=int, default=5)
+    parser.add_argument("--inter-run-wait", type=float, default=5.0)
+    parser.add_argument("--profile-only", action="store_true")
+    parser.add_argument("--qualification-steps", type=int)
+    parser.add_argument("--fixture-module", type=Path, default=here / "fixture.py")
+    parser.add_argument("--weights-module", type=Path, default=here / "weights.py")
+    return parser.parse_args()
+
+
+def _base_name(name: str) -> str:
+    return name.split("__ssa_", 1)[0]
+
+
+_shared_slot_state = shared_slot_state
+_update_slot = update_slot
+
+
+def _ordered_args(param_names: list[str], values: dict[str, Any]) -> tuple[Any, ...]:
+    missing = [name for name in param_names if name not in values]
+    if missing:
+        raise ValueError(f"decode artifact parameters have no runtime value: {missing}")
+    return tuple(values[name] for name in param_names)
+
+
+def _slot_value(value: Any, slot_id: int) -> Any:
+    return value[slot_id] if isinstance(value, list) else value
+
+
+def _sampled_value(resident: dict[str, Any], step: int, mode: str) -> Any:
+    index = step % 2 if mode == "single" else step
+    return resident["sampled"][index]
+
+
+def _run_sequence(  # noqa: PLR0913
+    *,
+    rt: Any,
+    compiled: Any,
+    run_config: Any,
+    param_names: list[str],
+    resident: dict[str, Any],
+    slots: list[dict[str, torch.Tensor]],
+    golden: dict[str, torch.Tensor],
+    mode: str,
+    steps: int,
+    sampled_ids_host_abi: bool,
+    page_size: int,
+    blocks_per_row: int,
+) -> dict[str, Any]:
+    initial_host = torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+    initial_host[:, 0] = golden["decode_input_token_ids"][0]
+    rt.copy_to(
+        resident["initial_tokens"].data_ptr,
+        initial_host.data_ptr(),
+        initial_host.nbytes,
+    )
+    for slot in slots:
+        slot["block_table"].copy_(slot["initial_block_table"])
+    completions = []
+    token_rows: list[list[int]] = []
+    started = time.perf_counter()
+
+    def read_sampled_ids(slot_id: int, step: int) -> list[int]:
+        if sampled_ids_host_abi:
+            host = slots[slot_id]["sampled_ids_host"]
+        else:
+            device_sampled = _sampled_value(resident, step, mode)
+            host = torch.empty((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32)
+            rt.copy_from(
+                host.data_ptr(),
+                device_sampled.data_ptr,
+                host.nbytes,
+            )
+        return [int(value) for value in host[:, 0].tolist()]
+
+    def submit(step: int):
+        slot_id = 0 if mode == "single" else step % 2
+        _update_slot(slots[slot_id], golden, step, page_size=page_size, blocks_per_row=blocks_per_row)
+        token_input = resident["initial_tokens"] if step == 0 else _sampled_value(resident, step - 1, mode)
+        values = {
+            **resident["weights"],
+            **slots[slot_id],
+            "rope_cos": resident["rope_cos"],
+            "rope_sin": resident["rope_sin"],
+            "k_cache": resident["k_cache"],
+            "v_cache": resident["v_cache"],
+            "out": _slot_value(resident["out"], slot_id),
+            "sampled_ids_in": token_input,
+            "sampled_ids": _sampled_value(resident, step, mode),
+            "next_hidden": _slot_value(resident["next_hidden"], slot_id),
+        }
+        return slot_id, rt.submit(
+            compiled,
+            *_ordered_args(param_names, values),
+            config=run_config,
+        )
+
+    if mode == "single":
+        for step in range(steps):
+            slot_id, handle = submit(step)
+            handle.result()
+            completions.append(time.perf_counter())
+            row = read_sampled_ids(slot_id, step)
+            token_rows.append(row)
+    else:
+        pending = []
+        completed = []
+        for step in range(min(2, steps)):
+            slot_id, handle = submit(step)
+            pending.append((step, slot_id, handle))
+        next_step = 2
+        while pending:
+            step, slot_id, handle = pending.pop(0)
+            handle.result()
+            completions.append(time.perf_counter())
+            if sampled_ids_host_abi:
+                token_rows.append(read_sampled_ids(slot_id, step))
+            else:
+                completed.append((step, slot_id))
+            if next_step < steps:
+                next_slot, next_handle = submit(next_step)
+                pending.append((next_step, next_slot, next_handle))
+                next_step += 1
+        if not sampled_ids_host_abi:
+            token_rows.extend(read_sampled_ids(slot_id, step) for step, slot_id in completed)
+
+    expected: list[list[int]] = golden["decode_output_token_ids"][:steps].tolist()
+    if token_rows != expected:
+        for step, (actual, wanted) in enumerate(zip(token_rows, expected)):
+            if actual != wanted:
+                raise RuntimeError(f"golden token mismatch at decode step {step}: {actual} != {wanted}")
+        raise RuntimeError("golden token sequence mismatch")
+    intervals = [(right - left) * 1000.0 for left, right in zip(completions, completions[1:])]
+    return {
+        "wall_s": time.perf_counter() - started,
+        "completion_intervals_ms": intervals,
+        "token_rows": token_rows,
+        "valid": True,
+    }
+
+
+def main() -> int:
+    args = _parse_args()
+    if args.mode != "dual":
+        raise ValueError("benchmark_dual.py is the dual-slot HBG entry point")
+    if args.qualification_steps is not None:
+        if args.profile_only or not 1 <= args.qualification_steps <= STEPS:
+            raise ValueError("qualification_steps must be in [1, 127] and cannot profile")
+        args.warmup_runs = 0
+        args.measured_runs = 1
+        args.inter_run_wait = 0.0
+        decode_steps = args.qualification_steps
+    elif args.profile_only:
+        if args.warmup_runs != 1:
+            raise ValueError("profile-only requires one complete warmup sequence")
+        args.measured_runs = 1
+        decode_steps = STEPS
+    elif args.warmup_runs != 1 or args.measured_runs != 5:
+        raise ValueError("formal execution requires exactly 1 warmup + 5 measured runs")
+    else:
+        decode_steps = STEPS
+    if args.output_dir.exists():
+        raise FileExistsError(args.output_dir)
+    args.output_dir.mkdir(parents=True)
+
+    fixture_module = _load_module(args.fixture_module.resolve(), "_serving_effective_fixture")
+    weights_module = _load_module(args.weights_module.resolve(), "_serving_effective_weights")
+    fixture = fixture_module.load_fixture(
+        args.fixture,
+        expected_versions=None,
+    )
+    fixture.require_executable()
+    fixture.verify_external_inputs(args.model_dir.resolve())
+    golden = fixture.load_golden()
+    layout = fixture.manifest["physical_layout"]
+    page_size = int(layout["page_size"])
+    blocks_per_row = int(fixture.metadata["block_table"].shape[1])
+
+    artifact_source = (args.artifact_source or fixture.artifact_dir).resolve()
+    if args.artifact_work_dir.exists():
+        raise FileExistsError(args.artifact_work_dir)
+    shutil.copytree(artifact_source, args.artifact_work_dir)
+    decode_dir = args.artifact_work_dir
+    artifact_module = _load_module(Path(__file__).with_name("build_hbg_artifact.py"), "_hbg_artifact")
+    artifact_manifest = artifact_module.verify_hbg_artifact(decode_dir)
+    distributed_meta = json.loads((decode_dir / "distributed_meta.json").read_text())
+    param_names = [_base_name(param["name"]) for param in distributed_meta["params"]]
+    if len(param_names) not in {25, 26}:
+        raise ValueError(f"unsupported decode ABI with {len(param_names)} parameters")
+    sampled_ids_host_abi = "sampled_ids_host" in param_names
+
+    from pypto.ir.distributed_compiled_program import (  # noqa: PLC0415
+        DistributedCompiledProgram,
+        DistributedConfig,
+    )
+    from pypto.runtime import RunConfig  # noqa: PLC0415
+
+    distributed = DistributedConfig(
+        device_ids=[args.device_id],
+        runtime="host_build_graph",
+        aicpu_thread_num=0,
+    )
+    compiled = DistributedCompiledProgram.from_dir(
+        decode_dir,
+        platform="a2a3",
+        distributed_config=distributed,
+    )
+    run_config = RunConfig(platform="a2a3", device_id=args.device_id)
+    slots = _shared_slot_state(fixture)
+
+    with compiled.prepare(config=run_config) as rt:
+        device_weights = {}
+        for name, host in weights_module.iter_kernel_weights(args.model_dir.resolve()):
+            device_weights[name] = rt.alloc_tensor(tuple(host.shape), host.dtype, init=host)
+            del host
+            gc.collect()
+        rope_cos_host, rope_sin_host = weights_module.rope_tables(args.model_dir.resolve())
+        rope_cos = rt.alloc_tensor(tuple(rope_cos_host.shape), rope_cos_host.dtype, init=rope_cos_host)
+        rope_sin = rt.alloc_tensor(tuple(rope_sin_host.shape), rope_sin_host.dtype, init=rope_sin_host)
+        del rope_cos_host, rope_sin_host
+        k_cache = fixture.allocate_kv(rt, "key")
+        v_cache = fixture.allocate_kv(rt, "value")
+        resident = {
+            "weights": device_weights,
+            "rope_cos": rope_cos,
+            "rope_sin": rope_sin,
+            "k_cache": k_cache,
+            "v_cache": v_cache,
+            "out": (
+                rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32)
+                if args.mode == "single"
+                else [rt.alloc_tensor((BATCH, PADDED_VOCAB), torch.float32) for _ in range(2)]
+            ),
+            "next_hidden": (
+                rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16)
+                if args.mode == "single"
+                else [rt.alloc_tensor((BATCH, HIDDEN), torch.bfloat16) for _ in range(2)]
+            ),
+            "initial_tokens": rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32),
+            "sampled": [
+                rt.alloc_tensor((BATCH, SAMPLED_IDS_PAD), torch.int32)
+                for _ in range(2 if args.mode == "single" else decode_steps)
+            ],
+        }
+        runs = []
+        for kind, count in (
+            ("warmup", args.warmup_runs),
+            ("measured", args.measured_runs),
+        ):
+            for run_index in range(count):
+                result = _run_sequence(
+                    rt=rt,
+                    compiled=compiled,
+                    run_config=run_config,
+                    param_names=param_names,
+                    resident=resident,
+                    slots=slots,
+                    golden=golden,
+                    mode=args.mode,
+                    steps=decode_steps,
+                    sampled_ids_host_abi=sampled_ids_host_abi,
+                    page_size=page_size,
+                    blocks_per_row=blocks_per_row,
+                )
+                result.update({"kind": kind, "run": run_index + 1})
+                runs.append(result)
+                is_last = kind == "measured" and run_index + 1 == count
+                if not is_last:
+                    time.sleep(args.inter_run_wait)
+
+    output = {
+        "schema": 1,
+        "campaign_kind": (
+            "qualification"
+            if args.qualification_steps is not None
+            else "diagnostic_profiling"
+            if args.profile_only
+            else "formal_performance"
+        ),
+        "official_performance": not args.profile_only and args.qualification_steps is None,
+        "scenario": {
+            "runtime": "host_build_graph",
+            "mode": args.mode,
+            "batch_size": BATCH,
+            "decode_dispatches": decode_steps,
+            "warmup_runs": args.warmup_runs,
+            "measured_runs": args.measured_runs,
+            "retain_all_measured_runs": True,
+            "steady_skip_dispatches": args.steady_skip,
+            "inter_run_wait_s": args.inter_run_wait,
+            "fixture": str(fixture.root),
+            "fixture_artifact_source": str(fixture.artifact_dir),
+            "artifact_source": str(artifact_source),
+            "artifact_work_dir": str(args.artifact_work_dir),
+            "tmr_reference_ring": {
+                "ring_task_window": RING_TASK_WINDOW,
+                "ring_dep_pool": RING_DEP_POOL,
+                "ring_heap": RING_HEAP,
+                "applicable_to_hbg": False,
+            },
+            "artifact_generation": artifact_manifest["adapter"],
+            "graph_definition": {
+                key: artifact_manifest[key]
+                for key in (
+                    "graph_definition_count",
+                    "graph_definition_invocations_per_frame",
+                    "graph_definition_boundary_tensors",
+                    "graph_definition_boundary_scalars",
+                    "graph_definition_task_count_per_layer",
+                )
+            },
+            "kv_reuse": "decode positions are overwritten before attention reads them",
+        },
+        "runs": runs,
+        "correctness": {
+            "all_runs_valid": all(run["valid"] for run in runs),
+            "cross_run_tokens_identical": len({json.dumps(run["token_rows"]) for run in runs}) == 1,
+            "golden_tokens_identical": True,
+        },
+    }
+    (args.output_dir / "benchmark.json").write_text(
+        json.dumps(output, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/build_hbg_artifact.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/build_hbg_artifact.py
@@ -1,0 +1,601 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Adapt a generated Qwen decode callable to host_build_graph."""
+
+# ruff: noqa: E501
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+from pathlib import Path
+
+
+def _parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-source", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--platform", choices=("a2a3",), default="a2a3")
+    parser.add_argument("--device-id", type=int, default=0)
+    return parser.parse_args(argv)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _bin_manifest(cache: Path) -> dict[str, str]:
+    return {path.name: _sha256(path) for path in sorted(cache.glob("incore_*.bin"))}
+
+
+def verify_hbg_artifact(root: Path) -> dict:
+    manifest = json.loads((root / "hbg_artifact_manifest.json").read_text(encoding="utf-8"))
+    if manifest.get("schema") != "simpler-hbg-pure-artifact-v1" or manifest.get("runtime") != "host_build_graph":
+        raise ValueError("unsupported HBG artifact manifest")
+    if not 0 < int(manifest["graph_definition_task_count_per_layer"]) < 1024:
+        raise ValueError("HBG Definition task count exceeds the supported contract")
+    child = root / "next_levels" / "decode_fwd"
+    paths = {
+        "distributed_meta_sha256": root / "distributed_meta.json",
+        "orchestration_cpp_sha256": child / "orchestration" / "decode_fwd.cpp",
+        "orchestration_so_sha256": child / "orchestration" / "decode_fwd.so",
+    }
+    for key, path in paths.items():
+        if _sha256(path) != manifest[key]:
+            raise ValueError(f"HBG artifact checksum mismatch: {path.name}")
+    bins = _bin_manifest(child / "cache")
+    if len(bins) not in {39, 41} or bins != manifest["source_incore_bins"]:
+        raise ValueError("HBG in-core binary checksum mismatch")
+    return manifest
+
+
+def _validate_param_names(param_names: list[str]) -> None:
+    required = {"out", "embed_weight", "sampled_ids_in", "sampled_ids", "next_hidden"}
+    if len(param_names) not in {25, 26} or not required.issubset(param_names):
+        raise RuntimeError(f"expected the Qwen decode ABI, got {param_names}")
+    has_host_output = "sampled_ids_host" in param_names
+    if has_host_output != (len(param_names) == 26):
+        raise RuntimeError(f"sampled_ids_host does not match the {len(param_names)}-argument ABI")
+
+
+def _normalize_tensor_type(path: Path) -> int:
+    source = path.read_text(encoding="utf-8")
+    normalized, count = re.subn(r"\bTaskTensor\b", "Tensor", source)
+    path.write_text(normalized, encoding="utf-8")
+    return count
+
+
+def _brace_end(source: str, open_brace: int) -> int:
+    depth = 0
+    for index in range(open_brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return index
+    raise RuntimeError("unterminated generated C++ block")
+
+
+def _definition_task_count(source: str) -> int:
+    start = source.find("static void decode_layer_definition")
+    if start < 0:
+        raise RuntimeError("cannot locate emitted layer Definition")
+    open_brace = source.find("{", start)
+    end = _brace_end(source, open_brace)
+    body = source[start : end + 1]
+    pairs: dict[int, int] = {}
+    stack: list[int] = []
+    for index, char in enumerate(body):
+        if char == "{":
+            stack.append(index)
+        elif char == "}" and stack:
+            pairs[stack.pop()] = index
+    constants = {
+        match.group(1): int(match.group(2))
+        for match in re.finditer(r"\b(?:int64_t|int32_t)\s+(\w+)\s*=\s*(-?\d+)", body)
+    }
+    loops: list[tuple[int, int, int]] = []
+    loop_pattern = re.compile(r"for\s*\([^;]+?=\s*(-?\d+)\s*;\s*\w+\s*<\s*([A-Za-z0-9_]+)\s*;[^)]*\)\s*\{")
+    for match in loop_pattern.finditer(body):
+        bound = constants.get(match.group(2))
+        if bound is None:
+            try:
+                bound = int(match.group(2))
+            except ValueError as error:
+                raise RuntimeError(f"cannot resolve loop bound {match.group(2)}") from error
+        open_loop = match.end() - 1
+        loops.append((match.start(), pairs[open_loop], max(0, bound - int(match.group(1)))))
+    task_count = 0
+    for submit in re.finditer(r"\brt_submit_(?:dummy_task|aic_task|aiv_task|task)\s*\(", body):
+        multiplier = 1
+        for loop_start, loop_end, trip_count in loops:
+            if loop_start < submit.start() < loop_end:
+                multiplier *= trip_count
+        task_count += multiplier
+    return task_count
+
+
+def _last_group(pattern: str, source: str) -> str:
+    matches = re.findall(pattern, source)
+    if not matches:
+        raise RuntimeError(f"generated source does not match {pattern}")
+    return matches[-1]
+
+
+def _remove_layer_output_allocations(body: str, layer_hidden: str, next_normed: str) -> str:
+    for name in (layer_hidden, next_normed):
+        body, count = re.subn(
+            rf"^[ \t]*uint32_t {re.escape(name)}_ci_shapes\[[^\n]+\n"
+            rf"^[ \t]*TensorCreateInfo {re.escape(name)}_ci\([^\n]+\n",
+            "",
+            body,
+            count=1,
+            flags=re.MULTILINE,
+        )
+        if count != 1:
+            raise RuntimeError(f"cannot remove generated create-info for {name}")
+
+    allocation = re.search(
+        rf"(?P<indent>[ \t]*)TaskOutputTensors (?P<alloc>alloc_\d+) = alloc_tensors\((?P<args>[^;]*{re.escape(layer_hidden)}_ci[^;]*)\);",
+        body,
+    )
+    if allocation is None:
+        raise RuntimeError("cannot locate generated layer output allocation")
+    alloc_name = allocation.group("alloc")
+    arguments = [value.strip() for value in allocation.group("args").split(",")]
+    filtered = [value for value in arguments if value not in (f"{layer_hidden}_ci", f"{next_normed}_ci")]
+    replacement = f"{allocation.group('indent')}TaskOutputTensors {alloc_name} = alloc_tensors({', '.join(filtered)});"
+    body = body[: allocation.start()] + replacement + body[allocation.end() :]
+    body = re.sub(
+        rf"^[ \t]*const TaskTensor& (?:{re.escape(layer_hidden)}|{re.escape(next_normed)}) = {re.escape(alloc_name)}\.get_ref\(\d+\);\n",
+        "",
+        body,
+        flags=re.MULTILINE,
+    )
+
+    def reindex(match: re.Match[str]) -> str:
+        index = int(match.group(1))
+        if index < 2:
+            raise RuntimeError("unexpected retained layer allocation output index")
+        return f"{alloc_name}.get_ref({index - 2})"
+
+    body = re.sub(rf"{re.escape(alloc_name)}\.get_ref\((\d+)\)", reindex, body)
+    return body
+
+
+def _move_layer_allocations_to_scratch(body: str) -> str:
+    """Replace generated intermediate alloc_tensors calls with ScratchArena views."""
+    dtype_by_ci = {
+        match.group(1): match.group(2)
+        for match in re.finditer(
+            r"TensorCreateInfo (?P<name>[A-Za-z0-9_]+)_ci\([^;]+, DataType::(?P<dtype>[A-Z0-9_]+)\);",
+            body,
+        )
+    }
+    for alloc_name in ("alloc_2", "alloc_3"):
+        match = re.search(
+            rf"(?P<indent>[ \t]*)TaskOutputTensors {alloc_name} = alloc_tensors\((?P<args>[^;]+)\);",
+            body,
+        )
+        if match is None:
+            raise RuntimeError(f"cannot locate {alloc_name} for scratch conversion")
+        lines = []
+        for ci in (value.strip() for value in match.group("args").split(",")):
+            if not ci.endswith("_ci"):
+                raise RuntimeError(f"unexpected {alloc_name} argument {ci}")
+            tensor_name = ci[:-3]
+            dtype = dtype_by_ci.get(tensor_name)
+            if dtype is None:
+                raise RuntimeError(f"cannot find dtype for {ci}")
+            selected_arena = "bf16_arena" if dtype == "BFLOAT16" else "fp32_arena"
+            lines.append(f"{match.group('indent')}TaskTensor {tensor_name} = {selected_arena}.allocate({ci});")
+        body = body[: match.start()] + "\n".join(lines) + body[match.end() :]
+        body = re.sub(
+            rf"^[ \t]*const TaskTensor& ([A-Za-z0-9_]+) = {alloc_name}\.get_ref\(\d+\);\n",
+            "",
+            body,
+            flags=re.MULTILINE,
+        )
+    return body
+
+
+def _outline_per_layer_definitions(orchestration_path: Path) -> int:
+    """Outline the generated layer loop into bounded HBG Definitions."""
+    source = orchestration_path.read_text(encoding="utf-8")
+    loop_match = re.search(
+        r"for \(int64_t (?P<layer>layer_idx_inline\d+) = 0; (?P=layer) < 40; (?P=layer) \+= 1\) \{",
+        source,
+    )
+    if loop_match is None:
+        raise RuntimeError("cannot locate generated 40-layer loop")
+    layer_index = loop_match.group("layer")
+    loop_open = source.find("{", loop_match.start())
+    loop_close = _brace_end(source, loop_open)
+    scope_start = source.find("SIMPLER_SCOPE()", loop_open, loop_close)
+    if scope_start < 0:
+        raise RuntimeError("generated layer loop is missing SIMPLER_SCOPE()")
+    scope_open = source.find("{", scope_start, loop_close)
+    scope_close = _brace_end(source, scope_open)
+    if source[scope_close + 1 : loop_close].strip():
+        raise RuntimeError("generated layer loop contains work outside its scope")
+    prefix = source[: loop_match.start()]
+    layer_body = source[scope_open + 1 : scope_close]
+
+    cur = _last_group(r"TaskTensor (cur_inline\d+__rv_v7) =", prefix)
+    normed = _last_group(r"TaskTensor (normed_inline\d+__rv_v5) =", prefix)
+    prev_out = _last_group(r"TaskId (prev_out_tid_inline\d+)\[1\]", prefix)
+    prev_normed = _last_group(r"TaskId (prev_normed_tid_inline\d+)\[1\]", prefix)
+    chunk_row0 = _last_group(r"int64_t (chunk_row0_inline\d+) =", prefix)
+    chunk_rows = _last_group(r"int64_t (chunk_rows_inline\d+) =", prefix)
+    chunk_rows_i32 = _last_group(r"int32_t (chunk_rows_i32_inline\d+) =", prefix)
+    layer_hidden = _last_group(r"TensorCreateInfo (layer_next_hidden_inline\d+)_ci", layer_body)
+    next_normed = _last_group(r"TensorCreateInfo (next_normed_inline\d+)_ci", layer_body)
+    next_gamma = _last_group(r"int64_t (next_gamma_idx_inline\d+) =", layer_body)
+    hidden_base = _last_group(r"int64_t (layer_hidden_base_inline\d+) =", layer_body)
+    inter_base = _last_group(r"int64_t (layer_inter_base_inline\d+) =", layer_body)
+    cache_base = _last_group(r"int64_t (layer_cache_base_token_rows_inline\d+) =", layer_body)
+    attention_cache_base = _last_group(r"int64_t (cache_base_inline\d+) =", layer_body)
+    q_norm_view = _last_group(r"TaskTensor (q_norm_w_inline\d+) =", layer_body)
+    k_norm_view = _last_group(r"TaskTensor (k_norm_w_inline\d+) =", layer_body)
+
+    layer_body = _remove_layer_output_allocations(layer_body, layer_hidden, next_normed)
+    layer_body = _move_layer_allocations_to_scratch(layer_body)
+    for index, external in enumerate(
+        (
+            "ext_input_rms_weight",
+            "ext_wq",
+            "ext_wk",
+            "ext_wv",
+            "ext_q_norm_weight",
+            "ext_k_norm_weight",
+            "ext_seq_lens",
+            "ext_block_table",
+            "ext_slot_mapping",
+            "ext_rope_cos",
+            "ext_rope_sin",
+            "ext_k_cache",
+            "ext_v_cache",
+            "ext_wo",
+            "ext_w_gate",
+            "ext_w_up",
+            "ext_w_down",
+            "ext_post_rms_weight",
+        )
+    ):
+        layer_body = layer_body.replace(f"orch_args.tensor({index}).ref()", external)
+
+    for name in (next_gamma, hidden_base, inter_base, cache_base, attention_cache_base):
+        layer_body = re.sub(rf"^[ \t]*int64_t {re.escape(name)} = [^\n]+\n", "", layer_body, flags=re.MULTILINE)
+    for view, external in ((q_norm_view, "ext_q_norm_weight"), (k_norm_view, "ext_k_norm_weight")):
+        layer_body = re.sub(
+            rf"^[ \t]*uint32_t {re.escape(view)}_offsets\[2\].*?^[ \t]*TaskTensor {re.escape(view)} = [^\n]+\n",
+            "",
+            layer_body,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        layer_body = layer_body.replace(view, external)
+    scalar_sources = (hidden_base, inter_base, cache_base, attention_cache_base, layer_index, next_gamma)
+    for name in scalar_sources:
+        layer_body = re.sub(
+            rf"(params_[A-Za-z0-9_]+\.add_scalar\(){re.escape(name)}(\);)",
+            r"\g<1>0\g<2>",
+            layer_body,
+        )
+    layer_body = re.sub(
+        r"(int64_t t__tmp_v\d+ = \(int64_t\)ext_k_cache\.shapes\[0\];)",
+        lambda match: match.group(1).replace("ext_k_cache.shapes[0]", "(ext_k_cache.shapes[0] * 40)"),
+        layer_body,
+        count=1,
+    )
+    if layer_index in layer_body:
+        raise RuntimeError("per-layer Definition retains host-side layer-index computation")
+    carry_start = re.search(rf"^[ \t]*TaskTensor {re.escape(cur.split('__')[0])}__ssa_v8 =", layer_body, re.MULTILINE)
+    if carry_start is None:
+        raise RuntimeError("cannot locate generated layer carry assignments")
+    carry_end_matches = list(re.finditer(rf"^[ \t]*{re.escape(normed)} = [^\n]+\n", layer_body, re.MULTILINE))
+    if not carry_end_matches:
+        raise RuntimeError("cannot locate final generated norm carry assignment")
+    carry_end = carry_end_matches[-1].end()
+    layer_body = layer_body[: carry_start.start()] + layer_body[carry_end:]
+
+    externals = (
+        "ext_input_rms_weight",
+        "ext_wq",
+        "ext_wk",
+        "ext_wv",
+        "ext_q_norm_weight",
+        "ext_k_norm_weight",
+        "ext_seq_lens",
+        "ext_block_table",
+        "ext_slot_mapping",
+        "ext_rope_cos",
+        "ext_rope_sin",
+        "ext_k_cache",
+        "ext_v_cache",
+        "ext_wo",
+        "ext_w_gate",
+        "ext_w_up",
+        "ext_w_down",
+        "ext_post_rms_weight",
+    )
+    boundary_names = (
+        cur,
+        normed,
+        layer_hidden,
+        next_normed,
+        *externals,
+        "score_transfer",
+        "probability_transfer",
+        "pv_transfer",
+        "ffts_workspace",
+        "bf16_scratch",
+        "fp32_scratch",
+    )
+    definition = [
+        "class ScratchArena {",
+        "public:",
+        "    explicit ScratchArena(const TaskTensor& storage) : storage_(storage) {}",
+        "    TaskTensor allocate(const TensorCreateInfo& create_info) {",
+        "        always_assert(create_info.dtype == storage_.dtype);",
+        "        const uint64_t element_size = get_element_size(storage_.dtype);",
+        "        const uint64_t alignment = 1024 / element_size;",
+        "        cursor_ = (cursor_ + alignment - 1) / alignment * alignment;",
+        "        const uint64_t elements = create_info.buffer_size_bytes() / element_size;",
+        "        const uint64_t aligned = (elements + alignment - 1) / alignment * alignment;",
+        "        always_assert((cursor_ + aligned) * element_size <= storage_.buffer.size);",
+        "        TaskTensor tensor;",
+        "        init_tensor_from_create_info(tensor, create_info, reinterpret_cast<void *>(static_cast<uintptr_t>(storage_.buffer.addr)), storage_.buffer.size);",
+        "        tensor.owner_task_id = storage_.owner_task_id;",
+        "        tensor.start_offset = storage_.start_offset + cursor_;",
+        "        cursor_ += aligned;",
+        "        return tensor;",
+        "    }",
+        "private:",
+        "    const TaskTensor& storage_;",
+        "    uint64_t cursor_{0};",
+        "};",
+        "",
+        "static void decode_layer_definition(const GraphTaskArgs& orch_args) {",
+    ]
+    definition.extend(
+        f"    const TaskTensor& {name} = orch_args.tensor({index}).ref();" for index, name in enumerate(boundary_names)
+    )
+    definition.extend(
+        [
+            f"    int64_t {chunk_row0} = 0;",
+            f"    int64_t {chunk_rows} = 16;",
+            f"    int32_t {chunk_rows_i32} = 16;",
+            f"    TaskId {prev_out}[1] = {{{cur}.owner_task_id}};",
+            f"    TaskId {prev_normed}[1] = {{{normed}.owner_task_id}};",
+            "    TaskId scratch_ready[1] = {TaskId::invalid()};",
+            "    ScratchArena bf16_arena(bf16_scratch);",
+            "    ScratchArena fp32_arena(fp32_scratch);",
+            layer_body,
+            "}",
+            "",
+        ]
+    )
+
+    storage = [
+        "                uint32_t hbg_hidden_shapes[2] = {16, 5120};",
+        "                TensorCreateInfo hbg_hidden_ci(hbg_hidden_shapes, 2, DataType::FLOAT32);",
+        "                uint32_t hbg_norm_shapes[2] = {16, 5120};",
+        "                TensorCreateInfo hbg_norm_ci(hbg_norm_shapes, 2, DataType::BFLOAT16);",
+        "                TaskOutputTensors hbg_layer_storage = alloc_tensors(hbg_hidden_ci, hbg_norm_ci, hbg_hidden_ci, hbg_norm_ci);",
+        "                uint32_t hbg_bf16_scratch_shapes[1] = {1048576};",
+        "                TensorCreateInfo hbg_bf16_scratch_ci(hbg_bf16_scratch_shapes, 1, DataType::BFLOAT16);",
+        "                uint32_t hbg_fp32_scratch_shapes[1] = {2097152};",
+        "                TensorCreateInfo hbg_fp32_scratch_ci(hbg_fp32_scratch_shapes, 1, DataType::FLOAT32);",
+        "                TaskOutputTensors hbg_scratch_storage = alloc_tensors(hbg_bf16_scratch_ci, hbg_fp32_scratch_ci);",
+        "                const TaskTensor& hbg_bf16_scratch = hbg_scratch_storage.get_ref(0);",
+        "                const TaskTensor& hbg_fp32_scratch = hbg_scratch_storage.get_ref(1);",
+    ]
+    replacement = [
+        *storage,
+        "                auto hbg_layer_view = [](const TaskTensor& tensor, int64_t layer, int64_t rows) {",
+        "                    uint32_t offsets[2] = {static_cast<uint32_t>(layer * rows), 0};",
+        "                    uint32_t shapes[2] = {static_cast<uint32_t>(rows), tensor.shapes[1]};",
+        "                    return tensor.view(shapes, offsets);",
+        "                };",
+        f"                for (int64_t {layer_index} = 0; {layer_index} < 40; {layer_index} += 1) {{",
+        "                    SIMPLER_SCOPE() {",
+    ]
+    replacement.extend(
+        [
+            f"                        const TaskTensor& {layer_hidden} = hbg_layer_storage.get_ref(({layer_index} & 1) * 2);",
+            f"                        const TaskTensor& {next_normed} = hbg_layer_storage.get_ref(({layer_index} & 1) * 2 + 1);",
+            f"                        uint32_t hbg_q_norm_offsets[2] = {{static_cast<uint32_t>({layer_index}), 0}};",
+            "                        uint32_t hbg_norm_shapes[2] = {1, 128};",
+            "                        TaskTensor hbg_q_norm = ext_q_norm_weight.view(hbg_norm_shapes, hbg_q_norm_offsets);",
+            f"                        uint32_t hbg_k_norm_offsets[2] = {{static_cast<uint32_t>({layer_index}), 0}};",
+            "                        TaskTensor hbg_k_norm = ext_k_norm_weight.view(hbg_norm_shapes, hbg_k_norm_offsets);",
+            f"                        TaskTensor hbg_graph_normed = {normed};",
+            f"                        hbg_graph_normed.owner_task_id = {prev_normed}[0];",
+            f"                        TaskTensor hbg_input_rms = hbg_layer_view(ext_input_rms_weight, std::min<int64_t>({layer_index} + 1, 39), 1);",
+            f"                        TaskTensor hbg_wq = hbg_layer_view(ext_wq, {layer_index}, 5120);",
+            f"                        TaskTensor hbg_wk = hbg_layer_view(ext_wk, {layer_index}, 5120);",
+            f"                        TaskTensor hbg_wv = hbg_layer_view(ext_wv, {layer_index}, 5120);",
+            f"                        TaskTensor hbg_k_cache = hbg_layer_view(ext_k_cache, {layer_index}, ext_k_cache.shapes[0] / 40);",
+            f"                        TaskTensor hbg_v_cache = hbg_layer_view(ext_v_cache, {layer_index}, ext_v_cache.shapes[0] / 40);",
+            f"                        TaskTensor hbg_wo = hbg_layer_view(ext_wo, {layer_index}, 5120);",
+            f"                        TaskTensor hbg_wgate = hbg_layer_view(ext_w_gate, {layer_index}, 5120);",
+            f"                        TaskTensor hbg_wup = hbg_layer_view(ext_w_up, {layer_index}, 5120);",
+            f"                        TaskTensor hbg_wdown = hbg_layer_view(ext_w_down, {layer_index}, 17408);",
+            f"                        TaskTensor hbg_post_rms = hbg_layer_view(ext_post_rms_weight, {layer_index}, 1);",
+            "                        GraphTaskArgs layer_args;",
+        ]
+    )
+    replacement.extend(
+        [
+            f"                        layer_args.add_input({cur});",
+            "                        layer_args.add_input(hbg_graph_normed);",
+            f"                        layer_args.add_inout({layer_hidden});",
+            f"                        layer_args.add_inout({next_normed});",
+        ]
+    )
+    caller_names = {
+        0: "hbg_input_rms",
+        1: "hbg_wq",
+        2: "hbg_wk",
+        3: "hbg_wv",
+        4: "hbg_q_norm",
+        5: "hbg_k_norm",
+        11: "hbg_k_cache",
+        12: "hbg_v_cache",
+        13: "hbg_wo",
+        14: "hbg_wgate",
+        15: "hbg_wup",
+        16: "hbg_wdown",
+        17: "hbg_post_rms",
+    }
+    for index, name in enumerate(externals):
+        method = "add_inout" if index in (11, 12) else "add_input"
+        replacement.append(f"                        layer_args.{method}({caller_names.get(index, name)});")
+    replacement.extend(
+        [
+            "                        layer_args.add_inout(score_transfer);",
+            "                        layer_args.add_inout(probability_transfer);",
+            "                        layer_args.add_inout(pv_transfer);",
+            "                        layer_args.add_inout(ffts_workspace);",
+            "                        layer_args.add_inout(hbg_bf16_scratch);",
+            "                        layer_args.add_inout(hbg_fp32_scratch);",
+            "                        rt_submit_graph(+decode_layer_definition, layer_args);",
+            f"                        {cur} = {layer_hidden};",
+            f"                        {normed} = {next_normed};",
+            "                    }",
+            "                }",
+        ]
+    )
+    source = source[: loop_match.start()] + "\n".join(replacement) + source[loop_close + 1 :]
+    entry_marker = '__attribute__((visibility("default")))\nvoid aicpu_orchestration_entry'
+    entry_index = source.find(entry_marker)
+    if entry_index < 0:
+        raise RuntimeError("cannot locate generated entry for layer Definition insertion")
+    source = source[:entry_index] + "\n".join(definition) + source[entry_index:]
+    orchestration_path.write_text(source, encoding="utf-8")
+    return 1
+
+
+def _adapt_child_callable(output_dir: Path, external_argument_count: int) -> dict[str, str | bool | int]:
+    """Rebind the generated chip callable and outline its decoder layer."""
+    child = output_dir / "next_levels" / "decode_fwd"
+    config_path = child / "kernel_config.py"
+    config = config_path.read_text(encoding="utf-8")
+    old_runtime = '\t"runtime": "tensormap_and_ringbuffer",'
+    new_runtime = '\t"runtime": "host_build_graph",'
+    if config.count(old_runtime) != 1:
+        raise RuntimeError("expected exactly one generated TMR child runtime binding")
+    config_path.write_text(config.replace(old_runtime, new_runtime), encoding="utf-8")
+    orchestration_path = child / "orchestration" / "decode_fwd.cpp"
+    definition_count = _outline_per_layer_definitions(orchestration_path)
+    _normalize_tensor_type(orchestration_path)
+    for kernel_path in sorted((child / "kernels").rglob("*.cpp")):
+        _normalize_tensor_type(kernel_path)
+
+    return {
+        "child_runtime": "host_build_graph",
+        "graph_definition_record_replay": True,
+        "graph_definition_boundary_tensors": 28,
+        "graph_definition_count": definition_count,
+        "graph_definition_invocations_per_frame": 40,
+        "graph_definition_boundary_scalars": 0,
+        "graph_definition_task_count_per_layer": _definition_task_count(orchestration_path.read_text(encoding="utf-8")),
+        "adapter": f"qwen3-14b-{external_argument_count}-arg-per-layer-hbg-v1",
+        "tensor_abi": "native HBG Tensor",
+    }
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv)
+    artifact_source = args.artifact_source.resolve()
+    source_manifest_path = artifact_source / "manifest.json"
+    if source_manifest_path.is_file():
+        source_manifest = json.loads(source_manifest_path.read_text(encoding="utf-8"))
+        source_decode = artifact_source / source_manifest["programs"]["decode"]["path"]
+    else:
+        source_manifest = None
+        source_decode = artifact_source
+    metadata_path = source_decode / "distributed_meta.json"
+    child = source_decode / "next_levels" / "decode_fwd"
+    for required in (metadata_path, child / "kernel_config.py", child / "orchestration" / "decode_fwd.cpp"):
+        if not required.is_file():
+            raise FileNotFoundError(required)
+
+    output_dir = args.output_dir.resolve()
+    if output_dir.exists():
+        raise FileExistsError(output_dir)
+    shutil.copytree(source_decode, output_dir)
+
+    metadata_path = output_dir / "distributed_meta.json"
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    param_names = [param["name"].split("__ssa_", 1)[0] for param in metadata["params"]]
+    _validate_param_names(param_names)
+    metadata["distributed_config"].update(
+        {"device_ids": [args.device_id], "runtime": "host_build_graph", "aicpu_thread_num": 0}
+    )
+    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+
+    child_output_dir = output_dir / "next_levels" / "decode_fwd"
+    source_bins = _bin_manifest(child_output_dir / "cache")
+    if len(source_bins) not in {39, 41}:
+        raise RuntimeError(f"expected 39 or 41 Qwen in-core binaries, got {len(source_bins)}")
+    source_cpp_sha = _sha256(child_output_dir / "orchestration" / "decode_fwd.cpp")
+    child_adapter = _adapt_child_callable(output_dir, len(param_names))
+    from pypto.runtime.device_runner import compile_and_assemble  # noqa: PLC0415
+
+    compile_and_assemble(child_output_dir, args.platform)
+    assembled_bins = _bin_manifest(child_output_dir / "cache")
+    if assembled_bins != source_bins:
+        changed = sorted(
+            name for name in set(source_bins) | set(assembled_bins) if source_bins.get(name) != assembled_bins.get(name)
+        )
+        raise RuntimeError(f"HBG assembly changed frozen in-core binaries: {changed}")
+
+    manifest = {
+        "schema": "simpler-hbg-pure-artifact-v1",
+        "runtime": "host_build_graph",
+        "platform": args.platform,
+        "device_id": args.device_id,
+        "batch_size": 16,
+        "max_seq_len": 4096,
+        "layers": 40,
+        "sampled_ids_pad": 8,
+        "external_argument_count": len(param_names),
+        "incore_bin_count": len(source_bins),
+        "source_artifact": str(source_decode),
+        "source_artifact_manifest_sha256": _sha256(source_manifest_path) if source_manifest is not None else None,
+        "source_distributed_meta_sha256": _sha256(source_decode / "distributed_meta.json"),
+        "source_orchestration_cpp_sha256": source_cpp_sha,
+        "source_incore_bins": source_bins,
+        "incore_bins_identical_to_tmr": True,
+        "orchestration_cpp_sha256": _sha256(child_output_dir / "orchestration" / "decode_fwd.cpp"),
+        "orchestration_so_sha256": _sha256(child_output_dir / "orchestration" / "decode_fwd.so"),
+        "distributed_meta_sha256": _sha256(metadata_path),
+        "output_dir": str(output_dir),
+        **child_adapter,
+    }
+    (output_dir / "hbg_artifact_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/export_strace_timeline.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/export_strace_timeline.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Export aligned HBG host and device STRACE spans as a Chrome trace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from pathlib import Path
+from typing import cast
+
+from trace_effective import Span, parse_spans
+
+
+def _event(
+    span: Span,
+    *,
+    category: str,
+    pid: int,
+    timestamp_ns: int,
+    args: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "name": span.name,
+        "cat": category,
+        "ph": "X",
+        "pid": pid,
+        "tid": span.tid,
+        "ts": timestamp_ns / 1000.0,
+        "dur": span.duration_ms * 1000.0,
+        "args": args,
+    }
+
+
+def export(log_path: Path, output_dir: Path) -> dict[str, object]:
+    spans = parse_spans(log_path)
+    by_inv: dict[tuple[int, int], list[Span]] = {}
+    for span in spans:
+        by_inv.setdefault((span.pid, span.inv), []).append(span)
+
+    events: list[dict[str, object]] = []
+    for pid in sorted({span.pid for span in spans}):
+        for output_pid, name in (
+            (pid, f"Simpler Host pid={pid}"),
+            (pid + 20_000_000, f"HBG device phases pid={pid}"),
+        ):
+            events.append(
+                {
+                    "name": "process_name",
+                    "ph": "M",
+                    "pid": output_pid,
+                    "tid": 0,
+                    "args": {"name": name},
+                }
+            )
+
+    phase_counts: Counter[str] = Counter()
+    unaligned = 0
+    host_count = 0
+    for (pid, inv), group in by_inv.items():
+        host_runner = next(
+            (span for span in group if span.name.endswith(".runner_run") and span.attrs.get("clk") != "dev"),
+            None,
+        )
+        for span in group:
+            attrs: dict[str, object] = {"inv": inv, "hid": span.hid, **span.attrs}
+            if span.attrs.get("clk") != "dev":
+                host_count += 1
+                events.append(
+                    _event(
+                        span,
+                        category="simpler_host",
+                        pid=pid,
+                        timestamp_ns=span.timestamp_ns,
+                        args=attrs,
+                    )
+                )
+                continue
+            if host_runner is None:
+                unaligned += 1
+                continue
+            phase_counts[span.name] += 1
+            attrs["alignment"] = "chip.run.runner_run start"
+            events.append(
+                _event(
+                    span,
+                    category="hbg_device",
+                    pid=pid + 20_000_000,
+                    timestamp_ns=host_runner.timestamp_ns + span.timestamp_ns,
+                    args=attrs,
+                )
+            )
+
+    required = ("chip.run.runner_run.device_wall",)
+    missing = [name for name in required if phase_counts[name] == 0]
+    if missing:
+        raise RuntimeError(f"missing native device STRACE phases: {missing}")
+    if unaligned:
+        raise RuntimeError(f"native device STRACE has {unaligned} unaligned spans")
+
+    events.sort(
+        key=lambda event: (
+            cast(float, event.get("ts", 0)),
+            cast(int, event["pid"]),
+            cast(int, event["tid"]),
+        )
+    )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    timeline_path = output_dir / "simpler_strace_timeline.json"
+    timeline_path.write_text(
+        json.dumps(
+            {
+                "traceEvents": events,
+                "displayTimeUnit": "ms",
+                "metadata": {
+                    "schema": "simpler-strace-chrome-timeline-v1",
+                    "runtime": "host_build_graph",
+                    "device_clock_alignment": "per-invocation chip.run.runner_run start",
+                    "device_phase_contract": "HBG exposes device_wall without TMR subspans",
+                },
+            },
+            separators=(",", ":"),
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    summary = {
+        "schema": "simpler-strace-timeline-summary-v1",
+        "passed": True,
+        "timeline": timeline_path.name,
+        "trace_event_count": len(events),
+        "host_span_count": host_count,
+        "device_span_count": sum(phase_counts.values()),
+        "unaligned_device_span_count": unaligned,
+        "device_phase_counts": dict(sorted(phase_counts.items())),
+        "runtime": "host_build_graph",
+        "device_wall_only": True,
+        "missing_device_subspans": [
+            "chip.run.runner_run.device_wall.orch",
+            "chip.run.runner_run.device_wall.sched",
+        ],
+    }
+    (output_dir / "simpler_strace_timeline_summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    print(
+        json.dumps(
+            export(args.log.resolve(), args.output_dir.resolve()),
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/fixture.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/fixture.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Load and validate a portable Serving-TMR prefill fixture."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections.abc import Iterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import load_file
+
+SCHEMA_NAME = "serving-tmr-standalone-fixture-v1"
+EXPECTED_METADATA = {
+    "prompt_token_ids": ((16, 3338), torch.int32),
+    "seq_lens_after_first_token": ((16,), torch.int32),
+    "next_slot_mapping": ((16,), torch.int32),
+    "first_generated_token_ids": ((16,), torch.int32),
+    "block_table": ((16, 32), torch.int32),
+    "tokens_used_after_prefill": ((16,), torch.int32),
+}
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _json_type_matches(value: Any, expected: str) -> bool:
+    return {
+        "object": isinstance(value, dict),
+        "array": isinstance(value, list),
+        "boolean": isinstance(value, bool),
+        "string": isinstance(value, str),
+        "integer": isinstance(value, int) and not isinstance(value, bool),
+        "number": isinstance(value, (int, float)) and not isinstance(value, bool),
+    }.get(expected, True)
+
+
+def _condition_matches(value: Any, schema: dict[str, Any]) -> bool:
+    if not isinstance(value, dict):
+        return False
+    for name, rule in schema.get("properties", {}).items():
+        if name not in value:
+            return False
+        if "const" in rule and value[name] != rule["const"]:
+            return False
+    return True
+
+
+def _validate_json_schema(value: Any, schema: dict[str, Any], path: str = "manifest") -> None:
+    expected_type = schema.get("type")
+    if expected_type is not None and not _json_type_matches(value, expected_type):
+        raise ValueError(f"{path} must have JSON type {expected_type}")
+    if "const" in schema and value != schema["const"]:
+        raise ValueError(f"{path} must equal {schema['const']!r}")
+
+    if isinstance(value, dict):
+        required = schema.get("required", [])
+        missing = sorted(set(required) - set(value))
+        if missing:
+            raise ValueError(f"{path} is missing required fields: {missing}")
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            extras = sorted(set(value) - set(properties))
+            if extras:
+                raise ValueError(f"{path} has unsupported fields: {extras}")
+        for name, rule in properties.items():
+            if name in value:
+                _validate_json_schema(value[name], rule, f"{path}.{name}")
+
+    if isinstance(value, list):
+        if len(value) < schema.get("minItems", 0):
+            raise ValueError(f"{path} has too few items")
+        if "maxItems" in schema and len(value) > schema["maxItems"]:
+            raise ValueError(f"{path} has too many items")
+
+    for rule in schema.get("allOf", []):
+        if _condition_matches(value, rule.get("if", {})):
+            _validate_json_schema(value, rule.get("then", {}), path)
+
+
+def _verify_sums(root: Path) -> dict[Path, str]:
+    sums_path = root / "SHA256SUMS"
+    if not sums_path.is_file():
+        raise FileNotFoundError(sums_path)
+    expected: dict[Path, str] = {}
+    for line in sums_path.read_text(encoding="utf-8").splitlines():
+        digest, relative = line.split(None, 1)
+        relative_path = Path(relative.removeprefix("./"))
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            raise ValueError(f"invalid SHA256SUMS path: {relative}")
+        if relative_path in expected:
+            raise ValueError(f"duplicate SHA256SUMS path: {relative_path}")
+        expected[relative_path] = digest
+    actual = {path.relative_to(root) for path in root.rglob("*") if path.is_file() and path.name != "SHA256SUMS"}
+    if set(expected) != actual:
+        raise ValueError(
+            f"SHA256SUMS file set mismatch: missing={sorted(set(expected) - actual)} "
+            f"extra={sorted(actual - set(expected))}"
+        )
+    for relative, digest in expected.items():
+        if _sha256(root / relative) != digest:
+            raise ValueError(f"SHA256 mismatch: {relative}")
+    return expected
+
+
+@dataclass(frozen=True)
+class Fixture:
+    root: Path
+    manifest: dict[str, Any]
+    metadata: dict[str, torch.Tensor]
+
+    @property
+    def metadata_only(self) -> bool:
+        return bool(self.manifest["metadata_only"])
+
+    @property
+    def artifact_dir(self) -> Path:
+        return (self.root / self.manifest["artifact"]["path"]).resolve()
+
+    @property
+    def golden_path(self) -> Path:
+        return (self.root / self.manifest["golden_contract"]["path"]).resolve()
+
+    def require_executable(self) -> None:
+        if self.metadata_only:
+            raise RuntimeError("metadata-only fixture cannot allocate device state or execute")
+
+    def iter_kv_shards(self, kind: str) -> Iterator[tuple[int, Path, str]]:
+        self.require_executable()
+        entries = [entry for entry in self.manifest["kv_shards"] if entry["kind"] == kind]
+        for entry in sorted(entries, key=lambda item: int(item["layer"])):
+            yield int(entry["layer"]), self.root / entry["path"], entry["tensor"]
+
+    def verify_external_inputs(self, model_dir: Path) -> None:
+        for entry in self.manifest["checkpoint_files"]:
+            path = model_dir / entry["name"]
+            if not path.is_file() or path.stat().st_size != int(entry["bytes"]):
+                raise ValueError(f"checkpoint file mismatch: {entry['name']}")
+            if _sha256(path) != entry["sha256"]:
+                raise ValueError(f"checkpoint SHA256 mismatch: {entry['name']}")
+
+    def verify_artifact_and_golden(self) -> None:
+        self.require_executable()
+        artifact = self.manifest["artifact"]
+        if _sha256(self.artifact_dir / "manifest.json") != artifact["manifest_sha256"]:
+            raise ValueError("artifact manifest SHA256 mismatch")
+        if _sha256(self.artifact_dir / "SHA256SUMS") != artifact["sha256sums_sha256"]:
+            raise ValueError("artifact SHA256SUMS mismatch")
+        _verify_sums(self.artifact_dir)
+        if not self.golden_path.is_file():
+            raise FileNotFoundError(self.golden_path)
+        _verify_sums(self.golden_path.parent)
+
+    def load_golden(self) -> dict[str, torch.Tensor]:
+        self.require_executable()
+        golden = load_file(str(self.golden_path), device="cpu")
+        shapes = self.manifest["golden_contract"]["tensor_shapes"]
+        if set(golden) != set(shapes):
+            raise ValueError("golden tensor names do not match the fixture contract")
+        for name, shape in shapes.items():
+            tensor = golden[name]
+            if tensor.dtype != torch.int32 or tuple(tensor.shape) != tuple(shape):
+                raise ValueError(f"golden tensor contract mismatch: {name}")
+        steps = int(self.manifest["decode_dispatches_remaining"])
+        if not torch.equal(golden["step_index"], torch.arange(steps, dtype=torch.int32)):
+            raise ValueError(f"golden step_index must be 0..{steps - 1}")
+        if not torch.equal(
+            golden["decode_input_token_ids"][0],
+            self.metadata["first_generated_token_ids"],
+        ):
+            raise ValueError("golden first decode input differs from the prefill token")
+        layout = self.manifest["physical_layout"]
+        page_size = int(layout["page_size"])
+        num_pages = int(layout["num_pages"])
+        positions = golden["seq_lens"] - 1
+        slots = golden["slot_mapping"]
+        if not torch.equal(slots.remainder(page_size), positions.remainder(page_size)):
+            raise ValueError("golden slot_mapping offset differs from seq_lens")
+        page_ids = slots.div(page_size, rounding_mode="floor")
+        if int(page_ids.min()) < 0 or int(page_ids.max()) >= num_pages:
+            raise ValueError("golden slot_mapping page is outside physical KV storage")
+        return golden
+
+    def allocate_kv(self, runtime: Any, kind: str) -> Any:
+        self.require_executable()
+        layout = self.manifest["physical_layout"]
+        num_layers = int(layout["num_layers"])
+        num_pages = int(layout["num_pages"])
+        num_kv_heads = int(layout["num_kv_heads"])
+        page_size = int(layout["page_size"])
+        head_dim = int(layout["head_dim"])
+        rows = num_layers * num_pages * num_kv_heads * page_size
+        used_page_ids = self.metadata["used_page_ids"].to(torch.long)
+        host = torch.zeros((rows, head_dim), dtype=torch.bfloat16)
+        host_layers = host.view(num_layers, num_pages, num_kv_heads, page_size, head_dim)
+        entries = list(self.iter_kv_shards(kind))
+        if [layer for layer, _, _ in entries] != list(range(num_layers)):
+            raise ValueError(f"{kind} KV shards do not cover every layer")
+        for layer, path, tensor_name in entries:
+            shard = load_file(str(path), device="cpu")[tensor_name]
+            expected_shape = (len(used_page_ids), num_kv_heads, page_size, head_dim)
+            if shard.dtype != torch.bfloat16 or tuple(shard.shape) != expected_shape:
+                raise ValueError(f"KV shard contract mismatch: {path.name}")
+            host_layers[layer].index_copy_(0, used_page_ids, shard)
+            del shard
+        return runtime.alloc_tensor(tuple(host.shape), host.dtype, init=host)
+
+
+def _validate_metadata(manifest: dict[str, Any], metadata: dict[str, torch.Tensor]) -> None:
+    expected_names = set(EXPECTED_METADATA) | {"used_page_ids", "allocated_page_ids"}
+    if set(metadata) != expected_names:
+        raise ValueError("metadata tensor names do not match fixture schema v1")
+    for name, (shape, dtype) in EXPECTED_METADATA.items():
+        tensor = metadata[name]
+        if tuple(tensor.shape) != shape or tensor.dtype != dtype:
+            raise ValueError(f"metadata tensor contract mismatch: {name}")
+    for name in ("used_page_ids", "allocated_page_ids"):
+        tensor = metadata[name]
+        if tensor.ndim != 1 or tensor.dtype != torch.int32:
+            raise ValueError(f"metadata tensor contract mismatch: {name}")
+
+    layout = manifest["physical_layout"]
+    num_pages = int(layout["num_pages"])
+    page_size = int(layout["page_size"])
+    block_table = metadata["block_table"]
+    allocated = sorted({int(value) for value in block_table.flatten().tolist() if value >= 0})
+    if allocated != metadata["allocated_page_ids"].tolist():
+        raise ValueError("allocated_page_ids differs from block_table")
+    if not allocated or allocated[0] < 0 or allocated[-1] >= num_pages:
+        raise ValueError("block_table page is outside physical KV storage")
+
+    prompt_tokens = int(manifest["prompt_tokens"])
+    used_blocks_per_row = math.ceil(prompt_tokens / page_size)
+    used = sorted({int(value) for value in block_table[:, :used_blocks_per_row].flatten().tolist() if value >= 0})
+    if used != metadata["used_page_ids"].tolist():
+        raise ValueError("used_page_ids differs from the prompt block mapping")
+    if len(used) != int(layout["used_page_count"]):
+        raise ValueError("used_page_count differs from metadata")
+
+    page_index, page_offset = divmod(prompt_tokens, page_size)
+    expected_slots = block_table[:, page_index] * page_size + page_offset
+    if not torch.equal(expected_slots, metadata["next_slot_mapping"]):
+        raise ValueError("next_slot_mapping does not name the first decode position")
+    if not torch.equal(
+        metadata["seq_lens_after_first_token"],
+        torch.full((16,), prompt_tokens + 1, dtype=torch.int32),
+    ):
+        raise ValueError("seq_lens_after_first_token is inconsistent with the prompt")
+    if not torch.equal(
+        metadata["tokens_used_after_prefill"],
+        torch.full((16,), prompt_tokens, dtype=torch.int32),
+    ):
+        raise ValueError("tokens_used_after_prefill is inconsistent with the prompt")
+    if not torch.equal(metadata["prompt_token_ids"], metadata["prompt_token_ids"][0].repeat(16, 1)):
+        raise ValueError("batch prompt rows must be identical")
+
+
+def load_fixture(root: Path, expected_versions: dict[str, str] | None = None) -> Fixture:
+    root = root.resolve()
+    fixture_sums = _verify_sums(root)
+    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    schema = json.loads((root / "manifest.schema.json").read_text(encoding="utf-8"))
+    _validate_json_schema(manifest, schema)
+    if manifest["schema"] != SCHEMA_NAME:
+        raise ValueError(f"unsupported fixture schema: {manifest['schema']}")
+    boundary = manifest["snapshot_boundary"]
+    required_boundary = {
+        "all_chunked_prefill_complete": True,
+        "first_token_produced": True,
+        "actual_decode_dispatches_before_snapshot": 0,
+        "prefill_and_sampling_fences_retired": True,
+    }
+    for name, expected in required_boundary.items():
+        if boundary.get(name) != expected:
+            raise ValueError(f"snapshot boundary mismatch: {name}")
+    if expected_versions is not None:
+        for name, expected in expected_versions.items():
+            if manifest["versions"].get(name) != expected:
+                raise ValueError(f"fixture version mismatch: {name}")
+
+    metadata_path = root / manifest["metadata"]["path"]
+    if _sha256(metadata_path) != manifest["metadata"]["sha256"]:
+        raise ValueError("metadata SHA256 differs from manifest")
+    metadata = load_file(str(metadata_path), device="cpu")
+    _validate_metadata(manifest, metadata)
+
+    fixture = Fixture(root=root, manifest=manifest, metadata=metadata)
+    if not fixture.metadata_only:
+        expected_shards = 2 * int(manifest["kv_shard_contract"]["layers"])
+        if len(manifest["kv_shards"]) != expected_shards:
+            raise ValueError(f"full fixture must contain {expected_shards} KV shards")
+        for entry in manifest["kv_shards"]:
+            path = root / entry["path"]
+            if path.stat().st_size != int(entry["bytes"]) or fixture_sums.get(Path(entry["path"])) != entry["sha256"]:
+                raise ValueError(f"KV shard checksum mismatch: {entry['path']}")
+        fixture.verify_artifact_and_golden()
+    return fixture
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fixture", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    fixture = load_fixture(_parse_args().fixture)
+    print(
+        json.dumps(
+            {
+                "fixture": str(fixture.root),
+                "schema": fixture.manifest["schema"],
+                "metadata_only": fixture.metadata_only,
+                "used_page_count": len(fixture.metadata["used_page_ids"]),
+                "decode_dispatches_remaining": fixture.manifest["decode_dispatches_remaining"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/hbg_common.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/hbg_common.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared slot state and fixture geometry for the Qwen HBG runners."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+BATCH = 16
+SAMPLED_IDS_PAD = 8
+
+
+def shared_slot_state(fixture: Any) -> list[dict[str, torch.Tensor]]:
+    block_table = fixture.metadata["block_table"].reshape(-1)
+    return [
+        {
+            "seq_lens": fixture.metadata["seq_lens_after_first_token"].clone().share_memory_(),
+            "block_table": block_table.clone().share_memory_(),
+            "initial_block_table": block_table.clone(),
+            "slot_mapping": fixture.metadata["next_slot_mapping"].clone().share_memory_(),
+            "sampled_ids_host": torch.zeros((BATCH, SAMPLED_IDS_PAD), dtype=torch.int32).share_memory_(),
+        }
+        for _ in range(2)
+    ]
+
+
+def update_slot(
+    slot: dict[str, torch.Tensor],
+    golden: dict[str, torch.Tensor],
+    step: int,
+    *,
+    page_size: int,
+    blocks_per_row: int,
+) -> None:
+    slot["seq_lens"].copy_(golden["seq_lens"][step])
+    slot["slot_mapping"].copy_(golden["slot_mapping"][step])
+    positions = slot["seq_lens"] - 1
+    if not torch.equal(slot["slot_mapping"].remainder(page_size), positions.remainder(page_size)):
+        raise RuntimeError(f"slot mapping offset mismatch at decode step {step}")
+    logical_blocks = positions.div(page_size, rounding_mode="floor")
+    page_ids = slot["slot_mapping"].div(page_size, rounding_mode="floor")
+    if int(logical_blocks.min()) < 0 or int(logical_blocks.max()) >= blocks_per_row:
+        raise RuntimeError(f"logical block exceeds the block table row at decode step {step}")
+    if slot["block_table"].numel() < BATCH * blocks_per_row:
+        raise RuntimeError("block table is smaller than the fixture geometry")
+    for row in range(BATCH):
+        slot["block_table"][row * blocks_per_row + int(logical_blocks[row])] = page_ids[row]
+    slot["sampled_ids_host"].zero_()

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/run_standalone_0p1.sh
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/run_standalone_0p1.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+set -eo pipefail
+
+DEVICE_ID="${1:?usage: run_standalone_0p1.sh DEVICE_ID OUTPUT_ROOT [MODE] [STEPS]}"
+OUTPUT_ROOT="${2:?usage: run_standalone_0p1.sh DEVICE_ID OUTPUT_ROOT [MODE] [STEPS]}"
+MODE="${3:-single}"
+STEPS="${4:-127}"
+: "${PYTHON_BIN:?set PYTHON_BIN to the isolated Python interpreter}"
+: "${PYPTO_ROOT:?set PYPTO_ROOT to the PyPTO checkout}"
+: "${PYPTO_LIB_ROOT:?set PYPTO_LIB_ROOT to the matching pypto-lib checkout}"
+: "${PTOAS_ROOT:?set PTOAS_ROOT to the matching PTOAS installation}"
+: "${FIXTURE_ROOT:?set FIXTURE_ROOT to the prefill KV snapshot}"
+: "${MODEL_DIR:?set MODEL_DIR to the Qwen3-14B checkpoint}"
+: "${ARTIFACT_SOURCE:?set ARTIFACT_SOURCE to the decode artifact}"
+test -f "$ARTIFACT_SOURCE/hbg_artifact_manifest.json"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+case "$MODE" in
+  single) BENCHMARK="$SCRIPT_DIR/benchmark.py" ;;
+  dual) BENCHMARK="$SCRIPT_DIR/benchmark_dual.py" ;;
+  *) echo "mode must be single or dual: $MODE" >&2; exit 2 ;;
+esac
+if (( STEPS < 1 || STEPS > 127 )); then
+  echo "steps must be in [1, 127]: $STEPS" >&2
+  exit 2
+fi
+STEADY_SKIP=5
+if (( STEPS <= STEADY_SKIP )); then
+  STEADY_SKIP=0
+fi
+RESULT="$OUTPUT_ROOT/results/${MODE}_0warmup_1measured"
+ARTIFACT_WORK="$OUTPUT_ROOT/artifact_work/${MODE}_0warmup_1measured"
+RUNLOG="$OUTPUT_ROOT/logs/${MODE}_0warmup_1measured"
+
+test ! -e "$RESULT"
+test ! -e "$ARTIFACT_WORK"
+eval "$(pypto-setup --export)"
+test -f "$ASCEND_HOME_PATH/set_env.sh"
+source "$ASCEND_HOME_PATH/set_env.sh"
+set -u
+
+mkdir -p "$OUTPUT_ROOT/results" "$OUTPUT_ROOT/artifact_work" "$RUNLOG"
+export PYTHONNOUSERSITE=1
+export PYTHONDONTWRITEBYTECODE=1
+export PYTHONPATH="$PYPTO_ROOT/python:$PYPTO_LIB_ROOT:$REPO_ROOT:$REPO_ROOT/python:$SCRIPT_DIR${PYTHONPATH:+:$PYTHONPATH}"
+export PATH="$PTOAS_ROOT/bin:$PATH"
+export PYPTO_PROG_BUILD_DIR="$OUTPUT_ROOT/compile_cache"
+export ASCEND_PROCESS_LOG_PATH="$RUNLOG/ascend"
+export SIMPLER_DEVICE_STRACE_ENABLE=1
+unset PTO2_OP_EXECUTE_TIMEOUT_US PTO2_STREAM_SYNC_TIMEOUT_MS
+unset PTO2_RING_DEP_POOL PTO2_RING_TASK_WINDOW PTO2_RING_HEAP
+unset PYPTO_RING_DEP_POOL PYPTO_RING_TASK_WINDOW PYPTO_RING_HEAP
+
+mkdir -p "$ASCEND_PROCESS_LOG_PATH" "$PYPTO_PROG_BUILD_DIR"
+npu-smi info -t board -i "$DEVICE_ID" -c 0 > "$RUNLOG/device_before.txt" 2>&1 || true
+capture_after() {
+  npu-smi info -t board -i "$DEVICE_ID" -c 0 > "$RUNLOG/device_after.txt" 2>&1 || true
+}
+trap capture_after EXIT
+
+"$PYTHON_BIN" "$BENCHMARK" \
+  --fixture "$FIXTURE_ROOT" \
+  --fixture-module "$SCRIPT_DIR/fixture.py" \
+  --weights-module "$SCRIPT_DIR/weights.py" \
+  --model-dir "$MODEL_DIR" \
+  --artifact-source "$ARTIFACT_SOURCE" \
+  --artifact-work-dir "$ARTIFACT_WORK" \
+  --output-dir "$RESULT" \
+  --mode "$MODE" \
+  --device-id "$DEVICE_ID" \
+  --warmup-runs 0 \
+  --measured-runs 1 \
+  --steady-skip "$STEADY_SKIP" \
+  --inter-run-wait 0 \
+  --qualification-steps "$STEPS" \
+  2>&1 | tee "$RUNLOG/run.log"
+
+cp "$RUNLOG/run.log" "$RESULT/run.log"
+cp "$RUNLOG/device_before.txt" "$RESULT/device_before.txt"
+"$PYTHON_BIN" "$SCRIPT_DIR/trace_effective.py" \
+  --log "$RESULT/run.log" \
+  --output "$RESULT/trace_summary.json" \
+  --warmup-runs 0 \
+  --measured-runs 1 \
+  --steps "$STEPS" \
+  --steady-skip "$STEADY_SKIP"
+"$PYTHON_BIN" "$SCRIPT_DIR/export_strace_timeline.py" \
+  --log "$RESULT/run.log" \
+  --output-dir "$RESULT/profile"
+
+if [[ "$MODE" == "dual" ]]; then
+  "$PYTHON_BIN" "$SCRIPT_DIR/validate_dual_result.py" \
+    --result "$RESULT" \
+    --fixture "$FIXTURE_ROOT" \
+    --golden-manifest "$FIXTURE_ROOT/../../golden/qualification/manifest.json" \
+    --steps "$STEPS"
+fi
+
+checksum_files=(
+  "$RESULT/benchmark.json"
+  "$RESULT/trace_summary.json"
+  "$RESULT/profile/simpler_strace_timeline.json"
+  "$RESULT/profile/simpler_strace_timeline_summary.json"
+)
+if [[ "$MODE" == "dual" ]]; then
+  checksum_files+=("$RESULT/dual_validation.json")
+fi
+sha256sum "${checksum_files[@]}" > "$RESULT/SHA256SUMS"

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/selftest.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/selftest.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""CPU checks for standalone HBG slot metadata isolation."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import benchmark
+import torch
+from hbg_common import shared_slot_state
+
+DUAL_PATH = Path(__file__).with_name("benchmark_dual.py")
+DUAL_SPEC = importlib.util.spec_from_file_location("benchmark_dual", DUAL_PATH)
+assert DUAL_SPEC is not None and DUAL_SPEC.loader is not None
+benchmark_dual = importlib.util.module_from_spec(DUAL_SPEC)
+sys.modules[DUAL_SPEC.name] = benchmark_dual
+DUAL_SPEC.loader.exec_module(benchmark_dual)
+
+
+def main() -> int:
+    assert callable(benchmark._run_sequence)
+    assert callable(benchmark_dual._run_sequence)
+
+    class FixtureStub:
+        metadata = {
+            "block_table": torch.cat(
+                (torch.arange(432, dtype=torch.int32), torch.full((80,), -1, dtype=torch.int32))
+            ).reshape(16, 32),
+            "seq_lens_after_first_token": torch.zeros(16, dtype=torch.int32),
+            "next_slot_mapping": torch.zeros(16, dtype=torch.int32),
+        }
+
+    slots = shared_slot_state(FixtureStub())
+    golden = {
+        "seq_lens": torch.full((2, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.stack((torch.arange(432, 448, dtype=torch.int32) * 128,) * 2),
+    }
+    benchmark._update_slot(slots[0], golden, 0, page_size=128, blocks_per_row=32)
+    assert torch.all(slots[1]["block_table"].view(16, 32)[:, 27] == -1)
+    benchmark._update_slot(slots[1], golden, 1, page_size=128, blocks_per_row=32)
+    assert torch.equal(
+        slots[0]["block_table"].view(16, 32)[:, 27],
+        torch.arange(432, 448, dtype=torch.int32),
+    )
+    assert torch.equal(
+        slots[1]["block_table"].view(16, 32)[:, 27],
+        torch.arange(432, 448, dtype=torch.int32),
+    )
+    print("standalone HBG single/dual CPU checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/stack_manifest.json
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/stack_manifest.json
@@ -1,0 +1,26 @@
+{
+  "schema": "simpler-qwen3-14b-hbg-decode-reference-v1",
+  "workload": {
+    "model": "Qwen3-14B",
+    "dtype": "bfloat16",
+    "prompt_tokens": 3338,
+    "batch_size": 16,
+    "output_tokens": 128,
+    "consumed_decode_dispatches": 127,
+    "steady_skip_dispatches": 5,
+    "runtime_slots": [0, 1],
+    "kv_backing_page_count": 691
+  },
+  "artifact": {
+    "runtime": "host_build_graph",
+    "supported_external_argument_counts": [25, 26],
+    "definition_count": 1,
+    "definition_invocations_per_frame": 40,
+    "definition_task_limit": 1024
+  },
+  "runtime_dependency": {
+    "prefill_fixture": "provided-by-caller",
+    "decode_artifact": "generated-by-build_hbg_artifact.py",
+    "model_checkpoint": "provided-by-caller"
+  }
+}

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/trace_effective.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/trace_effective.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Extract HBG runtime timing from a standalone Simpler STRACE log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+_STRACE_RE = re.compile(
+    r"\[STRACE\]\s+v=(?P<version>\d+)\s+pid=(?P<pid>\d+)\s+tid=(?P<tid>\d+)\s+"
+    r"inv=(?P<inv>\d+)\s+hid=(?P<hid>[0-9a-fA-F]+)\s+depth=(?P<depth>\d+)\s+"
+    r"name=(?P<name>\S+)\s+ts=(?P<ts>\d+)\s+dur=(?P<dur>\d+)(?:\s+(?P<attrs>.*))?"
+)
+_ATTR_RE = re.compile(r"(?P<key>[A-Za-z_][A-Za-z0-9_]*)=(?P<value>\S+)")
+
+
+@dataclass(frozen=True)
+class Span:
+    pid: int
+    tid: int
+    inv: int
+    hid: str
+    name: str
+    timestamp_ns: int
+    duration_ms: float
+    attrs: dict[str, str]
+
+
+def _parse_attrs(text: str | None) -> dict[str, str]:
+    if not text:
+        return {}
+    return {match.group("key"): match.group("value") for match in _ATTR_RE.finditer(text)}
+
+
+def parse_spans(log_path: Path) -> list[Span]:
+    spans = []
+    for line in log_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        match = _STRACE_RE.search(line)
+        if match is None:
+            continue
+        spans.append(
+            Span(
+                pid=int(match.group("pid")),
+                tid=int(match.group("tid")),
+                inv=int(match.group("inv")),
+                hid=match.group("hid"),
+                name=match.group("name"),
+                timestamp_ns=int(match.group("ts")),
+                duration_ms=int(match.group("dur")) / 1_000_000.0,
+                attrs=_parse_attrs(match.group("attrs")),
+            )
+        )
+    return spans
+
+
+def _percentile(values: list[float], quantile: float) -> float:
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * quantile
+    low = math.floor(position)
+    high = math.ceil(position)
+    if low == high:
+        return ordered[low]
+    return ordered[low] + (ordered[high] - ordered[low]) * (position - low)
+
+
+def _stats(values: list[float]) -> dict[str, float | int | None]:
+    if not values:
+        return {"count": 0, **dict.fromkeys(("mean", "std", "min", "p50", "p95", "p99", "max"))}
+    mean = statistics.fmean(values)
+    return {
+        "count": len(values),
+        "mean": mean,
+        "std": statistics.pstdev(values) if len(values) > 1 else 0.0,
+        "min": min(values),
+        "p50": _percentile(values, 0.50),
+        "p95": _percentile(values, 0.95),
+        "p99": _percentile(values, 0.99),
+        "max": max(values),
+    }
+
+
+def _span_by_suffix(spans: list[Span], suffix: str) -> Span | None:
+    matches = [span for span in spans if span.name.endswith(suffix)]
+    if len(matches) > 1:
+        raise ValueError(f"invocation has multiple spans ending in {suffix!r}")
+    return matches[0] if matches else None
+
+
+def _required_duration(spans: list[Span], suffix: str) -> float:
+    span = _span_by_suffix(spans, suffix)
+    if span is None:
+        raise ValueError(f"invocation is missing span ending in {suffix!r}")
+    return span.duration_ms
+
+
+def invocation_rows(spans: list[Span]) -> list[dict[str, float | int | bool | str]]:
+    roots = [span for span in spans if span.name in {"chip.run", "simpler_run"}]
+    if not roots:
+        raise ValueError("no chip.run or simpler_run root spans found")
+
+    spans_by_process_inv: dict[tuple[int, int], list[Span]] = {}
+    for span in spans:
+        spans_by_process_inv.setdefault((span.pid, span.inv), []).append(span)
+
+    rows = []
+    seen_dispatches = set()
+    for root in roots:
+        dispatch_id = int(root.attrs.get("dispatch_id", root.inv))
+        if dispatch_id in seen_dispatches:
+            raise ValueError(f"duplicate root span for dispatch {dispatch_id}")
+        seen_dispatches.add(dispatch_id)
+        invocation = list(spans_by_process_inv[(root.pid, root.inv)])
+        run_id = root.attrs.get("run_id")
+        for (pid, inv), group in spans_by_process_inv.items():
+            if pid == root.pid or inv != root.inv:
+                continue
+            if run_id is not None and any(span.attrs.get("run_id") == run_id for span in group):
+                invocation.extend(group)
+        node_dispatch = _span_by_suffix(invocation, "node.dispatch")
+        attrs = root.attrs if node_dispatch is None else {**node_dispatch.attrs, **root.attrs}
+        sched_span = _span_by_suffix(invocation, ".runner_run.device_wall.sched")
+        if sched_span is None:
+            effective = _required_duration(invocation, ".runner_run.device_wall")
+            effective_source = "chip.run.runner_run.device_wall"
+        else:
+            effective = sched_span.duration_ms
+            effective_source = "chip.run.runner_run.device_wall.sched"
+        rows.append(
+            {
+                "dispatch_id": dispatch_id,
+                "slot_id": int(attrs.get("slot_id", -1)),
+                "generation": int(attrs.get("generation", -1)),
+                "prepare_only": attrs.get("prepare_only", "0") == "1",
+                "root_start_ns": root.timestamp_ns,
+                "root_completion_ns": root.timestamp_ns + round(root.duration_ms * 1_000_000),
+                "chip_run_lifecycle_ms": root.duration_ms,
+                "graph_build_ms": _required_duration(invocation, "node.graph_build"),
+                "bind_ms": _required_duration(invocation, ".bind"),
+                "runner_run_ms": _required_duration(invocation, ".runner_run"),
+                "effective_ms": effective,
+                "effective_source": effective_source,
+                "device_wall_ms": _required_duration(invocation, ".runner_run.device_wall"),
+                "validate_ms": _required_duration(invocation, ".validate"),
+            }
+        )
+    return sorted(rows, key=lambda row: int(row["dispatch_id"]))
+
+
+def summarize_campaign(
+    rows: list[dict[str, float | int | bool | str]],
+    *,
+    warmup_runs: int,
+    measured_runs: int,
+    steps: int,
+    steady_skip: int,
+) -> dict[str, object]:
+    expected = (warmup_runs + measured_runs) * steps
+    if len(rows) != expected:
+        raise ValueError(f"expected {expected} dispatches, found {len(rows)}")
+    if not 0 <= steady_skip < steps:
+        raise ValueError("steady_skip must be nonnegative and smaller than steps")
+    if warmup_runs < 0 or measured_runs < 1:
+        raise ValueError("warmup_runs must be nonnegative and measured_runs must be positive")
+
+    measured = rows[warmup_runs * steps :]
+    effective_sources = sorted({str(row["effective_source"]) for row in measured})
+    if len(effective_sources) != 1:
+        raise ValueError(f"mixed Effective sources: {effective_sources}")
+    latency_metrics = (
+        "graph_build_ms",
+        "bind_ms",
+        "runner_run_ms",
+        "effective_ms",
+        "device_wall_ms",
+        "validate_ms",
+    )
+    run_summaries = []
+    pooled = {metric: [] for metric in ("rts_completion_interval_ms", *latency_metrics)}
+    diagnostic_lifecycles = []
+    for run_index in range(measured_runs):
+        start = run_index * steps
+        run_rows = measured[start : start + steps]
+        steady_rows = run_rows[steady_skip:]
+        dispatches = [int(row["dispatch_id"]) for row in run_rows]
+        completions = [int(row["root_completion_ns"]) for row in run_rows]
+        if any(current <= previous for previous, current in zip(dispatches, dispatches[1:])):
+            raise ValueError(f"run {run_index + 1} dispatch ids are not strictly increasing")
+        if any(current <= previous for previous, current in zip(completions, completions[1:])):
+            raise ValueError(f"run {run_index + 1} root completions are not strictly increasing")
+
+        interval_values = [
+            (completions[index] - completions[index - 1]) / 1_000_000.0 for index in range(max(1, steady_skip), steps)
+        ]
+        metric_stats = {"rts_completion_interval_ms": _stats(interval_values)}
+        pooled["rts_completion_interval_ms"].extend(interval_values)
+        for metric in latency_metrics:
+            values = [float(row[metric]) for row in steady_rows]
+            metric_stats[metric] = _stats(values)
+            pooled[metric].extend(values)
+        lifecycle_values = [float(row["chip_run_lifecycle_ms"]) for row in steady_rows]
+        diagnostic_lifecycles.extend(lifecycle_values)
+        run_summaries.append(
+            {
+                "run": run_index + 1,
+                "dispatch_first": int(run_rows[0]["dispatch_id"]),
+                "dispatch_last": int(run_rows[-1]["dispatch_id"]),
+                "steady_dispatch_count": len(steady_rows),
+                "metrics": metric_stats,
+                "diagnostic_metrics": {
+                    "chip_run_lifecycle_ms": _stats(lifecycle_values),
+                },
+            }
+        )
+
+    official = {}
+    for metric, pooled_values in pooled.items():
+        run_means = [
+            float(run["metrics"][metric]["mean"]) for run in run_summaries if run["metrics"][metric]["mean"] is not None
+        ]
+        official[metric] = {
+            "run_means": run_means,
+            "run_mean_stats": _stats(run_means),
+            "pooled_steady_stats": _stats(pooled_values),
+        }
+
+    return {
+        "schema": 2,
+        "aggregation": {
+            "warmup_runs": warmup_runs,
+            "measured_runs": measured_runs,
+            "retained_run_numbers": list(range(1, measured_runs + 1)),
+            "drop_high_low_run": False,
+            "steps_per_run": steps,
+            "steady_skip_dispatches": steady_skip,
+            "steady_dispatches_per_run": steps - steady_skip,
+        },
+        "dispatch_contract": {
+            "total": len(rows),
+            "warmup": warmup_runs * steps,
+            "measured": measured_runs * steps,
+        },
+        "effective_source": effective_sources[0],
+        "runs": run_summaries,
+        "official_metrics": official,
+        "diagnostic_metrics": {
+            "chip_run_lifecycle_ms": {
+                "status": "diagnostic_only",
+                "reason": "async-overlapped invocation lifetime is not frame latency or throughput",
+                "pooled_steady_stats": _stats(diagnostic_lifecycles),
+            }
+        },
+    }
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--warmup-runs", type=int, default=1)
+    parser.add_argument("--measured-runs", type=int, default=5)
+    parser.add_argument("--steps", type=int, default=127)
+    parser.add_argument("--steady-skip", type=int, default=5)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    summary = summarize_campaign(
+        invocation_rows(parse_spans(args.log)),
+        warmup_runs=args.warmup_runs,
+        measured_runs=args.measured_runs,
+        steps=args.steps,
+        steady_skip=args.steady_skip,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/validate_dual_result.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/validate_dual_result.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Validate one standalone HBG dual-slot decode result."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+from safetensors.torch import load_file
+from trace_effective import invocation_rows, parse_spans, summarize_campaign
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _full_output_sha(first_tokens: list[int], token_rows: list[list[int]]) -> str:
+    per_request = [
+        [int(first_tokens[batch])] + [int(row[batch]) for row in token_rows] for batch in range(len(first_tokens))
+    ]
+    payload = json.dumps(per_request, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--result", type=Path, required=True)
+    parser.add_argument("--fixture", type=Path, required=True)
+    parser.add_argument("--golden-manifest", type=Path, required=True)
+    parser.add_argument("--steps", type=int, required=True)
+    args = parser.parse_args()
+
+    benchmark = json.loads((args.result / "benchmark.json").read_text())
+    trace = json.loads((args.result / "trace_summary.json").read_text())
+    run = benchmark["runs"][0]
+    scenario = benchmark["scenario"]
+    _require(benchmark["correctness"]["all_runs_valid"], "benchmark correctness failed")
+    _require(scenario["mode"] == "dual", "result is not dual-slot")
+    _require(scenario["warmup_runs"] == 0 and scenario["measured_runs"] == 1, "expected 0+1")
+    _require(scenario["decode_dispatches"] == args.steps, "decode step count mismatch")
+    _require(run["valid"] and len(run["token_rows"]) == args.steps, "incomplete token rows")
+
+    rows = invocation_rows(parse_spans(args.result / "run.log"))
+    _require(len(rows) == args.steps, "native dispatch count mismatch")
+    recomputed: dict[str, Any] = summarize_campaign(
+        rows,
+        warmup_runs=int(benchmark["scenario"]["warmup_runs"]),
+        measured_runs=int(benchmark["scenario"]["measured_runs"]),
+        steps=args.steps,
+        steady_skip=int(benchmark["scenario"]["steady_skip_dispatches"]),
+    )
+    _require(recomputed["aggregation"] == trace["aggregation"], "trace aggregation does not match run.log")
+    _require(recomputed["official_metrics"] == trace["official_metrics"], "trace metrics do not match run.log")
+    expected_slots = [index % 2 for index in range(args.steps)]
+    actual_slots = [int(row["slot_id"]) for row in rows]
+    _require(actual_slots == expected_slots, "native slots do not strictly alternate")
+
+    generations = [0, 0]
+    for row in rows:
+        slot = int(row["slot_id"])
+        generations[slot] += 1
+        _require(
+            int(row["generation"]) == generations[slot],
+            "slot generation is not monotonic",
+        )
+    _require(not bool(rows[0]["prepare_only"]), "first dispatch must start immediately")
+    _require(
+        all(bool(row["prepare_only"]) for row in rows[1:]),
+        "later dispatch was not prepared",
+    )
+
+    host_runners = sorted(
+        (
+            span
+            for span in parse_spans(args.result / "run.log")
+            if span.name.endswith(".runner_run") and span.attrs.get("clk") != "dev"
+        ),
+        key=lambda span: span.timestamp_ns,
+    )
+    _require(len(host_runners) == args.steps, "runner span count mismatch")
+    for previous, current in zip(host_runners, host_runners[1:]):
+        previous_end = previous.timestamp_ns + round(previous.duration_ms * 1_000_000)
+        _require(current.timestamp_ns >= previous_end, "device runner spans overlap")
+
+    aggregation = recomputed["aggregation"]
+    steady_skip = int(aggregation["steady_skip_dispatches"])
+    expected_steady = args.steps - steady_skip
+    effective: dict[str, Any] = trace["official_metrics"]["effective_ms"]["pooled_steady_stats"]  # type: ignore[reportAny]
+    _require(effective["count"] == expected_steady, "steady Effective count mismatch")
+
+    full_output_sha = None
+    if args.steps == 127:
+        fixture_manifest = json.loads((args.fixture / "manifest.json").read_text())
+        metadata = load_file(str(args.fixture / fixture_manifest["metadata"]["path"]))
+        golden_manifest = json.loads(args.golden_manifest.read_text())
+        full_output_sha = _full_output_sha(metadata["first_generated_token_ids"].tolist(), run["token_rows"])
+        _require(
+            full_output_sha == golden_manifest["full_128_output_token_ids_sha256"],
+            "full output token SHA differs from golden",
+        )
+
+    slots = Counter(actual_slots)
+    result = {
+        "schema": "simpler-hbg-dual-qualification-v1",
+        "passed": True,
+        "steps": args.steps,
+        "warmup_runs": 0,
+        "measured_runs": 1,
+        "runtime_slots": {str(slot): count for slot, count in sorted(slots.items())},
+        "final_slot_generations": {"0": generations[0], "1": generations[1]},
+        "prepare_only_after_first": True,
+        "device_runner_serial": True,
+        "full_128_output_token_ids_sha256": full_output_sha,
+        "rts_completion_interval_ms": recomputed["official_metrics"]["rts_completion_interval_ms"][
+            "pooled_steady_stats"
+        ],
+        "runner_run_ms": recomputed["official_metrics"]["runner_run_ms"]["pooled_steady_stats"],
+        "effective_ms": effective,
+        "effective_over_50ms_count": sum(float(row["effective_ms"]) > 50.0 for row in rows[steady_skip:]),
+        "effective_over_70ms_count": sum(float(row["effective_ms"]) > 70.0 for row in rows[steady_skip:]),
+    }
+    output = args.result / "dual_validation.json"
+    output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/weights.py
+++ b/examples/a2a3/host_build_graph/qwen3_14b_serving_effective/weights.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Qwen3-14B checkpoint conversion for the decode callable ABI."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+NUM_LAYERS = 40
+HEAD_DIM = 128
+HIDDEN = 5120
+PADDED_VOCAB = 152064
+MAX_SEQ_LEN = 4096
+
+
+class CheckpointReader:
+    def __init__(self, model_dir: Path):
+        self.model_dir = model_dir
+        config = json.loads((model_dir / "config.json").read_text())
+        expected = {"num_hidden_layers": NUM_LAYERS, "hidden_size": HIDDEN, "head_dim": HEAD_DIM}
+        mismatches = {
+            name: (config[name], value)
+            for name, value in expected.items()
+            if name in config and int(config[name]) != value
+        }
+        vocab_size = int(config.get("vocab_size", 0))
+        if vocab_size > PADDED_VOCAB:
+            mismatches["vocab_size"] = (vocab_size, PADDED_VOCAB)
+        if mismatches:
+            raise ValueError(f"checkpoint geometry does not match decode ABI: {mismatches}")
+        index = json.loads((model_dir / "model.safetensors.index.json").read_text())
+        self.weight_map: dict[str, str] = index["weight_map"]
+
+    def load(self, name: str) -> torch.Tensor:
+        shard = self.weight_map.get(name)
+        if shard is None:
+            raise KeyError(name)
+        with safe_open(self.model_dir / shard, framework="pt", device="cpu") as handle:
+            return handle.get_tensor(name)
+
+    def load_optional(self, name: str, default: torch.Tensor) -> torch.Tensor:
+        return self.load(name) if name in self.weight_map else default
+
+
+def _stack_layers(
+    reader: CheckpointReader,
+    suffix: str,
+    *,
+    dtype: torch.dtype,
+    transpose: bool,
+) -> torch.Tensor:
+    layers = []
+    for layer in range(NUM_LAYERS):
+        tensor = reader.load(f"model.layers.{layer}.{suffix}")
+        tensor = tensor.transpose(0, 1) if transpose else tensor.view(1, -1)
+        layers.append(tensor.to(dtype).contiguous())
+    return torch.cat(layers, dim=0).contiguous()
+
+
+def iter_kernel_weights(model_dir: Path) -> Iterator[tuple[str, torch.Tensor]]:
+    reader = CheckpointReader(model_dir)
+    rules = (
+        ("input_rms_weight", "input_layernorm.weight", torch.float32, False),
+        ("wq", "self_attn.q_proj.weight", torch.bfloat16, True),
+        ("wk", "self_attn.k_proj.weight", torch.bfloat16, True),
+        ("wv", "self_attn.v_proj.weight", torch.bfloat16, True),
+        ("wo", "self_attn.o_proj.weight", torch.bfloat16, True),
+        ("w_gate", "mlp.gate_proj.weight", torch.bfloat16, True),
+        ("w_up", "mlp.up_proj.weight", torch.bfloat16, True),
+        ("w_down", "mlp.down_proj.weight", torch.bfloat16, True),
+        ("post_rms_weight", "post_attention_layernorm.weight", torch.float32, False),
+    )
+    for target, suffix, dtype, transpose in rules:
+        yield target, _stack_layers(reader, suffix, dtype=dtype, transpose=transpose)
+
+    for target, suffix in (
+        ("q_norm_weight", "q_norm.weight"),
+        ("k_norm_weight", "k_norm.weight"),
+    ):
+        layers = []
+        for layer in range(NUM_LAYERS):
+            layers.append(
+                reader.load_optional(
+                    f"model.layers.{layer}.self_attn.{suffix}",
+                    torch.ones(HEAD_DIM, dtype=torch.float32),
+                )
+                .view(1, -1)
+                .float()
+            )
+        yield target, torch.cat(layers, dim=0).contiguous()
+
+    yield (
+        "final_norm_weight",
+        reader.load("model.norm.weight").view(1, -1).float().contiguous(),
+    )
+
+    embed = reader.load("model.embed_tokens.weight").to(torch.bfloat16).contiguous()
+    if embed.shape[0] < PADDED_VOCAB:
+        padding = torch.zeros((PADDED_VOCAB - embed.shape[0], HIDDEN), dtype=embed.dtype)
+        embed = torch.cat((embed, padding), dim=0).contiguous()
+    yield "embed_weight", embed
+
+    lm_name = "lm_head.weight" if "lm_head.weight" in reader.weight_map else "model.embed_tokens.weight"
+    lm_head = reader.load(lm_name).to(torch.bfloat16).contiguous()
+    if lm_head.shape[0] < PADDED_VOCAB:
+        padding = lm_head[:1].expand(PADDED_VOCAB - lm_head.shape[0], -1).clone()
+        lm_head = torch.cat((lm_head, padding), dim=0).contiguous()
+    yield "lm_head_weight", lm_head
+
+
+def rope_tables(model_dir: Path) -> tuple[torch.Tensor, torch.Tensor]:
+    config = json.loads((model_dir / "config.json").read_text())
+    theta = float(config.get("rope_theta", 1_000_000.0))
+    half = HEAD_DIM // 2
+    positions = torch.arange(MAX_SEQ_LEN, dtype=torch.float32).unsqueeze(1)
+    inv_freq = 1.0 / (theta ** (torch.arange(half, dtype=torch.float32) / half))
+    angles = positions * inv_freq.unsqueeze(0)
+    return (
+        torch.cat((angles.cos(), angles.cos()), dim=1).contiguous(),
+        torch.cat((angles.sin(), angles.sin()), dim=1).contiguous(),
+    )

--- a/tests/ut/py/test_qwen3_14b_hbg_serving_effective.py
+++ b/tests/ut/py/test_qwen3_14b_hbg_serving_effective.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+CASE_DIR = (
+    Path(__file__).resolve().parents[3] / "examples" / "a2a3" / "host_build_graph" / "qwen3_14b_serving_effective"
+)
+sys.path.insert(0, str(CASE_DIR))
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = _load_module("qwen3_14b_hbg_benchmark", CASE_DIR / "benchmark.py")
+benchmark_dual = _load_module("qwen3_14b_hbg_benchmark_dual", CASE_DIR / "benchmark_dual.py")
+trace_effective = _load_module("qwen3_14b_hbg_trace_effective", CASE_DIR / "trace_effective.py")
+artifact_builder = _load_module("qwen3_14b_hbg_artifact_builder", CASE_DIR / "build_hbg_artifact.py")
+
+
+def _slot() -> dict[str, torch.Tensor]:
+    block_table = torch.full((16 * 32,), -1, dtype=torch.int32)
+    block_table.view(16, 32)[:, :27] = torch.arange(432, dtype=torch.int32).view(16, 27)
+    return {
+        "seq_lens": torch.zeros(16, dtype=torch.int32),
+        "slot_mapping": torch.zeros(16, dtype=torch.int32),
+        "block_table": block_table,
+        "sampled_ids_host": torch.zeros((16, 8), dtype=torch.int32),
+    }
+
+
+def test_single_update_slot_installs_new_page() -> None:
+    slot = _slot()
+    page_ids = torch.arange(432, 448, dtype=torch.int32)
+    golden = {
+        "seq_lens": torch.full((127, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.zeros((127, 16), dtype=torch.int32),
+    }
+    golden["slot_mapping"][118] = page_ids * 128
+
+    benchmark._update_slot(slot, golden, 118, page_size=128, blocks_per_row=32)
+
+    assert torch.equal(slot["block_table"].view(16, 32)[:, 27], page_ids)
+
+
+def test_dual_slot_updates_do_not_share_block_table() -> None:
+    slots = [_slot(), _slot()]
+    page_ids = torch.arange(432, 448, dtype=torch.int32)
+    golden = {
+        "seq_lens": torch.full((2, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.stack((page_ids * 128, page_ids * 128)),
+    }
+
+    benchmark_dual._update_slot(slots[0], golden, 0, page_size=128, blocks_per_row=32)
+    assert torch.all(slots[1]["block_table"].view(16, 32)[:, 27] == -1)
+    benchmark_dual._update_slot(slots[1], golden, 1, page_size=128, blocks_per_row=32)
+    assert torch.equal(slots[0]["block_table"].view(16, 32)[:, 27], page_ids)
+    assert torch.equal(slots[1]["block_table"].view(16, 32)[:, 27], page_ids)
+
+
+def test_update_slot_rejects_page_offset_mismatch() -> None:
+    slot = _slot()
+    golden = {
+        "seq_lens": torch.full((1, 16), 3457, dtype=torch.int32),
+        "slot_mapping": torch.ones((1, 16), dtype=torch.int32),
+    }
+
+    with pytest.raises(RuntimeError, match="offset mismatch"):
+        benchmark._update_slot(slot, golden, 0, page_size=128, blocks_per_row=32)
+
+
+def test_update_slot_rejects_logical_block_overflow() -> None:
+    slot = _slot()
+    golden = {
+        "seq_lens": torch.full((1, 16), 4097, dtype=torch.int32),
+        "slot_mapping": torch.full((1, 16), 4096 * 128, dtype=torch.int32),
+    }
+
+    with pytest.raises(RuntimeError, match="logical block"):
+        benchmark._update_slot(slot, golden, 0, page_size=128, blocks_per_row=32)
+
+
+def test_trace_summary_uses_steady_completion_intervals(tmp_path: Path) -> None:
+    lines = []
+    for inv, timestamp in ((1, 1_000_000_000), (2, 1_040_000_000)):
+        common = f"[STRACE] v=1 pid=1 tid=1 inv={inv} hid=abc depth=2"
+        lines.extend(
+            [
+                (
+                    f"{common} name=chip.run ts={timestamp} dur=40000000 "
+                    f"dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0"
+                ),
+                (
+                    f"{common} name=node.dispatch ts={timestamp} dur=1 "
+                    f"dispatch_id={inv} slot_id=0 generation={inv} prepare_only=0"
+                ),
+                f"{common} name=node.graph_build ts={timestamp} dur=2000000",
+                f"{common} name=chip.run.bind ts={timestamp} dur=1000000",
+                f"{common} name=chip.run.runner_run ts={timestamp} dur=39000000",
+                f"{common} name=chip.run.runner_run.device_wall ts={timestamp} dur=38000000",
+                f"{common} name=chip.run.validate ts={timestamp} dur=1000000",
+            ]
+        )
+    log = tmp_path / "strace.log"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    rows = trace_effective.invocation_rows(trace_effective.parse_spans(log))
+    summary = trace_effective.summarize_campaign(rows, warmup_runs=0, measured_runs=1, steps=2, steady_skip=1)
+
+    assert summary["dispatch_contract"]["total"] == 2
+    assert summary["official_metrics"]["rts_completion_interval_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(
+        40.0
+    )
+    assert summary["official_metrics"]["effective_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(38.0)
+    assert summary["official_metrics"]["graph_build_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(2.0)
+    assert summary["official_metrics"]["bind_ms"]["pooled_steady_stats"]["mean"] == pytest.approx(1.0)
+    assert summary["effective_source"] == "chip.run.runner_run.device_wall"
+
+
+def test_trace_summary_associates_child_process_spans_by_root_window(tmp_path: Path) -> None:
+    lines = [
+        "[STRACE] v=1 pid=10 tid=10 inv=1 hid=abc depth=0 name=chip.run ts=1000 dur=100 dispatch_id=1 run_id=1",
+        "[STRACE] v=1 pid=10 tid=10 inv=1 hid=abc depth=0 name=node.graph_build ts=1000 dur=10 run_id=1",
+        "[STRACE] v=1 pid=20 tid=20 inv=1 hid=abc depth=1 name=chip.run.bind ts=1020 dur=5 run_id=1",
+        "[STRACE] v=1 pid=20 tid=20 inv=1 hid=abc depth=1 name=chip.run.runner_run ts=1030 dur=50",
+        "[STRACE] v=1 pid=20 tid=20 inv=1 hid=abc depth=2 name=chip.run.runner_run.device_wall ts=0 dur=45 clk=dev",
+        "[STRACE] v=1 pid=20 tid=20 inv=1 hid=abc depth=1 name=chip.run.validate ts=1080 dur=2",
+        "[STRACE] v=1 pid=30 tid=30 inv=1 hid=def depth=0 name=node.graph_build ts=2000 dur=10",
+        "[STRACE] v=1 pid=30 tid=30 inv=1 hid=def depth=1 name=chip.run.bind ts=2020 dur=5",
+        "[STRACE] v=1 pid=30 tid=30 inv=1 hid=def depth=1 name=chip.run.runner_run ts=2030 dur=50",
+        "[STRACE] v=1 pid=30 tid=30 inv=1 hid=def depth=2 name=chip.run.runner_run.device_wall ts=0 dur=45 clk=dev",
+        "[STRACE] v=1 pid=30 tid=30 inv=1 hid=def depth=1 name=chip.run.validate ts=2080 dur=2",
+        "[STRACE] v=1 pid=30 tid=30 inv=1 hid=def depth=0 name=chip.run ts=2000 dur=100 dispatch_id=2 run_id=2",
+    ]
+    log = tmp_path / "multi-process.log"
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    rows = trace_effective.invocation_rows(trace_effective.parse_spans(log))
+    assert [row["dispatch_id"] for row in rows] == [1, 2]
+
+
+def test_artifact_builder_accepts_supported_decode_abis() -> None:
+    common = [f"input_{index}" for index in range(20)]
+    outputs = ["out", "embed_weight", "sampled_ids_in", "sampled_ids", "next_hidden"]
+    artifact_builder._validate_param_names([*common, *outputs])
+    artifact_builder._validate_param_names([*common, *outputs, "sampled_ids_host"])
+
+
+@pytest.mark.parametrize("steps", [1, 3])
+def test_zero_skip_intervals_require_two_completions(steps: int) -> None:
+    rows = [
+        {
+            "dispatch_id": index + 1,
+            "root_completion_ns": 1_000_000_000 + index * 40_000_000,
+            "effective_source": "chip.run.runner_run.device_wall",
+            "graph_build_ms": 2.0,
+            "bind_ms": 1.0,
+            "runner_run_ms": 39.0,
+            "effective_ms": 38.0,
+            "device_wall_ms": 38.0,
+            "validate_ms": 1.0,
+            "chip_run_lifecycle_ms": 40.0,
+        }
+        for index in range(steps)
+    ]
+    summary = trace_effective.summarize_campaign(rows, warmup_runs=0, measured_runs=1, steps=steps, steady_skip=0)
+    metric = summary["official_metrics"]["rts_completion_interval_ms"]
+    assert metric["pooled_steady_stats"]["count"] == steps - 1
+    if steps == 1:
+        assert metric["pooled_steady_stats"]["mean"] is None
+        assert metric["run_means"] == []
+    else:
+        assert metric["pooled_steady_stats"]["mean"] == pytest.approx(40.0)
+    assert summary["official_metrics"]["runner_run_ms"]["pooled_steady_stats"]["count"] == steps
+
+
+def test_artifact_builder_rejects_inconsistent_host_output() -> None:
+    common = [f"input_{index}" for index in range(20)]
+    outputs = ["out", "embed_weight", "sampled_ids_in", "sampled_ids", "next_hidden"]
+    with pytest.raises(RuntimeError, match="sampled_ids_host"):
+        artifact_builder._validate_param_names([*common[:-1], *outputs, "sampled_ids_host"])
+
+
+def test_artifact_builder_normalizes_generated_tensor_type(tmp_path: Path) -> None:
+    source = tmp_path / "kernel.cpp"
+    source.write_text("TaskTensor input; const TaskTensor& output = input;\n", encoding="utf-8")
+
+    assert artifact_builder._normalize_tensor_type(source) == 2
+    assert source.read_text(encoding="utf-8") == "Tensor input; const Tensor& output = input;\n"
+
+
+def test_artifact_builder_counts_emitted_definition_tasks() -> None:
+    source = """
+static void decode_layer_definition(const GraphTaskArgs& args) {
+  rt_submit_aiv_task(1, params);
+  for (int64_t i = 0; i < 2; ++i) {
+    rt_submit_aic_task(2, params);
+  }
+}
+"""
+    assert artifact_builder._definition_task_count(source) == 3
+
+
+@pytest.mark.parametrize("tamper", [None, "metadata", "cpp", "so", "bin"])
+def test_artifact_preflight_checks_frozen_files(tmp_path: Path, tamper: str | None) -> None:
+    child = tmp_path / "next_levels" / "decode_fwd"
+    (child / "orchestration").mkdir(parents=True)
+    (child / "cache").mkdir()
+    paths = {
+        "metadata": tmp_path / "distributed_meta.json",
+        "cpp": child / "orchestration" / "decode_fwd.cpp",
+        "so": child / "orchestration" / "decode_fwd.so",
+        "bin": child / "cache" / "incore_0.bin",
+    }
+    for path in paths.values():
+        path.write_text("frozen", encoding="utf-8")
+    for index in range(1, 39):
+        (child / "cache" / f"incore_{index}.bin").write_text("kernel", encoding="utf-8")
+    manifest = {
+        "schema": "simpler-hbg-pure-artifact-v1",
+        "runtime": "host_build_graph",
+        "graph_definition_task_count_per_layer": 277,
+        "distributed_meta_sha256": artifact_builder._sha256(paths["metadata"]),
+        "orchestration_cpp_sha256": artifact_builder._sha256(paths["cpp"]),
+        "orchestration_so_sha256": artifact_builder._sha256(paths["so"]),
+        "source_incore_bins": artifact_builder._bin_manifest(child / "cache"),
+    }
+    (tmp_path / "hbg_artifact_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    if tamper:
+        paths[tamper].write_text("changed", encoding="utf-8")
+        with pytest.raises(ValueError, match="checksum"):
+            artifact_builder.verify_hbg_artifact(tmp_path)
+    else:
+        assert artifact_builder.verify_hbg_artifact(tmp_path) == manifest


### PR DESCRIPTION
## Summary

Adds a manual Qwen3-14B decode benchmark for `host_build_graph`, with single-slot and dual-slot entrypoints using caller-provided weights, prefill KV snapshots, and golden tokens.

The artifact adapter outlines the generated 40-layer decoder into one bounded per-layer Definition: 277 tasks, 28 tensor boundaries, and 40 invocations per frame. It preserves in-core binaries and both runners verify artifact checksums before preparing the runtime. The adapter accepts the 25-argument ABI and the 26-argument ABI with `sampled_ids_host`.

STRACE extraction reports RTS completion interval, `runner_run`, Effective (`device_wall`), `graph_build`, and bind timing. It exports `simpler_strace_timeline.json` for Perfetto. Qualification defaults to zero warmups, one measured request, 127 decode dispatches, and steady skip 5; the Python entrypoints also support 1 warmup + 5 measured runs.

## Validation

- Based on `main` at `6940c8ccbc4d8ec7111e542a0ce4a4985a99a24a`.
- 14 CPU unit tests pass, covering slot isolation, ABI checks, artifact integrity, and timing boundaries.
- Native artifact builds with all 39 in-core binaries byte-identical to the supplied source artifact.
- A2/A3 single-slot and dual-slot 8-dispatch hardware smoke passes. Token rows match golden and each other; dual slots alternate with independent generations and prepared dispatches. Both Perfetto exports have eight aligned device spans.
- Full repository pre-commit checks pass for all changed files.

Full 127-dispatch qualification on the latest main remains incomplete: a previous main candidate with the supplied legacy 25-argument artifact failed strict golden comparison. The cause is unresolved. The 26-argument path has metadata/unit coverage and still requires hardware qualification.
