### PR TITLE
Docs: correct the dep_gen schema claim and the pool-rebuild contract

### DIFF
--- a/docs/dfx/dep-gen.md
+++ b/docs/dfx/dep-gen.md
@@ -34,7 +34,10 @@ deps.json now fully replaces the removed `fanout[]`.
 
 dep_gen has two shapes, chosen by where the orchestrator runs. Both emit the
 same `deps.json` (§4), so every consumer — deps viewer, swimlane join — reads
-either one the same way.
+either one the same way, with one documented exception: an edge's `flags`
+(WAIT/RETAIN) describes `tensormap_and_ringbuffer`'s own dependency computation,
+which `host_build_graph` has no equivalent of, so only the device-orchestrated
+shape emits it. A consumer must treat `flags` as optional.
 
 ### 2.1 Device orchestration (`tensormap_and_ringbuffer`)
 
@@ -226,7 +229,7 @@ Each edge is `{pred, succ}` plus annotation. Fields:
 | `pred`, `succ` | uint64 (string) | always | `TaskId::raw` of producer and consumer |
 | `arg` | int32 | always | Consumer's arg-slot index; `-1` for `explicit` source |
 | `source` | string | always | `explicit` (from `explicit_deps[]`), `creator` (`owner_task_id` retention), or `tensormap` (overlap lookup hit) |
-| `flags` | string array | `tensormap_and_ringbuffer` | Subset of `["wait", "retain"]` — the edge's `DepFlags`. `wait` = ordering (readiness); `retain` = producer lifetime held until the consumer releases. `creator` edges are `["wait","retain"]`; `tensormap` edges `["wait"]`. `explicit` edges start with the per-dependency kind captured at submit time, so `CoreTaskArgsWithDeps::add_dep_wait()` emits `["wait"]` while the default dependency kind emits `["wait","retain"]`. When the same producer is also the creator of an input, replay matches runtime fanin dedup by OR-accumulating the creator's flags into the explicit edge. The host_build_graph writer does not currently emit this field. |
+| `flags` | string array | `tensormap_and_ringbuffer` | Subset of `["wait", "retain"]` — the edge's `DepFlags`. `wait` = ordering (readiness); `retain` = producer lifetime held until the consumer releases. `creator` edges are `["wait","retain"]`; `tensormap` edges `["wait"]`. `explicit` edges start with the per-dependency kind captured at submit time, so `CoreTaskArgsWithDeps::add_dep_wait()` emits `["wait"]` while the default dependency kind emits `["wait","retain"]`. When the same producer is also the creator of an input, replay matches runtime fanin dedup by OR-accumulating the creator's flags into the explicit edge. `DepFlags` is a `tensormap_and_ringbuffer` runtime concept — it does not exist in the host_build_graph tree — so the host-orchestrated writer omits the field rather than lagging behind it. Consumers must treat it as optional. |
 | `overlap` | string | `source=tensormap` | `covered` (producer slice fully contains consumer slice) or `other` |
 | `tensor_id` | uint64 (string) | not `explicit` | Identity of the underlying tensor; cross-references `tensors[]` |
 | `consumer_dtype` | string | not `explicit` | Element type the consumer reads as |

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -1004,7 +1004,24 @@ protected:
         int launch_aicpu_num{0};
     };
 
