### PR TITLE
Fix: align runtime documentation with current APIs

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -91,11 +91,11 @@ pytest examples tests/st --exclude-level 4 --platform a5 --device <range> \
 pytest examples tests/st --platform a2a3sim --runtime host_build_graph
 
 # Single example (pytest, uses pre-built binaries)
-pytest examples/a2a3/host_build_graph/vector_example --platform a2a3sim
+pytest tests/st/a2a3/host_build_graph/vector_example --platform a2a3sim --manual include
 
 # Single example (standalone; re-run `pip install --no-build-isolation -e .` first if runtime C++ changed)
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py \
-    -p a2a3sim
+python tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py \
+    -p a2a3sim --manual include
 ```
 
 ## Pre-Commit Testing Strategy

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -33,10 +33,10 @@ pto-runtime/
 │       ├── worker.py                  # Unified Worker (L2 single-chip, L3 distributed)
 │       ├── task_interface.py          # Python re-exports of nanobind types + helpers
 │       ├── env_manager.py             # Environment variable management
-│       ├── kernel_compiler.py         # [transitional, NOT in wheel — use simpler_setup version]
-│       ├── runtime_compiler.py        # [transitional, NOT in wheel — use simpler_setup version]
-│       ├── elf_parser.py              # [transitional, NOT in wheel — use simpler_setup version]
-│       └── toolchain.py               # [transitional, NOT in wheel — use simpler_setup version]
+│       ├── kernel_compiler.py         # Transitional, ships in wheel; use simpler_setup version
+│       ├── runtime_compiler.py        # Transitional, ships in wheel; use simpler_setup version
+│       ├── elf_parser.py              # Transitional, ships in wheel; use simpler_setup version
+│       └── toolchain.py               # Transitional, ships in wheel; use simpler_setup version
 │
 ├── simpler_setup/                     # Test framework + authoritative compilers (packaged in wheel)
 │   ├── scene_test.py                  # SceneTestCase + @scene_test decorator
@@ -93,7 +93,12 @@ Runtime binaries (host `.so`, aicpu `.so`, aicore `.o`) are pre-built during `pi
 
 Persistent cmake build directories under `build/cache/` enable incremental compilation — only changed files are recompiled.
 
-**Architecture note:** a2a3 and a5 differ only at runtime (device selection, block dimensions, etc.). The compiled binaries are architecture-independent — the same toolchain and flags produce artifacts that work on both chips. Therefore `pip install .` should build **all** architectures (both a2a3 and a5, both onboard and sim) whenever the corresponding toolchain is available. Toolchain detection (`build_runtimes.py`):
+**Architecture note:** binaries are built separately for each architecture and
+backend. The onboard AICore targets are `dav-c220-cube/vec` for a2a3 and
+`dav-c310-cube/vec` for a5, so their artifacts are not interchangeable.
+`pip install .` builds both architectures when their toolchain is available;
+build-tool availability does not imply that the host has both kinds of NPU.
+Toolchain detection (`build_runtimes.py`):
 
 - **sim** (a2a3sim, a5sim): requires `gcc` + `g++` in `PATH`
 - **onboard** (a2a3, a5): requires `ccec` in `PATH` + cross-compiler under `ASCEND_HOME_PATH`
@@ -119,12 +124,11 @@ The resolver uses `importlib.resources.files("simpler_setup") / "_assets"`. If `
 
 | Package | Where on disk | What it ships in wheel |
 | ------- | ------------- | ---------------------- |
-| `simpler` | `python/simpler/` | Stable user API: `task_interface`, `worker`, `env_manager`, `__init__` |
-| `simpler` (excluded) | same dir | `kernel_compiler`, `runtime_compiler`, `toolchain`, `elf_parser` are **transitional** — present in source tree but excluded from wheel via `pyproject.toml::wheel.exclude` |
+| `simpler` | `python/simpler/` | Every module, including the runtime API and the four transitional compiler/toolchain modules |
 | `simpler_setup` | `simpler_setup/` | Test framework + authoritative copies of the four transitional files |
 | `_task_interface` | built from `python/bindings/` | Top-level nanobind extension (.so) |
 
-**Migration direction:** existing `from simpler.{kernel_compiler,runtime_compiler,toolchain,elf_parser} import ...` should move to `from simpler_setup.{kernel_compiler,...} import ...`. Once all callers migrate, the four transitional files in `python/simpler/` can be deleted and `wheel.exclude` cleaned up.
+**Migration direction:** existing `from simpler.{kernel_compiler,runtime_compiler,toolchain,elf_parser} import ...` should move to `from simpler_setup.{kernel_compiler,...} import ...`. The `simpler_setup` copies are authoritative. Both copies ship because `wheel.packages` includes both packages and there is no `wheel.exclude`; deletion of the transitional modules requires migrating their callers.
 
 ## Cross-Platform Preprocessor Convention
 
@@ -170,7 +174,7 @@ pip install --no-build-isolation -e .
 
 `--no-build-isolation` is required: scikit-build-core needs the system `nanobind` and `cmake` (and any other build dep already in the venv); build isolation would hide them. The flag is also faster — no temporary build venv per install.
 
-This builds the nanobind `_task_interface` extension **and** pre-builds all runtime binaries for available toolchains into `build/lib/`. Sim platforms (a2a3sim, a5sim) are built when `gcc`/`g++` are available; onboard platforms (a2a3, a5) are built when `ccec` and the cross-compiler under `ASCEND_HOME_PATH` are available. Since a2a3 and a5 share the same compilation — differing only at runtime — both architectures are always built together when their toolchain is present.
+This builds the nanobind `_task_interface` extension **and** pre-builds runtime binaries for available toolchains into `build/lib/`. Sim platforms (a2a3sim, a5sim) are built when `gcc`/`g++` are available; onboard platforms (a2a3, a5) are built when `ccec` and the cross-compiler under `ASCEND_HOME_PATH` are available. Each architecture has its own sources, compiler target, and output directory.
 
 ### No rebuild on import
 

--- a/docs/dfx/args-dump.md
+++ b/docs/dfx/args-dump.md
@@ -96,7 +96,7 @@ pytest tests/st/<case> --platform a5sim --dump-args 2
 # a5 host_build_graph has no examples — use the scene test
 pytest tests/st/a5/host_build_graph/dump_args --platform a5sim --dump-args 2
 pytest tests/st/<case> --platform a2a3sim --dump-args 2
-pytest examples/a2a3/host_build_graph/vector_example --platform a2a3sim --dump-args 2
+pytest tests/st/a2a3/host_build_graph/vector_example --platform a2a3sim --manual include --dump-args 2
 ```
 
 The level sets `CallConfig::enable_dump_args` (0/1/2/3). The host then

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -32,8 +32,8 @@ The test framework automatically handles PTO-ISA setup:
 Just run your example. PTO-ISA will be cloned automatically on first run:
 
 ```bash
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py \
-  -p a2a3sim
+python tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py \
+  -p a2a3sim --manual include
 ```
 
 **Manual Setup** (if auto-setup fails or you prefer manual control):
