### PR TITLE
Fix: align worker guide and build comments with source

### DIFF
--- a/docs/user/how-to/write-and-run-a-kernel.md
+++ b/docs/user/how-to/write-and-run-a-kernel.md
@@ -99,84 +99,26 @@ for the full `CallConfig` field list.
 
 ## Option B — the `Worker` API directly
 
-Use this when you need to see the stages, or when your program is not a test.
-The canonical worked example is
-[`examples/workers/l2/vector_add/main.py`](../../../examples/workers/l2/vector_add/main.py);
-the shape is:
+Use the runnable
+[`examples/workers/l2/vector_add/main.py`](../../../examples/workers/l2/vector_add/main.py)
+example to follow compilation, callable construction, registration, device
+allocation, copies, execution, and golden comparison in one place:
 
-```python
-from simpler.task_interface import (
-    ArgDirection, CallConfig, ChipCallable, CoreCallable,
-    DataType, TaskArgs, TensorArgType,
-)
-from simpler.worker import Worker
-
-from simpler_setup.kernel_compiler import KernelCompiler
-from simpler_setup.pto_isa import ensure_pto_isa_root
-
-# 1. Compile. pto_isa_root is the managed sibling header checkout.
-kc = KernelCompiler(platform=platform)
-kernel_bytes = kc.compile_incore(
-    source_path=".../kernels/aiv/my_kernel.cpp",
-    core_type="aiv",
-    pto_isa_root=ensure_pto_isa_root(),
-    extra_include_dirs=kc.get_orchestration_include_dirs("tensormap_and_ringbuffer"),
-)
-# On real hardware only, extract .text before wrapping:
-if not platform.endswith("sim"):
-    from simpler_setup.elf_parser import extract_text_section
-    kernel_bytes = extract_text_section(kernel_bytes)
-
-orch_bytes = kc.compile_orchestration(
-    runtime_name="tensormap_and_ringbuffer",
-    source_path=".../kernels/orchestration/my_orch.cpp",
-)
-
-# 2. Wrap into callables. children maps func_id -> CoreCallable.
-core = CoreCallable.build(
-    signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
-    binary=kernel_bytes,
-)
-chip = ChipCallable.build(
-    signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
-    func_name="my_orchestration",
-    binary=orch_bytes,
-    children=[(0, core)],
-)
-
-# 3. Register and initialize the worker.
-worker = Worker(level=2, platform=platform,
-                runtime="tensormap_and_ringbuffer", device_id=device_id)
-handle = worker.register(chip)
-worker.init()
-try:
-    # 4. Device memory + H2D.
-    dev_a = worker.malloc(nbytes)
-    dev_b = worker.malloc(nbytes)
-    dev_out = worker.malloc(nbytes)
-    worker.copy_to(dev_a, host_a)
-    worker.copy_to(dev_b, host_b)
-
-    # 5. Task args, in the same order as the signature.
-    args = TaskArgs()
-    args.add_tensor(dev_a.tensor((rows, cols), DataType.FLOAT32), TensorArgType.INPUT)
-    args.add_tensor(dev_b.tensor((rows, cols), DataType.FLOAT32), TensorArgType.INPUT)
-    args.add_tensor(dev_out.tensor((rows, cols), DataType.FLOAT32), TensorArgType.OUTPUT_EXISTING)
-
-    # 6. Run, then D2H.
-    worker.run(handle, args, CallConfig())
-    worker.copy_from(host_out, dev_out)
-    worker.free(dev_a)
-    worker.free(dev_b)
-    worker.free(dev_out)
-finally:
-    worker.close()          # always; a leaked device stays locked
+```bash
+python examples/workers/l2/vector_add/main.py -p a2a3sim -d 0
 ```
 
-Here `host_a`, `host_b`, and `host_out` are contiguous CPU torch tensors of
-shape `(rows, cols)` and dtype `torch.float32`; `nbytes = rows * cols * 4`.
-Allocations return `Buffer` handles. For partial copies, pass `nbytes`,
-`src_offset`, and `dst_offset` by keyword.
+The same implementation is exercised by
+[`test_vector_add.py`](../../../examples/workers/l2/vector_add/test_vector_add.py).
+Its cases are manual; run the simulator case with:
+
+```bash
+pytest examples/workers/l2/vector_add/test_vector_add.py --platform a2a3sim --manual include
+```
+
+The example uses contiguous CPU torch tensors of shape `(128, 128)` and dtype
+`torch.float32`. Device allocations return `Buffer` handles. For partial copies,
+pass `nbytes`, `src_offset`, and `dst_offset` by keyword.
 
 Lifecycle and argument rules:
 

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -94,7 +94,7 @@ callable is a **Python orchestration function** `f(orch, args, cfg)`, where
 | `submit_next_level(callable_handle, args, config=None, *, worker: int) -> TaskHandle` | Hands a callable to one exact NEXT_LEVEL child and returns an opaque handle for explicit task dependencies |
 | `submit_next_level_group(callable_handle, args_list, config=None, *, workers: list[int]) -> TaskHandle` | Submits one group DAG node and returns its opaque handle |
 | `submit_sub(callable_handle, args=None)` | Schedules a registered host-side Python callable |
-| `allocate_domain(name, workers, window_size, buffers=[...])` | Context manager returning a handle indexed by domain-local rank |
+| `allocate_domain(*, name, workers, window_size, buffers=())` | Context manager returning a handle indexed by domain-local rank |
 | `alloc_child_tensor(worker_id, shapes, dtype) -> Buffer` | Delegates allocation to the owning Worker; target chip memory is named by the returned handle |
 
 ## Callables and task args

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -79,8 +79,8 @@ def detect_buildable_platforms() -> list:
         platforms.extend(["a2a3sim", "a5sim"])
 
     # Onboard platforms: need ccec + cross-compiler from ASCEND_HOME_PATH.
-    # a2a3 and a5 use the same toolchain and produce identical artifacts;
-    # the difference is runtime-only, so always build both.
+    # a2a3 and a5 share toolchain prerequisites but build separate artifacts
+    # with architecture-specific AICore targets (dav-c220 and dav-c310).
     has_ccec = shutil.which("ccec") is not None
 
     ascend_home = os.environ.get("ASCEND_HOME_PATH", "")


### PR DESCRIPTION
The direct Worker guide duplicates the runnable vector-add implementation using placeholder kernel paths and inputs. Point readers at the existing example and its pytest entry point, including the manual simulator option, so the implementation stays in one place.

Also correct `allocate_domain` to show its keyword-only parameters and clarify that a2a3 and a5 share toolchain prerequisites but build separate architecture-specific artifacts.

Validation:
- Existing L2 vector-add simulation suite passes: all 3 cases, including the documented `test_vector_add.py` entry point.
- Strict MkDocs build and all applicable pre-commit checks pass.
- The build-platform detector's Python AST is unchanged; its edit is comment-only.