-    /** True once collectors are built and this run's counts differ from theirs. */
+    /**
+     * True once collectors are built and this run's counts differ from theirs,
+     * i.e. their pools must be released and rebuilt before this run seeds them.
+     *
+     * The release frees device memory the collectors are holding, so it is only
+     * safe while no other run is executing against them. Nothing here enforces
+     * that. What guarantees it today is the diagnostics depth-1 gate: with any
+     * diagnostic on, `allow_prepared_successor` is false, so a successor cannot
+     * even reserve while a predecessor is in flight, and a stale shape is only
+     * ever seen between runs.
+     *
+     * **Whoever lifts that gate must move this rebuild inside the execution
+     * claim.** Do not reach for `native_run_active()` as the guard — it is not a
+     * usable predicate at this point: onboard takes the claim in
+     * `simpler_launch_run`, but sim takes it in `simpler_prepare_run`, so on sim
+     * it is already true for the run being prepared and the check fires on its
+     * own run.
+     */
     bool collector_shape_is_stale(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) const {
         return collector_shape_.latched &&
                (collector_shape_.num_aicore != num_aicore || collector_shape_.aicpu_thread_num != aicpu_thread_num ||

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -529,7 +529,24 @@ protected:
         int launch_aicpu_num{0};
     };
 
-    /** True once collectors are built and this run's counts differ from theirs. */
+    /**
+     * True once collectors are built and this run's counts differ from theirs,
+     * i.e. their pools must be released and rebuilt before this run seeds them.
+     *
+     * The release frees device memory the collectors are holding, so it is only
+     * safe while no other run is executing against them. Nothing here enforces
+     * that. What guarantees it today is the diagnostics depth-1 gate: with any
+     * diagnostic on, `allow_prepared_successor` is false, so a successor cannot
+     * even reserve while a predecessor is in flight, and a stale shape is only
+     * ever seen between runs.
+     *
+     * **Whoever lifts that gate must move this rebuild inside the execution
+     * claim.** Do not reach for `native_run_active()` as the guard — it is not a
+     * usable predicate at this point: onboard takes the claim in
+     * `simpler_launch_run`, but sim takes it in `simpler_prepare_run`, so on sim
+     * it is already true for the run being prepared and the check fires on its
+     * own run.
+     */
     bool collector_shape_is_stale(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) const {
         return collector_shape_.latched &&
                (collector_shape_.num_aicore != num_aicore || collector_shape_.aicpu_thread_num != aicpu_thread_num ||


### PR DESCRIPTION
Two documentation defects found while reviewing #2135. **No behavior change** — docs and two header comments only.

## 1. `deps.json` is not identical across the two runtimes

`docs/dfx/dep-gen.md` §2 said both shapes emit the same `deps.json` and "every consumer — deps viewer, swimlane join — reads either one the same way." They do not: an edge's `flags` (WAIT/RETAIN) is emitted only by `tensormap_and_ringbuffer`.

That turned out **not** to be drift. `DepFlags` is a tmr runtime concept — zero occurrences anywhere under `src/common/host_build_graph/` — so the host-orchestrated writer omits the field because it has nothing to put there, not because it lagged behind. No downstream tool reads it; only tmr's own `test_dep_gen_chain` scene tests assert it.

The §4 schema table already had it right (`flags` is listed as `tensormap_and_ringbuffer`-only). Two fixes:

- §2's summary now states the exception and says a consumer must treat `flags` as optional.
- §4's "The host_build_graph writer does not **currently** emit this field" read as a gap awaiting closure; replaced with why it structurally cannot.

## 2. `collector_shape_is_stale()` had no stated precondition

#2126 added the helper. Acting on a true result releases the collectors' device memory, which is only safe while no other run is executing against it — and nothing in the class enforces that. What guarantees it today is the diagnostics depth-1 gate: with any diagnostic on, `allow_prepared_successor` is false, so a successor cannot reserve while a predecessor is in flight, and a stale shape is only ever observed between runs.

The comment now says that, and says the rebuild must move inside the execution claim when that gate is lifted.

It also records a trap I walked into while trying to *enforce* the precondition rather than document it: **`native_run_active()` is not a usable guard at that point.** Onboard takes the execution claim in `simpler_launch_run`, but sim takes it in `simpler_prepare_run` (`c_api_shared.cpp:718`), so on sim it is already true for the run being prepared. A check on it fires on its own run — measured: it failed 16 DFX channel runs and the residency test before I reverted it. Documenting the asymmetry is worth more than a check that is wrong on half the platforms.

## Testing

No behavior change, so the bar is that nothing moved:

- [x] DFX channels one per invocation as CI runs them: 12 runs across a2a3sim/a5sim — no failures
- [x] collector residency test — pass
- [x] cpput 134/134, pyut 2151/2151
- [x] `a2a3sim` sweep — 44 passed; the one failure (`TestSpmdPagedAttentionHighPerf::b4_h32_kv8_s512_bs128_fp16`, `max_diff=0.0625`) is pre-existing and `manual`-only, reproduced identically on a clean base build
- [x] clang-format, cpplint, the four `tests/lint` hooks, markdownlint

Follow-up to #2126 and #2135. The remaining finding from the same review — `deps.json` has three independent writers and three file-local copies of its graph types — is larger and not in scope here.