@@ -150,28 +150,19 @@ host_binary = compiler.compile("host", include_dirs, source_dirs)        # → .
 
 ```bash
 # Simulation platform (no hardware required)
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3sim
+python tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3sim --manual include
 
 # Hardware platform (requires Ascend device)
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3 -d 0
+python tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3 -d 0
 
 # Or as a pytest batch:
-pytest examples/a2a3/host_build_graph/vector_example --platform a2a3sim
+pytest tests/st/a2a3/host_build_graph/vector_example --platform a2a3sim --manual include
 ```
 
-Expected output:
-
-```text
-=== Building Runtime: host_build_graph (platform: a2a3sim) ===
-...
-=== Comparing Results ===
-Comparing f: shape=(16384,), dtype=float32
-  f: PASS (16384/16384 elements matched)
-
-============================================================
-TEST PASSED
-============================================================
-```
+The simulator case is marked manual, so include `--manual include` to run it.
+It computes `f = (a + b + 1) * (a + b + 2)` for 16,384 elements with `a=2`
+and `b=3`, then compares every output against the golden value `42`. A
+successful run exits with status 0; the pytest form reports a passed test.
 
 ### Python API Example
 
@@ -198,15 +189,27 @@ Reach for the high-level `Worker` first. Public registration returns a
 
 ## Configuration
 
-### Compile-time Configuration (Runtime Limits)
+### Graph capacity and runtime limits
 
-In `src/common/host_build_graph/runtime.h`:
+For `host_build_graph`, the graph task table defaults to
+`CHIP_DEFAULT_GRAPH_TASKS=16384` in `src/common/host_build_graph/runtime_types.h`.
+Override it per run through `CallConfig.runtime_env.ring_task_window[0]`.
+In Python, assign the whole property because its getter returns a list copy:
 
-```cpp
-#define RUNTIME_MAX_TASKS 131072   // Maximum number of tasks
-#define RUNTIME_MAX_ARGS 16        // Maximum arguments per task
-#define RUNTIME_MAX_FANOUT 512     // Maximum successors per task
+```python
+cfg = CallConfig()
+cfg.runtime_env.ring_task_window = [32768, 0, 0, 0]
+worker.run(handle, orch_args, cfg)
 ```
+
+HBG sizes and commits its graph heap after orchestration; `ring_heap` and
+`ring_dep_pool` are TRB settings, not HBG capacity controls.
+
+The HBG orchestration-entry limit is `RUNTIME_MAX_ARGS=128` in
+`src/common/host_build_graph/runtime.h`. Per-task fanin is capped at
+`CHIP_MAX_FANIN=128`; there is no `RUNTIME_MAX_FANOUT` knob. See
+[capacity errors](troubleshooting/device-error-codes/capacity.md) for the
+resource-specific limits and diagnostics.
 
 ### Runtime Configuration
 
@@ -229,7 +232,7 @@ Programmatic users select the runtime when constructing `Worker` and may pass a
 Device selection is done via CLI flag:
 
 ```bash
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3 --device 0
+python tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3 --device 0
 ```
 
 ## Notes

--- a/docs/python-packaging.md
+++ b/docs/python-packaging.md
@@ -41,12 +41,21 @@ _task_interface.*.so      nanobind extension at site-packages root
 
 | Concern | `simpler` | `simpler_setup` |
 | ------- | --------- | --------------- |
-| What it is | Stable user-facing runtime API | Test/build infrastructure |
-| Imported by user code? | Yes — `from simpler.worker import Worker` | Sometimes — test framework uses it |
-| Imported by other packages? | Yes — `simpler_setup` imports `simpler.env_manager` | No — leaf consumer |
-| Lifecycle | Slow-changing public API | Fast-changing internal helpers |
+| What it is | Runtime API | Kernel compilation, runtime assembly, scene tests, and analysis tools |
+| Imported by user code? | Yes — `from simpler.worker import Worker` | Yes — for example, `KernelCompiler`, `TensorArg`, and `SceneTestCase` |
+| Imported by the other package? | `simpler_setup` uses `simpler.env_manager` and task types | `Worker` lazily imports `RuntimeBuilder` during chip setup |
 
-Internal coupling: `simpler_setup.toolchain`, `simpler_setup.kernel_compiler`, and `simpler_setup.runtime_compiler` import `simpler.env_manager`. This is the only direction allowed (`simpler_setup → simpler`); never the reverse. `simpler` must not depend on `simpler_setup`.
+The packages ship together. `simpler_setup.toolchain`, `kernel_compiler`, and
+`runtime_compiler` import `simpler.env_manager`. In the other direction,
+`Worker._init_level2` and hierarchical chip-child setup lazily import
+`simpler_setup.runtime_builder.RuntimeBuilder` to resolve runtime binaries.
+Keep that runtime-assembly dependency lazy: importing `simpler` alone does not
+load the native extension or initialize a worker.
+
+The transitional `kernel_compiler`, `runtime_compiler`, `toolchain`, and
+`elf_parser` modules under `python/simpler/` also ship in the wheel. New
+callers should use their authoritative `simpler_setup` equivalents;
+`wheel.packages` includes both packages without excluding those modules.
 
 ### Dependencies
 

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -1,6 +1,6 @@
 # Task Flow — Callable / TaskArgs / CallConfig Pass-Through
 
-Callable identity update: public Python submit APIs now accept
+Public Python submit APIs accept
 `CallableHandle` objects returned by `Worker.register`, and hierarchical task
 mailboxes carry the handle's 32-byte hash digest. Target-local integer slots
 remain private to the receiving worker. Older `cid` references in this document
@@ -34,7 +34,7 @@ Every task flowing through any level carries exactly three pieces of data:
 | Handle | Type | What it is |
 | ------ | ---- | ---------- |
 | `CallableHandle` / `CallableIdentity` | hash digest + kind + namespace | What the target worker should execute; targets resolve the digest to a local slot |
-| `TaskArgs` | user builder class | ChipTensors + scalars + per-tensor tags (IN/OUT/INOUT/etc.) |
+| `TaskArgs` | user builder class | Self-describing Tensor views + scalars + per-tensor tags (IN/OUT/INOUT/etc.) |
 | `CallConfig` | small POD | Execution knobs (aicpu_thread_num, profiling/dump/PMU flags, …) |
 
 Everything else in the engine is either plumbing (slots, ring, tensormap,
@@ -73,7 +73,7 @@ use either of two task frames after the base control frame, with
 from native launch. The receiving child resolves the digest in its own address
 space in both forms.
 
-The proposed remote L3 path keeps the same callable identity contract, but
+The remote L3 path keeps the same callable identity contract, but
 sends it in a versioned TASK frame. The remote endpoint resolves the digest
 against its own registry after it has reported `HELLO READY`.
 
@@ -101,112 +101,102 @@ One user-facing class. Its contents appear in four different physical
 representations across a task's lifetime — these are **phases**, not
 hierarchy levels.
 
+The canonical C++ builder is declared in
+[`task_args_wire.h`](../src/common/task_interface/task_args_wire.h):
+
 ```cpp
-class TaskArgs {
-    std::vector<ChipTensor> tensors_;
-    std::vector<TensorArgType>    tags_;     // per-tensor: INPUT/OUTPUT/INOUT/OUTPUT_EXISTING/NO_DEP
-    std::vector<uint64_t>         scalars_;
-    std::vector<TaskHandle>       explicit_deps_;  // parent graph only
-public:
-    void add_tensor(const ChipTensor&, TensorArgType tag = TensorArgType::INPUT);
-    void add_scalar(uint64_t);
-    void add_dep(const TaskHandle&);
-    void add_dep_wait(const TaskHandle&);
-    TaskArgsView view() const;
-    int32_t tensor_count() const;
-    int32_t scalar_count() const;
-    TensorArgType tag(int32_t i) const;    // only Orchestrator reads tags
-};
+using TaskArgs = TaskArgsTpl<Tensor, uint64_t, 0, 0, TensorArgType>;
 ```
 
-`TensorArgType` has five values (matches existing `tensor.h:45-51`):
-`INPUT`, `OUTPUT`, `INOUT`, `OUTPUT_EXISTING`, `NO_DEP`.
+It stores vectors of `Tensor` records, scalar values, tensor tags, and
+`ExplicitTaskDependency` records. `add_dep` adds a retaining dependency;
+`add_dep_wait` adds an ordering-only dependency. Tensors must be added before
+scalars. `TensorArgType` has five values: `INPUT`, `OUTPUT`, `INOUT`,
+`OUTPUT_EXISTING`, and `NO_DEP`.
 
-For remote L3 submits, public Python still uses the same `TaskArgs` builder.
-`TaskArgs.add_tensor(RemoteTensorRef(...), tag)` appends a normal
-`ChipTensor` metadata entry with `data == 0` plus a hidden remote
-sidecar at the same tensor index. The local mailbox path rejects non-empty
-remote sidecars; the remote framed path encodes the sidecar as a
-`RemoteTensorDescWire`.
+Each `Tensor` embeds its `BufferDescriptor` and a strided view. It carries no
+materialized address. `ChipTensor` is the device descriptor produced only at
+the L2 boundary; it is not the element stored in user-facing `TaskArgs`.
+See [Buffer Memory Model](buffer-abi.md) for identity, access, and lifetime.
+
+For remote L3 submits, `TaskArgs.add_tensor(RemoteTensorRef(...), tag)`
+creates a `Tensor` with a `REMOTE_SIDECAR` backend and keeps the remote
+reference in a sidecar at the same tensor index. The local mailbox path rejects
+remote sidecars; remote dispatch encodes the reference in its framed protocol.
 
 ### Representation at each phase
 
 | Phase | Form | Backing memory | Who writes | Who reads |
 | ----- | ---- | -------------- | ---------- | --------- |
-| **① User submit** | `TaskArgs` object (builder) | Python/C++ parent heap | user orch fn | Orchestrator |
-| **② Slot storage** | `TaskArgs` object (inside `slot.task_args`) | parent heap | Orchestrator.submit moves it here | WorkerThread at dispatch |
-| **③ Dispatch wire (PROCESS only)** | length-prefixed blob | shm mailbox (MAP_SHARED) | parent WorkerThread encodes | forked child decodes |
-| **④ L2 ABI edge** | `ChipStorageTaskArgs` POD | child stack | `ChipWorker::run` assembles | `simpler_run` consumes |
+| **① User submit** | `TaskArgs` builder with `Tensor` records | parent heap | user orchestration | Orchestrator |
+| **② Slot storage** | `TaskArgs` inside the task slot | parent heap | Orchestrator | endpoint at dispatch |
+| **③ Dispatch wire (PROCESS only)** | counts, `Tensor` records, scalars | shm mailbox | endpoint blob encoder | child decoder and ImportRegistry |
+| **④ L2 ABI edge** | `ChipStorageTaskArgs` containing `ChipTensor` records | child-owned materialization | child materializer | native chip runtime |
 
 ### Tags and explicit dependencies stay parent-side
 
-Tags are consumed by `Orchestrator::submit_*` to derive TensorMap dependencies
-and `TaskHandle` dependencies are consumed to add task-to-task ordering edges.
-Neither reaches phases ③ or ④ — scheduler dispatch payloads, child workers,
-and runtime.so do not receive them.
+Tags drive TensorMap dependency inference, and explicit handles add
+host-graph task edges. Neither is serialized into the dispatch blob or copied
+into the L2 argument POD.
 
 ### Blob byte layout (phase ③)
 
 ```text
-offset 0:            int32  tensor_count = T
-offset 4:            int32  scalar_count = S
-offset 8:            ChipTensor tensors[T]    // 128 B each
-offset 8 + 128T:      uint64_t scalars[S]            // 8 B each
-total used:          8 + 128T + 8S
+offset 0:            int32 tensor_count = T
+offset 4:            int32 scalar_count = S
+offset 8:            Tensor tensors[T]       // 144 bytes each
+offset 8 + 144T:     uint64_t scalars[S]      // 8 bytes each
+total used:          8 + 144T + 8S
 ```
 
-No tags, no pickle, no schema versioning — pure memcpy.
+`task_args_blob_size` and `write_blob` use `sizeof(Tensor)`, whose 144-byte
+size is guarded in [`buffer.h`](../src/common/task_interface/buffer.h).
+`read_blob` validates the counts against the available bytes. The blob has no
+outer schema version; each tensor contains a descriptor validated on access.
 
 ### TaskArgsView — the interface type
 
-The parent-side encoder (from `TaskArgs::view()`) and the child-side
-decoder (over the mailbox blob bytes) yield the same view type:
+`read_blob` returns a non-owning view over the encoded bytes:
 
 ```cpp
 struct TaskArgsView {
     int32_t tensor_count;
     int32_t scalar_count;
-    const ChipTensor *tensors;   // T items
-    const uint64_t         *scalars;   // S items
+    const uint8_t *tensor_bytes;
+    const uint64_t *scalars;
+
+    Tensor tensors(int32_t i) const;
 };
 ```
 
-24 bytes, POD, passable by value. Where the pointed-to arrays live depends on
-mode:
-
-- **THREAD**: `tensors` points into the `std::vector<ChipTensor>` heap
-  backing inside `slot.task_args`
-- **PROCESS**: `tensors` points into the shm mailbox blob region
-
-View does **not** own memory. Valid for the duration of a single
-`ChipWorker::run` call in the forked child.
+On a 64-bit host the view is 24 bytes. `tensors(i)` bounds-checks the index,
+copies the record to aligned local storage, and validates its descriptor and
+view. The tensor region starts after the 8-byte blob header, so readers must
+not reinterpret it as an aligned `Tensor*`. The referenced storage must remain
+alive while the view is consumed; a staged endpoint owns an immutable frame
+snapshot for that purpose.
 
 ### Conversion diagram
 
 ```text
-① TaskArgs (user)                    — parent heap (vectors)
-     │
-     │ Orchestrator::submit_next_level (tags consumed)
+① TaskArgs (Tensor views, scalars, tags, explicit dependencies)
+     │ Orchestrator consumes tags and explicit dependencies
      ▼
-② slot.task_args: TaskArgs           — parent heap, stored in slot
-     │
-     │ LocalMailboxEndpoint::run: memcpy into shm mailbox blob
-     │   layout = [int32 T][int32 S][ChipTensor × T][uint64 × S]
+② slot.task_args (parent heap)
+     │ write_blob: [int32 T][int32 S][Tensor × T][uint64 × S]
      ▼
-③ shm mailbox bytes (MAP_SHARED)     — visible to forked child
-     │
-     │ child decodes header → builds TaskArgsView over the blob bytes
+③ mailbox bytes → child-owned args
+     │ ImportRegistry resolves each descriptor to a consumer-local base
+     │ materialize_task_args builds the chip representation
      ▼
-    child resolves digest -> local slot
-    ChipWorker::run(local_slot, view, config)  (in the forked child)
-
-     │ (L2 ABI edge)
+④ ChipStorageTaskArgs (ChipTensor records + scalars)
+     │ native run or prepare/launch/poll/finalize lifecycle
      ▼
-④ ChipStorageTaskArgs POD — child stack
-     │ memcpy view.tensors, view.scalars into struct
-     ▼
-    simpler_run(local_slot, &chip_storage, &config)
+    chip runtime stages host-backed data or uses owned device memory
 ```
+
+A public L2 `Worker.run()` performs the same materialization in its own
+process, without a mailbox. It accepts `TaskArgs`, not `ChipStorageTaskArgs`.
 
 ---
 
@@ -221,8 +211,8 @@ struct CallConfig {
     int32_t enable_dep_gen = 0;
     int32_t enable_scope_stats = 0;
     int32_t capture_clock_anchors = 0; // set by the ChipWorker child, not by callers
+    RuntimeEnv runtime_env;      // three arrays of four uint64_t overrides
     char    output_prefix[1024] = {};
-    // future fields here - same POD used at all levels
 };
 ```
 
@@ -250,23 +240,17 @@ concrete leaves, each consumed by its own Python child loop.
 
 ### `ChipWorker` (NEXT_LEVEL, L2 leaf)
 
-Wraps a dlsym'd `runtime.so`. `_chip_process_loop` instantiates one
-`ChipWorker` per chip child and calls its `run` on every dispatch.
-`run()` assembles a `ChipStorageTaskArgs` POD from the decoded view and
-calls `simpler_run`:
+The Python chip child resolves the callable digest to a local slot, decodes
+`TaskArgs`, and resolves each `Tensor` through its `ImportRegistry`.
+`materialize_task_args` builds `ChipStorageTaskArgs` at the resolved bases.
+The child then calls the native `run_materialized` binding, or submits a native
+run token for the staged prepare/launch/poll/finalize path.
 
-```cpp
-void ChipWorker::run(int32_t local_slot, TaskArgsView view, const CallConfig &config) {
-    ChipStorageTaskArgs chip_storage;
-    chip_storage.tensor_count_ = view.tensor_count;
-    chip_storage.scalar_count_ = view.scalar_count;
-    memcpy(chip_storage.tensors_, view.tensors, view.tensor_count * sizeof(ChipTensor));
-    memcpy(chip_storage.scalars_, view.scalars, view.scalar_count * sizeof(uint64_t));
-    simpler_run(local_slot, &chip_storage, &config);
-}
-```
-
-One memcpy of a few KB per task; negligible.
+This boundary is a descriptor resolution and materialization step, not a
+memcpy from the mailbox tensor array into `ChipTensor[]`. Host-backed arguments
+may need device staging and output copy-back; device-backed arguments must
+resolve to allocations owned by the target chip. The native `ChipWorker`
+consumes the resulting POD and invokes the runtime's execution lifecycle.
 
 #### Pipeline resource leases
 
@@ -466,20 +450,17 @@ run fails before device argument staging. See the runtime's `RUNTIME_LOGIC.md`
 
 ### SUB-type child loop (Python callable leaf)
 
-SUB execution is handled entirely in Python. The forked child process
-runs `_sub_worker_loop` which reads the args blob from the shared-memory
-mailbox, decodes it into a `TaskArgs` object, and passes it to the
-registered callable:
+SUB execution is handled in Python. `_sub_worker_loop` resolves the callable
+digest and uses `ImportRegistry.mapped_args_from_blob` to create a `MappedArgs`
+object whose tensor data is mapped into the child's address space:
 
 ```python
-fn(args)    # args: TaskArgs decoded from the mailbox blob
+fn(args)    # args: MappedArgs with mapped tensors and scalars
 ```
 
-The callable receives the same `TaskArgs` that was submitted via
-`orch.submit_sub(handle, args)`, with tags stripped (tags are consumed by
-the Orchestrator at submit time). There is no C++ class for SUB workers
-— the Python child loop and callable registry are the entire
-implementation; the child inherits the Python registry through fork COW.
+The submitted tensor descriptors and scalars cross the mailbox; dependency
+tags stay parent-side. Pre-start registrations enter the fork snapshot;
+post-start registrations reach the live child through the control plane.
 
 ### L4+ recursion — no extra leaf type
 
@@ -618,8 +599,9 @@ that completion through `Scheduler::worker_done`.
 
 At this point:
 
-- ChipTensor output data is already written to shm (kernel wrote via
-  `ChipTensor.data` pointer → shm page visible to parent)
+- Host-backed output data has been copied back during native finalization
+  and is visible through the shared backing. Device-backed output stays on
+  its owning chip until the caller requests a copy
 - Control returns to the Scheduler, which marks the slot `COMPLETED` on
   success or `FAILED` on task/endpoint failure, then releases fanout refs and
   either wakes or poisons downstream consumers
@@ -723,29 +705,41 @@ diagnostic label.
 
 ## 10. Worked example — one L3 chip task
 
-User code:
+Given a compiled `chip_callable` with signature `(IN, IN, OUT)` that accepts
+three float32 tensors of shape `(N,)`:
 
 ```python
-a = torch.randn(N).share_memory_()
-b = torch.randn(N).share_memory_()
-c = torch.zeros(N).share_memory_()
+import torch
+from simpler import Worker
+from simpler.task_interface import CallConfig, DataType, TaskArgs, TensorArgType
 
-args = TaskArgs()
-args.add_tensor(make_ct(a), IN)
-args.add_tensor(make_ct(b), IN)
-args.add_tensor(make_ct(c), OUT)
+w3 = Worker(level=3, device_ids=[0], platform="a2a3sim",
+            runtime="tensormap_and_ringbuffer")
+chip_handle = w3.register(chip_callable)
+w3.init()
+try:
+    a_buf = w3.create_buffer(N * 4)
+    b_buf = w3.create_buffer(N * 4)
+    c_buf = w3.create_buffer(N * 4)
+    a = torch.frombuffer(a_buf.shm.buf, dtype=torch.float32, count=N)
+    b = torch.frombuffer(b_buf.shm.buf, dtype=torch.float32, count=N)
+    c = torch.frombuffer(c_buf.shm.buf, dtype=torch.float32, count=N)
+    a.fill_(2)
+    b.fill_(3)
+    c.zero_()
 
-def my_orch(orch, view, cfg):
-    chip_args = TaskArgs()
-    for i in range(view.tensor_count):
-        chip_args.add_tensor(view.tensors[i], IN if i < 2 else OUT)
-    orch.submit_next_level(chip_kernel_handle, chip_args, cfg, worker=0)
+    args = TaskArgs()
+    args.add_tensor(a_buf.tensor((N,), DataType.FLOAT32), TensorArgType.INPUT)
+    args.add_tensor(b_buf.tensor((N,), DataType.FLOAT32), TensorArgType.INPUT)
+    args.add_tensor(c_buf.tensor((N,), DataType.FLOAT32), TensorArgType.OUTPUT_EXISTING)
 
-w3 = Worker(level=3, child_mode=PROCESS)
-w3.add_worker(NEXT_LEVEL, chip_worker_0)
-w3.init()    # fork chip_0 here
+    def my_orch(orch, task_args, cfg):
+        orch.submit_next_level(chip_handle, task_args, cfg, worker=0)
 
-w3.run(my_orch, args, CallConfig(aicpu_thread_num=0))
+    w3.run(my_orch, args, CallConfig())
+    # Read c here, while its backing is live.
+finally:
+    w3.close()
 ```
 
 Step-by-step (one chip worker):
@@ -753,13 +747,13 @@ Step-by-step (one chip worker):
 | Step | Where | What happens |
 | ---- | ----- | ------------ |
 | 1 | parent Python | user builds `args: TaskArgs`, calls `w3.run(my_orch, args, config)` |
-| 2 | `Worker::run` | `scope_begin` → call `my_orch(&orch_, args.view(), cfg)` |
-| 3 | `Orchestrator::submit_next_level` | `slot = ring.alloc()`; move `chip_args` into `slot.task_args`; walk tags → `tensormap.lookup(a.data)`, `tensormap.lookup(b.data)`, `tensormap.insert(c.data, slot)`; push ready |
+| 2 | `Worker::run` | invoke the Python orchestration callback with its Orchestrator facade, args, and config |
+| 3 | `Orchestrator::submit_next_level` | allocate a task slot; store its args; infer dependencies using canonical buffer identities and overlapping views; enqueue ready work |
 | 4 | Scheduler thread | pop `slot` from worker 0's FIFO; resolve stable worker ID 0 to WT_chip_0; dispatch |
 | 5 | WT_chip_0 parent side | encode one leased task frame: write `config`, digest prefix, and the args blob; publish `TASK_READY` for the active lane or `PREPARE_READY` for a staged successor |
 | 6 | chip_0 child process | validate the frame and resolve its digest; ordinary HBG with an active predecessor also prepares the leased inactive arena bank before publishing `FRAME_STAGED`, while a frame with no active predecessor, diagnostic HBG, and TMR publish after validation and defer native prepare |
 | 7 | chip_0 native-run path | after activation and the predecessor's finalization fence, launch an already-prepared HBG run or finish deferred native preparation and then launch; poll it to completion and finalize it before another staged frame may launch. Compatibility endpoints perform the equivalent operation through blocking `ChipWorker::run` |
-| 8 | runtime.so | translate host ptrs → device ptrs; dispatch AICPU / AICore; write output into `c`'s shm |
+| 8 | runtime.so | stage resolved host-backed tensors on the device; dispatch AICPU / AICore; copy output back to `c` during finalization |
 | 9 | chip_0 child | native finalization returns; write `TASK_DONE` |
 | 10 | WT_chip_0 parent | observe `TASK_DONE`; push success completion |
 | 11 | Scheduler | mark slot COMPLETED; fanout release (none in this DAG); scope_end will release scope ref |
@@ -788,9 +782,9 @@ runtime: `ChipStorageTaskArgs` (`task_args.h`) is already declared with
 
 ### Why no `WorkerPayload` wrapper
 
-`ChipWorker::run` takes `(local_slot, TaskArgsView, const CallConfig&)`
-directly. Wrapping them in a struct added no value and made mailbox serialization
-indirect. The scheduler's parent-private `TaskSlot` is held by WorkerThread for
+The chip child resolves the local slot and materializes the args before
+calling the native ChipWorker with the chip POD and `CallConfig`. The
+scheduler's parent-private `TaskSlot` is held by WorkerThread for
 the completion callback and is not passed into the child. The distinct,
 generation-safe `PipelineSlotLease.slot_id` does cross the mailbox boundary.
 
@@ -815,11 +809,10 @@ time.
 
 ### Why `TaskArgsView` is just pointers + counts
 
-View is constructed at both ends of the mailbox handshake (from
-`TaskArgs::view()` on the parent side for encoding, from a decoded
-mailbox blob on the child side). Making it POD (24 B) lets it pass by
-value through `ChipWorker::run`. The underlying `ChipTensor[]`
-lives in the mailbox blob bytes on the child side — view doesn't care.
+`read_blob` constructs a non-owning view over the encoded `Tensor` and scalar
+records. Counts allow bounds checks; byte storage plus the copying `tensors(i)`
+accessor avoids assuming tensor alignment in the mailbox. Native chip execution
+consumes materialized `ChipStorageTaskArgs`, not this view.
 
 ---
 

--- a/docs/user/how-to/profile-a-kernel.md
+++ b/docs/user/how-to/profile-a-kernel.md
@@ -35,9 +35,11 @@ pytest examples/my_example --platform a2a3 --device 4 --dump-args
 `--enable-swimlane-overhead` requires `--enable-chip-swimlane` plus a `deps.json`;
 if it is absent, re-run adding `--enable-dep-gen`.
 
-**For single-round runs, `--enable-chip-swimlane` is L2-only.** Asking for it
-on an L3 test is rejected up front — scope to a single chip with `--level 2`,
-or drop the flag.
+**Single-round chip-swimlane capture supports L2 and same-host L3.** L3 chip
+children write separate `rankN/dN` captures; cross-rank merging requires
+detail level `4` on every rank (the bare flag's default). NETWORK1/L4 is
+rejected by the automatic capture path because it needs a node namespace.
+See [multi-rank output](../../dfx/chip-swimlane-profiling.md#32-output) for the layout.
 
 Use `--rounds N` for repeated non-diagnostic timing. All diagnostic flags above
 are disabled when `N > 1`; warm up separately, then collect diagnostics with a
@@ -58,8 +60,9 @@ worker.run(handle, args, cfg)
 ```
 
 In a `@scene_test`, per-case knobs live under `"config"`, including
-`aicpu_thread_num` and — on `tensormap_and_ringbuffer` — `runtime_env` ring
-sizing (`ring_task_window`, `ring_heap`, `ring_dep_pool`).
+`aicpu_thread_num` and `runtime_env`. TRB uses `ring_task_window`, `ring_heap`,
+and `ring_dep_pool`; HBG reads `ring_task_window[0]` for graph task capacity
+and sizes its graph heap after orchestration.
 
 ## Reading the results
 

--- a/docs/user/how-to/run-on-multiple-chips.md
+++ b/docs/user/how-to/run-on-multiple-chips.md
@@ -21,7 +21,7 @@ worker = Worker(
     num_sub_workers=1,        # optional host-side Python callables
 )
 
-# Register everything BEFORE init(): chip callables and any sub-worker callable.
+# These registrations enter the children's startup snapshot.
 chip_handle = worker.register(chip_callable)
 postprocess = worker.register(lambda args: print("post-process got", args))
 
@@ -45,8 +45,10 @@ Three differences from L2 that trip people up:
 - **The orchestration function is Python and runs on the host.** At L2 the
   orchestration is a compiled `.cpp`; at L3 the top-level orchestration is a
   Python callable that hands compiled `ChipCallable`s down to the children.
-- **Register before `init()`.** `init()` is the fork point, so registration
-  afterwards does not reach children that already exist.
+- **Register before use.** `init()` is the fork point. Earlier registrations
+  enter the startup snapshot; later registrations are installed through the
+  control plane on eligible live children before `register()` returns. Set up
+  the worker topology before `init()`.
 
 To direct a task at one specific child rather than any free one, see
 [Directed NEXT_LEVEL Scheduling](../../directed-next-level-scheduling.md).
@@ -88,8 +90,10 @@ implementations.
 
 - **Collectives are single-host, multi-card.** Both backends state this
   explicitly; there is no cross-node collective path today.
-- **`--enable-chip-swimlane` does not work on L3.** It is rejected up front. To
-  get a swimlane, scope the run to one chip with `--level 2`.
+- **Same-host L3 supports `--enable-chip-swimlane`.** Each chip child writes
+  under `rankN/dN`; cross-rank merging requires detail level `4` (the bare
+  flag's default). Automatic merging across NETWORK1/L4 is rejected because
+  those captures need a node namespace. See [Chip Swimlane Profiling](../../dfx/chip-swimlane-profiling.md).
 - **Multi-host (L4) remote L3 uses the shipped host_tcp data plane.** You
   can register a remote worker, the remote side builds a genuine L3 subtree,
   and remote buffers move through the host TCP session. The RoCE / HCCS / UB

--- a/docs/user/how-to/write-and-run-a-kernel.md
+++ b/docs/user/how-to/write-and-run-a-kernel.md
@@ -93,8 +93,8 @@ python examples/my_example/test_my_example.py -p a2a3sim
 in `CASES`**, not on the decorator. Ordinary cases should omit `"config"` and
 use the architecture's automatic AICPU thread count. Add `aicpu_thread_num`
 only when a test specifically depends on a thread-count or scheduler-topology
-behavior; `runtime_env` holds ring-sizing overrides for
-`tensormap_and_ringbuffer`. See the [Python API reference](../reference/python-api.md)
+behavior. `runtime_env` holds TRB ring-sizing overrides; HBG also reads
+`ring_task_window[0]` to size its graph task table. See the [Python API reference](../reference/python-api.md)
 for the full `CallConfig` field list.
 
 ## Option B — the `Worker` API directly
@@ -106,8 +106,8 @@ the shape is:
 
 ```python
 from simpler.task_interface import (
-    ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
-    CoreCallable, DataType, Tensor,
+    ArgDirection, CallConfig, ChipCallable, CoreCallable,
+    DataType, TaskArgs, TensorArgType,
 )
 from simpler.worker import Worker
 
@@ -144,33 +144,46 @@ chip = ChipCallable.build(
     children=[(0, core)],
 )
 
-# 3. Register BEFORE init(), then init.
+# 3. Register and initialize the worker.
 worker = Worker(level=2, platform=platform,
                 runtime="tensormap_and_ringbuffer", device_id=device_id)
 handle = worker.register(chip)
 worker.init()
 try:
     # 4. Device memory + H2D.
-    dev_a, dev_out = worker.malloc(nbytes), worker.malloc(nbytes)
-    worker.copy_to(dev_a, host_a.data_ptr(), nbytes)
+    dev_a = worker.malloc(nbytes)
+    dev_b = worker.malloc(nbytes)
+    dev_out = worker.malloc(nbytes)
+    worker.copy_to(dev_a, host_a)
+    worker.copy_to(dev_b, host_b)
 
     # 5. Task args, in the same order as the signature.
-    args = ChipStorageTaskArgs()
-    args.add_tensor(Tensor.make(dev_a, (rows, cols), DataType.FLOAT32))
-    args.add_tensor(Tensor.make(dev_out, (rows, cols), DataType.FLOAT32))
+    args = TaskArgs()
+    args.add_tensor(dev_a.tensor((rows, cols), DataType.FLOAT32), TensorArgType.INPUT)
+    args.add_tensor(dev_b.tensor((rows, cols), DataType.FLOAT32), TensorArgType.INPUT)
+    args.add_tensor(dev_out.tensor((rows, cols), DataType.FLOAT32), TensorArgType.OUTPUT_EXISTING)
 
     # 6. Run, then D2H.
     worker.run(handle, args, CallConfig())
-    worker.copy_from(host_out.data_ptr(), dev_out, nbytes)
-    worker.free(dev_a); worker.free(dev_out)
+    worker.copy_from(host_out, dev_out)
+    worker.free(dev_a)
+    worker.free(dev_b)
+    worker.free(dev_out)
 finally:
     worker.close()          # always; a leaked device stays locked
 ```
 
-Ordering rules that are not optional:
+Here `host_a`, `host_b`, and `host_out` are contiguous CPU torch tensors of
+shape `(rows, cols)` and dtype `torch.float32`; `nbytes = rows * cols * 4`.
+Allocations return `Buffer` handles. For partial copies, pass `nbytes`,
+`src_offset`, and `dst_offset` by keyword.
 
-- **`register()` happens before `init()`.** Construction only stashes config;
-  `init()` is where runtime binaries are resolved and the device is opened.
+Lifecycle and argument rules:
+
+- **Register before use.** Registration before `init()` enters the startup
+  snapshot. Registration after `init()` installs and prewarms the callable
+  before returning; at L3+ it also publishes to eligible live children. The
+  worker topology must be established before `init()`.
 - **`close()` belongs in a `finally`.** Skipping it leaves the device held, and
   the next job on that device hangs.
 - **Task-arg order must match the callable `signature`**, positionally.

--- a/docs/user/reference/cli.md
+++ b/docs/user/reference/cli.md
@@ -41,7 +41,7 @@ rounds stay uninstrumented. The harness warns for each one it switches off.
 
 | Flag | Meaning |
 | ---- | ------- |
-| `--enable-chip-swimlane` | Per-task timing. Bare flag = level 4 (full); `1` AICore timing, `2` + dispatch/fanout, `3` + scheduler phases, `4` + orchestration. **L2 only** |
+| `--enable-chip-swimlane` | Per-task timing. Bare flag = level 4 (full); `1` AICore timing, `2` + dispatch/fanout, `3` + scheduler phases, `4` + orchestration. **L2 and same-host L3**; cross-rank merging requires level `4` |
 | `--enable-swimlane-overhead` | Adds the 8 Overhead Analysis counter tracks. Requires `--enable-chip-swimlane` **and** a `deps.json` — add `--enable-dep-gen` if absent |
 | `--enable-pmu` | AICore hardware counters. Bare flag = `PIPE_UTILIZATION` (2); pass an event type to override, e.g. `--enable-pmu 4` |
 | `--dump-args` | Capture per-task arguments. `0` off; `1` partial; `2` full; `3` hybrid (all metadata plus payload selected via `Arg::dump(...)`) |

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -16,8 +16,8 @@ stays cheap and does not require the `_task_interface` extension.
 ```python
 from simpler import Worker, trace     # or: from simpler.worker import Worker
 from simpler.task_interface import (
-    ArgDirection, CallConfig, ChipCallable, ChipStorageTaskArgs,
-    ChipTensor, CoreCallable, DataType, TaskArgs, TaskHandle,
+    ArgDirection, CallConfig, ChipCallable, CoreCallable,
+    DataType, TaskArgs, TaskHandle, TensorArgType,
 )
 from simpler_setup import KernelCompiler, SceneTestCase, scene_test
 ```
@@ -49,7 +49,7 @@ else raises. Remote-worker and remote-memory calls require `level >= 4`.
 
 | Method | Notes |
 | ------ | ----- |
-| `register(target, *, workers=None) -> CallableHandle` | **Before `init()`.** Accepts a `ChipCallable` or, at L3+, a Python callable |
+| `register(target, *, workers=None) -> CallableHandle` | Accepts a `ChipCallable` or, at L3+, a Python callable. Pre-init registrations enter the startup snapshot; post-init registration installs the callable on eligible live targets before returning |
 | `unregister(handle_or_slot)` | Releases a registration |
 | `add_worker(worker) -> int` | Attaches a child worker; returns its id |
 | `add_remote_worker(spec: RemoteWorkerSpec) -> int` | L4; see the remote-L3 design doc |
@@ -60,8 +60,9 @@ else raises. Remote-worker and remote-memory calls require `level >= 4`.
 
 | Method | Notes |
 | ------ | ----- |
-| `malloc(size, worker_id=0) -> int` | Returns a device pointer as an integer |
-| `free(ptr, worker_id=0)` | |
+| `malloc(size) -> Buffer` | L2 only; allocates on this worker's chip |
+| `alloc_child_tensor(worker_id, shapes, dtype) -> Buffer` | Allocates on an L3 worker's chip child; use `handle.tensor(shapes, dtype)` to name a task argument |
+| `free(handle)` | Releases a device `Buffer` returned by either allocation method |
 | `copy_to(dst, src, *, dst_offset=0, src_offset=0, nbytes=None)` | H2D; `dst` is a device `Buffer`, `src` a host `Buffer` from `create_buffer` (at L2, also any torch tensor or writable buffer). `nbytes` defaults to the rest of the host side after `src_offset`, so `copy_to(dst, src)` transfers the whole host backing |
 | `copy_from(dst, src, *, dst_offset=0, src_offset=0, nbytes=None)` | D2H; `dst` is the host `Buffer` (at L2, also any writable buffer). Same defaulting, measured from `dst_offset` on the host side |
 | `create_buffer(nbytes) -> Buffer` / `Buffer.close()` | Shared host backing this Worker owns; build a view over `handle.shm.buf`, name it on the wire with `handle.tensor(shapes, dtype)` |
@@ -94,7 +95,7 @@ callable is a **Python orchestration function** `f(orch, args, cfg)`, where
 | `submit_next_level_group(callable_handle, args_list, config=None, *, workers: list[int]) -> TaskHandle` | Submits one group DAG node and returns its opaque handle |
 | `submit_sub(callable_handle, args=None)` | Schedules a registered host-side Python callable |
 | `allocate_domain(name, workers, window_size, buffers=[...])` | Context manager returning a handle indexed by domain-local rank |
-| `malloc(worker_id, size) -> int` | **Argument order is `(worker_id, size)`** — the reverse of `Worker.malloc(size, worker_id=0)` |
+| `alloc_child_tensor(worker_id, shapes, dtype) -> Buffer` | Delegates allocation to the owning Worker; target chip memory is named by the returned handle |
 
 ## Callables and task args
 
@@ -113,6 +114,11 @@ ChipCallable.build(
 positional and defines the task-arg order. `func_id` must match the id the
 orchestration submits. `ChipCallable` exposes `binary_size`.
 
+Public `Worker` calls use `TaskArgs` containing address-free `Tensor` views at
+every level. The L2 leaf resolves those views into the internal
+`ChipStorageTaskArgs` / `ChipTensor` representation; callers do not pass that
+internal representation to `Worker.run()`.
+
 For L3+ graph construction, `TaskArgs.add_dep(*handles)` adds `WAIT | RETAIN`
 edges: each consumer waits for its producers and keeps their task-owned
 resources alive until it completes. `TaskArgs.add_dep_wait(*handles)` adds
@@ -121,12 +127,14 @@ same orchestration run; they are opaque and cannot be constructed by the
 caller.
 
 ```python
-args = ChipStorageTaskArgs()
-args.add_tensor(ChipTensor.make(dev_ptr, (rows, cols), DataType.FLOAT32))
+args = TaskArgs()
+args.add_tensor(device_buffer.tensor((rows, cols), DataType.FLOAT32), TensorArgType.INPUT)
 ```
 
-Tensors are added **in signature order**. `ChipTensor.make(data_ptr, shape, dtype)`
-takes a device pointer; `DataType` carries the element types.
+`device_buffer` is a `Buffer` returned by `malloc` or `alloc_child_tensor`.
+Add tensors **in signature order**, before any scalars. Use `INPUT` for an
+input, `OUTPUT_EXISTING` for a caller-allocated output, and `INOUT` for an
+input/output view. `DataType` carries the element types.
 
 ## `CallConfig`
 
@@ -135,14 +143,14 @@ takes a device pointer; `DataType` carries the element types.
 | Field | Default | Meaning |
 | ----- | ------- | ------- |
 | `aicpu_thread_num` | `0` | AICPU threads for this run; `0` selects the architecture default |
-| `enable_chip_swimlane` | `0` | `0` off; `1`–`4` select detail. L2 only |
+| `enable_chip_swimlane` | `0` | `0` off; `1`–`4` select detail. L2 and same-host L3; cross-rank merging requires detail level `4` |
 | `enable_dump_args` | `0` | Capture per-task arguments |
 | `enable_pmu` | `0` | `0` off; `>0` selects the event type |
 | `enable_dep_gen` | `0` | Emit the dependency graph |
 | `enable_scope_stats` | `0` | Writes `<output_prefix>/scope_stats/scope_stats.jsonl` |
 | `capture_clock_anchors` | `False` | Anchors the Host and Device clocks so device timestamps land on an absolute Host timeline. Set by the ChipWorker child for an L3 chip-swimlane capture; not a caller knob |
 | `output_prefix` | `""` | **Required whenever any diagnostic is enabled** |
-| `runtime_env` | — | `ring_task_window`, `ring_heap`, `ring_dep_pool`; `tensormap_and_ringbuffer` only |
+| `runtime_env` | — | TRB uses `ring_task_window`, `ring_heap`, and `ring_dep_pool`. HBG uses `ring_task_window[0]` for graph task capacity; its graph heap is sized after orchestration |
 
 `validate()` runs at every submit/run entry point and throws if a diagnostic is
 on without `output_prefix`, or if a ring override breaks the ring's constraints.
@@ -181,7 +189,7 @@ Compilation and test scaffolding. Exported from the package root:
 | `ensure_pto_isa_root()` | Clones/updates the pinned pto-isa checkout and returns its path |
 | `extract_text_section(binary)` | Required on hardware platforms before wrapping a kernel `.o` |
 | `scene_test(level, runtime)` / `SceneTestCase` | The decorator and base class for declarative examples and tests |
-| `Tensor`, `Scalar`, `TaskArgsBuilder`, `CallableNamespace` | Scene-test arg construction |
+| `TensorArg`, `Scalar`, `TaskArgsBuilder`, `CallableNamespace` | Scene-test arg construction; `TensorArg` is separate from the runtime `Tensor` type |
 | `make_chip_tensor_arg`, `torch_dtype_to_datatype` | torch interop |
 | `parse_platform` | Platform string parsing |
 | `RuntimeBuilder` | Runtime build orchestration |


### PR DESCRIPTION
## Summary

The user guides contain examples that fail against the current Worker API, and the task-flow reference describes an obsolete mailbox tensor layout. Update the examples to Buffer-backed TaskArgs and keyword-only copy options, document the 144-byte Tensor wire records and their materialization, and replace deleted example paths with the current HBG scene test.

Also align HBG capacity settings, dynamic registration, same-host L3 swimlane support, architecture-specific binaries, package dependencies, and TensorArg exports with the implementation. The changes are confined to Markdown, including the testing skill's example commands.

## Validation

- All applicable pre-commit hooks passed.
- `mkdocs build --strict` passed.
- HBG getting-started command passed on a2a3sim with `--manual include`.
- Extracted Worker tutorial and L3 task-flow examples passed simulator golden comparisons using the existing vector-add kernels and concrete input fixtures.
- Documented imports, API signatures, and HBG capacity assignment checked against the installed worktree.

Simulator checks used `TORCH_DEVICE_BACKEND_AUTOLOAD=0` to avoid loading the shared host's NPU backend. No hardware runs were needed.
