### PR TITLE
Add: hbg in-graph early-dispatch prerequisites — recorded verdicts and a sorted CSR

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -627,7 +627,7 @@ struct SchedulerState {
         const int32_t start = s->wake_scan_cursor < p.fanin_count ? s->wake_scan_cursor : p.fanin_count - 1;
         for (int32_t i = start; i >= 0; i--) {
             if (!tasks.is_completed(fanin[i])) {
-                s->wake_scan_cursor = static_cast<uint8_t>(i);
+                s->wake_scan_cursor = static_cast<uint16_t>(i);
                 return i;
             }
         }
@@ -1130,18 +1130,46 @@ struct SchedulerState {
     // Orch owns dependency discovery and saves the immutable fanin wire.
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.
-    int32_t graph_first_unmet_producer(const GraphExecution &execution, const ChipTaskSlotState &consumer) const {
+    //
+    // Returns -1 (every producer complete -> route to ready) or the consumer's
+    // own CSR row index of an unmet producer, which graph_producer_at maps back
+    // to that producer. Hanging on the producer that completes last minimises
+    // wake-list transfers (a consumer re-registered onto a second producer once
+    // its first one completes) and the CAS traffic those transfers put on the
+    // lists, so the scan walks the row from its tail.
+    //
+    // What the tail names depends on the row. A row holds the consumer's
+    // deduplicated operand order, which is a declaration order and carries no
+    // relation to producer depth. Only an early-dispatch candidate's row is
+    // sorted by producer index (graph_fill_definition), and a producer is
+    // emitted before its consumers, so there the tail is the deepest producer
+    // and the bet is exact. On an unsorted row the tail is the last-declared
+    // operand and the scan is a heuristic, no worse-founded than picking the
+    // head.
+    //
+    // Resumes at the wake-scan cursor: entries above it were complete at the
+    // last classification and completion is monotonic, so re-walking them
+    // cannot change the verdict.
+    int32_t graph_first_unmet_producer(const GraphExecution &execution, ChipTaskSlotState &consumer) const {
         const int32_t task_index = consumer.in_graph_local_id;
         const int32_t begin = execution.fanin_offsets[task_index];
-        const int32_t end = execution.fanin_offsets[task_index + 1];
-        for (int32_t edge = begin; edge < end; ++edge) {
-            const uint16_t producer_index = execution.fanin_indices[edge];
-            const ChipTaskSlotState &producer = execution.task_at(producer_index).slot;
+        const int32_t count = execution.fanin_offsets[task_index + 1] - begin;
+        const int32_t start = consumer.wake_scan_cursor < count ? consumer.wake_scan_cursor : count - 1;
+        for (int32_t row = start; row >= 0; --row) {
+            const ChipTaskSlotState &producer = execution.task_at(execution.fanin_indices[begin + row]).slot;
             if (producer.task_state.load(std::memory_order_acquire) != CHIP_TASK_COMPLETED) {
-                return static_cast<int32_t>(producer_index);
+                consumer.wake_scan_cursor = static_cast<uint16_t>(row);
+                return row;
             }
         }
         return -1;
+    }
+
+    // The producer a graph_first_unmet_producer row index names.
+    ChipTaskSlotState &
+    graph_producer_at(const GraphExecution &execution, const ChipTaskSlotState &consumer, int32_t row) const {
+        const int32_t begin = execution.fanin_offsets[consumer.in_graph_local_id];
+        return execution.task_at(execution.fanin_indices[begin + row]).slot;
     }
 
     void register_graph_wake(GraphExecution &execution, ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
@@ -1164,25 +1192,32 @@ struct SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &execution.task_at(unmet_producer).slot;
+            producer = &graph_producer_at(execution, *consumer, unmet_producer);
         }
     }
 
     uint32_t drain_graph_wake_list(GraphExecution &execution, ChipTaskSlotState &producer) {
-        uint32_t consumers_rescanned = 0;
+        uint32_t consumers_resolved = 0;
         ChipTaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
             ChipTaskSlotState *next = waiter->next_in_wake_list;
+            const int32_t local_id = waiter->in_graph_local_id;
+            if (execution.fanin_offsets[local_id + 1] - execution.fanin_offsets[local_id] == 1) {
+                push_ready_routed(waiter);  // single-producer waiter was waiting only on us
+                consumers_resolved++;
+                waiter = next;
+                continue;
+            }
             const int32_t unmet_producer = graph_first_unmet_producer(execution, *waiter);
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_graph_wake(execution, &execution.task_at(unmet_producer).slot, waiter);
+                register_graph_wake(execution, &graph_producer_at(execution, *waiter, unmet_producer), waiter);
             }
-            consumers_rescanned++;
+            consumers_resolved++;
             waiter = next;
         }
-        return consumers_rescanned;
+        return consumers_resolved;
     }
 
     // Push every materialized-and-published root that has not been routed yet,
@@ -1227,7 +1262,7 @@ struct SchedulerState {
             if (unmet < 0) {
                 push_ready_routed(&task);
             } else {
-                register_graph_wake(execution, &execution.task_at(unmet).slot, &task);
+                register_graph_wake(execution, &graph_producer_at(execution, task, unmet), &task);
             }
         }
         execution.published_tasks.store(last, std::memory_order_release);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -638,7 +638,7 @@ struct SchedulerState {
         const int32_t start = s->wake_scan_cursor < p.fanin_count ? s->wake_scan_cursor : p.fanin_count - 1;
         for (int32_t i = start; i >= 0; i--) {
             if (!tasks.is_completed(fanin[i])) {
-                s->wake_scan_cursor = static_cast<uint8_t>(i);
+                s->wake_scan_cursor = static_cast<uint16_t>(i);
                 return i;
             }
         }
@@ -1141,18 +1141,46 @@ struct SchedulerState {
     // Orch owns dependency discovery and saves the immutable fanin wire.
     // Scheduler polling only chooses which already-wired producer a consumer
     // waits on at this instant; it never recomputes producer relationships.
-    int32_t graph_first_unmet_producer(const GraphExecution &execution, const ChipTaskSlotState &consumer) const {
+    //
+    // Returns -1 (every producer complete -> route to ready) or the consumer's
+    // own CSR row index of an unmet producer, which graph_producer_at maps back
+    // to that producer. Hanging on the producer that completes last minimises
+    // wake-list transfers (a consumer re-registered onto a second producer once
+    // its first one completes) and the CAS traffic those transfers put on the
+    // lists, so the scan walks the row from its tail.
+    //
+    // What the tail names depends on the row. A row holds the consumer's
+    // deduplicated operand order, which is a declaration order and carries no
+    // relation to producer depth. Only an early-dispatch candidate's row is
+    // sorted by producer index (graph_fill_definition), and a producer is
+    // emitted before its consumers, so there the tail is the deepest producer
+    // and the bet is exact. On an unsorted row the tail is the last-declared
+    // operand and the scan is a heuristic, no worse-founded than picking the
+    // head.
+    //
+    // Resumes at the wake-scan cursor: entries above it were complete at the
+    // last classification and completion is monotonic, so re-walking them
+    // cannot change the verdict.
+    int32_t graph_first_unmet_producer(const GraphExecution &execution, ChipTaskSlotState &consumer) const {
         const int32_t task_index = consumer.in_graph_local_id;
         const int32_t begin = execution.fanin_offsets[task_index];
-        const int32_t end = execution.fanin_offsets[task_index + 1];
-        for (int32_t edge = begin; edge < end; ++edge) {
-            const uint16_t producer_index = execution.fanin_indices[edge];
-            const ChipTaskSlotState &producer = execution.task_at(producer_index).slot;
+        const int32_t count = execution.fanin_offsets[task_index + 1] - begin;
+        const int32_t start = consumer.wake_scan_cursor < count ? consumer.wake_scan_cursor : count - 1;
+        for (int32_t row = start; row >= 0; --row) {
+            const ChipTaskSlotState &producer = execution.task_at(execution.fanin_indices[begin + row]).slot;
             if (producer.task_state.load(std::memory_order_acquire) != CHIP_TASK_COMPLETED) {
-                return static_cast<int32_t>(producer_index);
+                consumer.wake_scan_cursor = static_cast<uint16_t>(row);
+                return row;
             }
         }
         return -1;
+    }
+
+    // The producer a graph_first_unmet_producer row index names.
+    ChipTaskSlotState &
+    graph_producer_at(const GraphExecution &execution, const ChipTaskSlotState &consumer, int32_t row) const {
+        const int32_t begin = execution.fanin_offsets[consumer.in_graph_local_id];
+        return execution.task_at(execution.fanin_indices[begin + row]).slot;
     }
 
     void register_graph_wake(GraphExecution &execution, ChipTaskSlotState *producer, ChipTaskSlotState *consumer) {
@@ -1175,25 +1203,32 @@ struct SchedulerState {
                 push_ready_routed(consumer);
                 return;
             }
-            producer = &execution.task_at(unmet_producer).slot;
+            producer = &graph_producer_at(execution, *consumer, unmet_producer);
         }
     }
 
     uint32_t drain_graph_wake_list(GraphExecution &execution, ChipTaskSlotState &producer) {
-        uint32_t consumers_rescanned = 0;
+        uint32_t consumers_resolved = 0;
         ChipTaskSlotState *waiter = producer.wake_list_head.exchange(WAKE_LIST_SENTINEL, std::memory_order_acq_rel);
         while (waiter != nullptr && waiter != WAKE_LIST_SENTINEL) {
             ChipTaskSlotState *next = waiter->next_in_wake_list;
+            const int32_t local_id = waiter->in_graph_local_id;
+            if (execution.fanin_offsets[local_id + 1] - execution.fanin_offsets[local_id] == 1) {
+                push_ready_routed(waiter);  // single-producer waiter was waiting only on us
+                consumers_resolved++;
+                waiter = next;
+                continue;
+            }
             const int32_t unmet_producer = graph_first_unmet_producer(execution, *waiter);
             if (unmet_producer < 0) {
                 push_ready_routed(waiter);
             } else {
-                register_graph_wake(execution, &execution.task_at(unmet_producer).slot, waiter);
+                register_graph_wake(execution, &graph_producer_at(execution, *waiter, unmet_producer), waiter);
             }
-            consumers_rescanned++;
+            consumers_resolved++;
             waiter = next;
         }
-        return consumers_rescanned;
+        return consumers_resolved;
     }
 
     // Push every materialized-and-published root that has not been routed yet,
@@ -1238,7 +1273,7 @@ struct SchedulerState {
             if (unmet < 0) {
                 push_ready_routed(&task);
             } else {
-                register_graph_wake(execution, &execution.task_at(unmet).slot, &task);
+                register_graph_wake(execution, &graph_producer_at(execution, task, unmet), &task);
             }
         }
         execution.published_tasks.store(last, std::memory_order_release);

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -108,8 +108,9 @@ bool bind_graph_topology(GraphExecution &execution) {
             task.tensor_count > definition.tensor_arg_count - task.tensor_offset ||
             task.scalar_offset > definition.scalar_arg_count ||
             task.scalar_count > definition.scalar_arg_count - task.scalar_offset ||
-            (task.active_mask & ~VALID_ACTIVE_MASK) != 0 || task.logical_block_num <= 0 ||
-            task.total_required_subtasks < 0) {
+            (task.active_mask & ~VALID_ACTIVE_MASK) != 0 ||
+            (task.ed_flags & ~(ED_FLAG_CANDIDATE | ED_FLAG_TRACKED)) != 0 || task.reserved != 0 ||
+            task.logical_block_num <= 0 || task.total_required_subtasks < 0) {
             return false;
         }
         for (int32_t slot = 0; slot < SUBTASK_SLOT_COUNT; ++slot) {

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -328,6 +328,14 @@ Definition. It contains:
 - in-graph task order and AIC/AIV/MIX/SPMD kernel metadata;
 - `root_indices` plus both directions of the immutable topology:
   fanin CSR and fanout CSR;
+- each in-graph task's early-dispatch verdicts (`ED_FLAG_CANDIDATE` when every
+  producer allows early resolve and the task itself carries no predicate, a
+  dispatchable shape and at least one internal producer; `ED_FLAG_TRACKED` when
+  some candidate names it as a producer). A candidate's fanin CSR row is stored
+  sorted by producer index, so its tail names its deepest producer; every other
+  row keeps record order. `bind_graph_topology` validates these flags but
+  nothing propagates them to a task slot, so they steer no dispatch yet — the
+  sorted row is the only part of the verdict the device acts on;
 - one packed-heap offset per in-graph task;
 - each in-graph task's ChipTensor source:
   `BOUNDARY_EXACT`, `BOUNDARY_VIEW`, `INTERNAL`, or `OWN_OUTPUT`;
@@ -435,13 +443,19 @@ dependency wiring remains an Orchestrator responsibility:
   resolving its Tensor addresses against the boundary image and its producers'
   packed windows;
 - materialization registers each non-root on one producer selected from its
-  saved fanin CSR;
+  saved fanin CSR, scanning the row from its tail so the bet lands on the
+  producer likeliest to complete last. A row holds the consumer's deduplicated
+  operand order, so the tail is exactly the deepest producer only on an
+  early-dispatch candidate's row, which recording sorts by producer index;
+  elsewhere the direction is a heuristic;
 - an in-graph task's release/acquire `task_state` is its Graph-local completion truth, so
   such tasks need neither a shared-memory `task_states` byte nor a task-table slot;
 - producer completion closes and drains only its current wake-list rather than
   traversing the saved fanout CSR;
-- a woken consumer scans its saved fanin CSR and either enters its shape queue
-  or registers on the next incomplete producer;
+- a woken consumer with a single producer enters its shape queue directly; any
+  other rescans its saved fanin CSR from its wake-scan cursor and either enters
+  that queue or registers on the deepest incomplete producer. Completion is
+  monotonic, so rows above the cursor stay complete and are never re-walked;
 - `WAKE_LIST_SENTINEL` closes the completion/registration race: a failed
   registration observes completion and immediately rescans.
 

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -27,6 +27,9 @@ static_assert(
     MAX_IN_GRAPH_TASKS <= (1 << TaskId::IN_GRAPH_LOCAL_ID_BITS),
     "an in-graph local id must fit the low field of an IN_GRAPH task id"
 );
+// A body's producers precede their consumers, so a fanin CSR row holds at most
+// task_count - 1 entries and the wake-scan cursor indexes one of them.
+static_assert(MAX_IN_GRAPH_TASKS - 1 < 0xFFFF, "a fanin CSR row index must fit ChipTaskSlotState::wake_scan_cursor");
 inline constexpr int32_t GRAPH_MATERIALIZE_SLICE_TASKS = 4;
 
 enum class GraphTensorSourceKind : uint8_t {
@@ -123,6 +126,13 @@ struct InGraphTaskDefinition {
     int32_t kernel_id[SUBTASK_SLOT_COUNT];
     uint8_t active_mask;
     uint8_t task_attrs;
+    // Early-dispatch verdicts (ED_FLAG_CANDIDATE / ED_FLAG_TRACKED), decided once
+    // per recorded shape rather than per execution: a body's structure is fixed by
+    // its Definition, so every execution of it qualifies the same tasks. Carries
+    // the same meaning as ChipTaskSlotState::ed_flags, against the Definition's
+    // fanin CSR instead of a payload fanin region.
+    uint8_t ed_flags;
+    uint8_t reserved;
     int16_t logical_block_num;
     int16_t total_required_subtasks;
     // One-based index into the Definition's predicate array; 0 means the task
@@ -231,6 +241,11 @@ static_assert(std::is_trivially_copyable_v<GraphScalarSourceRef>);
 static_assert(std::is_standard_layout_v<GraphScalarSourceRef>);
 static_assert(std::is_trivially_copyable_v<InGraphTaskDefinition>);
 static_assert(std::is_standard_layout_v<InGraphTaskDefinition>);
+// graph_fill_definition assigns this struct field by field, so its interior padding
+// is the one part of the in-graph task section no writer reaches. Nothing reads it
+// either, but pinning the size makes a new field's padding cost visible in the diff
+// that adds it rather than silently.
+static_assert(sizeof(InGraphTaskDefinition) == 80, "an InGraphTaskDefinition field changed the wire layout");
 static_assert(std::is_trivially_copyable_v<GraphPredicate>);
 static_assert(std::is_standard_layout_v<GraphPredicate>);
 static_assert(std::is_trivially_copyable_v<GraphBoundarySignature>);

--- a/src/common/host_build_graph/host/orchestrator.cpp
+++ b/src/common/host_build_graph/host/orchestrator.cpp
@@ -1086,7 +1086,10 @@ std::optional<GraphDefinition> graph_layout_definition(const GraphRecording &rec
 // Every section is written in full here, so the destination's prior content does not
 // reach the device — with one exception, `fanout_offsets`, which is accumulated
 // rather than assigned and is therefore zeroed below before its first increment.
-// The alignment slack between sections is written by nobody and read by nobody.
+// Two kinds of byte are written by nobody and read by nobody: the alignment slack
+// between sections, and `InGraphTaskDefinition`'s interior padding, which the
+// per-field assignment below cannot reach and a static_assert on that struct's
+// size pins against further growth.
 bool graph_fill_definition(const GraphRecording &recording, GraphDefinition definition, std::byte *image) {
     if (image == nullptr) return false;
     always_assert(
@@ -1133,18 +1136,55 @@ bool graph_fill_definition(const GraphRecording &recording, GraphDefinition defi
         required_heap += output_bytes;
 
         if (source.fanin_count == 0) roots[root_cursor++] = static_cast<uint16_t>(i);
+        // Early-dispatch qualification, carrying the top-level submit path's
+        // conjunction over to the Definition's own data. An internal fanin of at
+        // least one excludes a body root, whose real gate is the outer shell's
+        // activation rather than this CSR. A body records once per shape and every
+        // execution replays it, so the verdict costs nothing per invocation.
+        //
+        // The top-level conjunction's Graph-shell term has no counterpart here:
+        // graph_begin refuses a nested recording, so no producer in a body is a
+        // Graph shell.
+        bool ed_candidate = source.fanin_count > 0 && !source.task_attrs.has_predicate() &&
+                            source.active_mask.to_shape() != ResourceShape::DUMMY;
+        const size_t row_begin = fanin_cursor;
         for (int32_t f = 0; f < source.fanin_count; ++f) {
             const int32_t producer = recording.internal_fanins[source.fanin_offset + f];
             if (producer >= i) return false;
             fanin_indices[fanin_cursor++] = static_cast<uint16_t>(producer);
             fanout_offsets[producer + 1]++;
+            if (!recording.tasks[producer].task_attrs.allow_early_resolve()) ed_candidate = false;
         }
         fanin_offsets[i + 1] = static_cast<int32_t>(fanin_cursor);
+        if (ed_candidate) {
+            // A candidate's row is sorted ascending, and the builder emits a
+            // producer before its consumers, so the row's tail names its deepest
+            // producer — the entry the completion chain's tail-first scan bets on.
+            // Every other row keeps its record order, which is the consumer's
+            // deduplicated operand order and names no depth.
+            std::sort(fanin_indices + row_begin, fanin_indices + fanin_cursor);
+            // Every producer of a candidate must record its publication state.
+            // Producers precede consumers, so each entry here was assigned its own
+            // ed_flags at its own iteration and this only ever adds to it.
+            for (size_t f = row_begin; f < fanin_cursor; ++f) {
+                tasks[fanin_indices[f]].ed_flags |= ED_FLAG_TRACKED;
+            }
+        }
 
         InGraphTaskDefinition &task = tasks[i];
         std::copy(source.kernel_ids.begin(), source.kernel_ids.end(), std::begin(task.kernel_id));
         task.active_mask = source.active_mask.raw();
-        task.task_attrs = source.task_attrs.raw();
+        // The recorded attrs carry the caller's early-resolve intent, which the
+        // qualification above consumes; no in-graph task reaches the device with
+        // that bit set.
+        TaskAttrs wire_attrs = source.task_attrs;
+        wire_attrs.set_early_resolve(false);
+        task.task_attrs = wire_attrs.raw();
+        // Assignment, not accumulation: this entry may hold a previous body's
+        // verdict, and only a consumer recorded later can add ED_FLAG_TRACKED to
+        // it, which happens after this write.
+        task.ed_flags = ed_candidate ? ED_FLAG_CANDIDATE : 0;
+        task.reserved = 0;
         task.logical_block_num = source.logical_block_num;
         task.total_required_subtasks = source.total_required_subtasks;
         task.tensor_count = source.tensor_count;
@@ -2236,8 +2276,11 @@ TaskOutputTensors graph_record_submit_in_graph_task(
     task.kernel_ids[static_cast<int>(SubtaskSlot::AIV0)] = aiv0_kernel_id;
     task.kernel_ids[static_cast<int>(SubtaskSlot::AIV1)] = aiv1_kernel_id;
     task.active_mask = active_mask;
+    // The recorded copy keeps the caller's early-resolve intent, which is the input
+    // graph_fill_definition qualifies this body's early dispatch against. The bit is
+    // cleared on the way into the Definition instead, so no in-graph task reaches
+    // the device carrying it.
     task.task_attrs = task_attrs;
-    task.task_attrs.set_early_resolve(false);
     task.logical_block_num = args.launch_spec.block_num();
     // Mirror prepare_task's contract: block_num must be positive and the subtask
     // count must fit int16_t. An out-of-contract value marks asynchronous
@@ -2946,9 +2989,17 @@ TaskOutputTensors OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
     // task — the same shape submit_dummy_task records — and replay reserves the
     // intermediate heap for every in-graph task anyway, so the outputs land at
     // addresses the replayed Definition derives for itself.
+    //
+    // An allocation is transparent to early-dispatch qualification inside a body
+    // exactly as it is at top level: its output is ready at creation, so it must
+    // never be the unflagged producer that disqualifies a consumer. The top-level
+    // path marks the slot after prepare_task, which this branch returns before, so
+    // here the recorded attrs carry the mark instead.
     if (active_graph_recording(orch) != nullptr) {
+        TaskAttrs alloc_attrs;
+        alloc_attrs.set_early_resolve(true);
         return graph_record_submit_in_graph_task(
-            orch, args, ActiveMask{}, TaskAttrs{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID
+            orch, args, ActiveMask{}, alloc_attrs, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID
         );
     }
 

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -646,6 +646,20 @@ struct alignas(64) ChipTaskSlotState {
     // ranges through claim_block_range().
     std::atomic<int16_t> next_block_idx{0};
 
+    // Completion-chain scan cursor: the fanin-row index this task last hung at
+    // in the wake list. The state a producer publishes is monotone, so indices
+    // above the cursor stay completed forever and every reclassification
+    // resumes here instead of re-walking the row's completed tail. 0xFFFF =
+    // never hung; the scan start folds it to the row's last index. The
+    // classifier owning this task is its only writer, so a plain field
+    // suffices.
+    //
+    // The row it indexes is the payload's inline fanin region for a GLOBAL task
+    // and the Definition's fanin CSR row for an IN_GRAPH one. The CSR row is
+    // bounded by the in-graph task cap rather than by CHIP_MAX_FANIN, which is
+    // what makes this wider than its early-dispatch twin below.
+    uint16_t wake_scan_cursor{0xFFFF};
+
     // Completion state, PENDING or COMPLETED only (never PUBLISHED). PENDING at
     // submit; COMPLETED at whichever completion path owns this slot. For an
     // IN_GRAPH task this is the readiness truth the device itself polls
@@ -683,23 +697,15 @@ struct alignas(64) ChipTaskSlotState {
     // task is hung on in the publish list. The row is sorted and the state byte
     // is monotone, so indices above the cursor are known-published forever
     // and every rescan resumes here — each row entry is loaded once per life.
+    // Only a GLOBAL task holds a publish list, so this indexes the payload's
+    // inline fanin region alone, which append_fanin_or_fail hard-caps at
+    // CHIP_MAX_FANIN with a named fatal.
     uint8_t ed_publish_scan_cursor{0};
-
-    // Completion-chain scan cursor: the fanin-row index this task last hung at
-    // in the wake list. The state byte is monotone, so indices above the
-    // cursor stay completed forever and every reclassification resumes here
-    // instead of re-walking the row's completed tail. 0xFF = never hung; the
-    // scan start folds it to fanin_count - 1. The classifier owning this task
-    // is its only writer, so a plain byte suffices.
-    uint8_t wake_scan_cursor{0xFF};
-    // Both cursors store fanin-row indices in a byte; 0xFF is wake's never-hung
-    // sentinel. append_fanin_or_fail hard-caps rows at CHIP_MAX_FANIN with a
-    // named fatal, and this ties any future cap raise to the cursor width.
-    static_assert(CHIP_MAX_FANIN < 0xFF, "scan cursors are uint8_t and 0xFF is reserved");
+    static_assert(CHIP_MAX_FANIN <= 0xFF, "ed_publish_scan_cursor is a uint8_t fanin-row index");
 
     // Keeps the record at one cache line. Members run widest-first up to the
     // byte block above, so their sizes sum to exactly the bytes this leaves.
-    uint8_t reserved[4];
+    uint8_t reserved[3];
 
     int32_t claim_block_range(int32_t block_limit, int32_t max_count, int32_t &start) {
         int16_t current = next_block_idx.load(std::memory_order_relaxed);
@@ -750,7 +756,7 @@ struct alignas(64) ChipTaskSlotState {
         // time cannot race a tracker.
         ed_flags = 0;
         ed_publish_scan_cursor = 0;
-        wake_scan_cursor = 0xFF;
+        wake_scan_cursor = 0xFFFF;
         ed_publish_list_head.store(nullptr, std::memory_order_relaxed);
         next_in_ed_publish_list = nullptr;
         // Note: active_mask and task_attrs are per-submit-constant fields
@@ -774,7 +780,7 @@ static_assert(sizeof(ChipTaskSlotState) == 64);
 static_assert(
     offsetof(ChipTaskSlotState, ed_publish_list_head) == 16, "the ED publish pair sits right after its wake-list twin"
 );
-static_assert(offsetof(ChipTaskSlotState, reserved) == 60, "ChipTaskSlotState grew interior padding");
+static_assert(offsetof(ChipTaskSlotState, reserved) == 61, "ChipTaskSlotState grew interior padding");
 
 // =============================================================================
 // Per-Task Storage

--- a/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -57,6 +57,11 @@ void layer(const GraphTaskArgs &args, int variant) {
     right_args.add_input(sum);
     right_args.add_output(intermediate);
     right_args.add_scalar(args.scalar(variant == 0 ? 1 : 0));
+    // Flagged alongside left so mul qualifies as an early-dispatch candidate on
+    // both its producers, which is what puts a sorted multi-entry fanin row and
+    // a pair of tracked producers on the device path. left and right are not
+    // themselves candidates: the fence dummy is an unflagged producer of both.
+    right_args.set_allow_early_resolve(true);
     TaskOutputTensors right_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, right_args);
     simpler::hbg::Tensor right = right_outputs.get_ref(0);
 

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -57,6 +57,11 @@ void layer(const GraphTaskArgs &args, int variant) {
     right_args.add_input(sum);
     right_args.add_output(intermediate);
     right_args.add_scalar(args.scalar(variant == 0 ? 1 : 0));
+    // Flagged alongside left so mul qualifies as an early-dispatch candidate on
+    // both its producers, which is what puts a sorted multi-entry fanin row and
+    // a pair of tracked producers on the device path. left and right are not
+    // themselves candidates: the fence dummy is an unflagged producer of both.
+    right_args.set_allow_early_resolve(true);
     TaskOutputTensors right_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, right_args);
     simpler::hbg::Tensor right = right_outputs.get_ref(0);
 

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -1009,6 +1009,18 @@ target_sources(test_a5_hbg_ed_qualification PRIVATE
     ${HBG_ORCH_SHARED_SOURCES}
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
 )
+# Drives the real recording path to pin the in-graph early-dispatch verdicts a
+# Definition carries and the sorted fanin CSR row of a candidate.
+add_a2a3_hbg_runtime_test(test_hbg_graph_ed_qualification common/test_hbg_graph_ed_qualification.cpp)
+target_sources(test_hbg_graph_ed_qualification PRIVATE
+    ${HBG_ORCH_SHARED_SOURCES}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
+add_a5_hbg_runtime_test(test_a5_hbg_graph_ed_qualification common/test_hbg_graph_ed_qualification.cpp)
+target_sources(test_a5_hbg_graph_ed_qualification PRIVATE
+    ${HBG_ORCH_SHARED_SOURCES}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+)
 add_a2a3_hbg_runtime_test(test_hbg_graph_recording_bounds common/test_hbg_graph_recording_bounds.cpp)
 target_sources(test_hbg_graph_recording_bounds PRIVATE
     ${HBG_ORCH_SHARED_SOURCES}

--- a/tests/ut/cpp/common/test_hbg_ed_qualification.cpp
+++ b/tests/ut/cpp/common/test_hbg_ed_qualification.cpp
@@ -170,9 +170,9 @@ TEST_F(HbgEdQualificationTest, WakeScanCursorResumesAndNeverRewalks) {
     auto &tasks = sm_handle->header->tasks;
     const int32_t *row = c_slot.to_payload().fanin_data();
 
-    // Never hung: cursor is the 0xFF sentinel and the first scan starts at the
+    // Never hung: cursor is the 0xFFFF sentinel and the first scan starts at the
     // row's tail.
-    EXPECT_EQ(c_slot.wake_scan_cursor, 0xFF);
+    EXPECT_EQ(c_slot.wake_scan_cursor, 0xFFFF);
     EXPECT_EQ(sched.classify_fanin_state(&c_slot), 2);
     EXPECT_EQ(c_slot.wake_scan_cursor, 2);
 

--- a/tests/ut/cpp/common/test_hbg_graph_ed_qualification.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_ed_qualification.cpp
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The in-graph twin of the early-dispatch qualification contract. A body is
+ * recorded once per shape, so its verdicts are decided at Definition build time
+ * rather than per submit:
+ *
+ *   ED_FLAG_CANDIDATE  every internal producer carries allow_early_resolve, no
+ *                      dispatch predicate, dispatchable shape, internal fanin >= 1
+ *   ED_FLAG_TRACKED    at least one candidate names this task as a producer
+ *
+ * and a candidate's fanin CSR row is sorted by ascending producer index. The
+ * builder emits a producer before its consumers, so that order puts the deepest
+ * producer at the row's tail, which is where the device's backward scan starts.
+ * Non-candidate rows keep their record order.
+ *
+ * The second fixture covers the device side of the same row: the tail-first
+ * scan, the wake-scan cursor that resumes it, the row-index-to-producer mapping,
+ * and the drain's single-producer fast path.
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "graph_execution.h"
+#include "graph_host_state.h"
+#include "scheduler/scheduler.h"
+#include "host_build_graph/orchestrator.h"
+#include "host_build_graph/shared_memory.h"
+#include "utils/device_arena.h"
+#include "host_build_graph/task_id.h"
+
+class HbgGraphEdQualificationTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    SharedMemoryHandle *sm_handle = nullptr;
+    OrchestratorState orch{};
+    SchedulerState sched{};
+    SchedulerLayout sched_layout{};
+    GraphHostStatePtr graph_state;
+    std::vector<char> gm_heap;
+    std::vector<std::byte> definition_staging;
+    std::vector<TensorCreateInfo> create_infos;
+    std::array<uint32_t, 16> boundary_storage{};
+
+    static constexpr size_t HEAP_BYTES = 8 * 1024 * 1024;
+    static constexpr size_t STAGING_BYTES = 256 * 1024;
+
+    void SetUp() override {
+        sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(HEAP_BYTES);
+        create_infos.reserve(16);
+
+        sched_layout = SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        ASSERT_TRUE(orch.init(sm_handle->sm_base, gm_heap.data(), HEAP_BYTES, CHIP_DEFAULT_GRAPH_TASKS));
+
+        definition_staging.assign(STAGING_BYTES, std::byte{0});
+        GraphDefinitionArena arena{};
+        arena.base = definition_staging.data();
+        arena.capacity = definition_staging.size();
+        arena.object_prefix_bytes = sizeof(GraphDefinitionHeader);
+        arena.object_align = GRAPH_DEFINITION_OBJECT_ALIGN;
+        graph_state = make_graph_host_state(arena);
+        ASSERT_NE(graph_state, nullptr);
+        orch.graph_host_state = graph_state.get();
+    }
+
+    void TearDown() override {
+        orch.graph_host_state = nullptr;
+        graph_state.reset();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    simpler::hbg::Tensor boundary_tensor() {
+        uint32_t shape[] = {static_cast<uint32_t>(boundary_storage.size())};
+        return simpler::hbg::make_tensor_external(boundary_storage.data(), shape, 1);
+    }
+
+    // Opens a recording over one boundary tensor. Returns the boundary the body's
+    // tasks read from.
+    simpler::hbg::Tensor begin_body(uint64_t key, GraphTaskArgs &boundary_args) {
+        orch.begin_scope();
+        const simpler::hbg::Tensor boundary = boundary_tensor();
+        boundary_args.add_input(boundary);
+        const GraphScopeResult graph = orch.graph_begin(key, boundary_args, 0);
+        EXPECT_TRUE(graph.recording);
+        EXPECT_NE(graph.recording_handle, nullptr);
+        EXPECT_TRUE(orch.graph_prepare(graph.recording_handle, boundary_args));
+        return boundary;
+    }
+
+    // One AIV task reading `input` and writing its own output; `flagged` sets
+    // allow_early_resolve. Returns the output, which is how a later task in the
+    // body names this one as its producer.
+    simpler::hbg::Tensor record_task(const simpler::hbg::Tensor &input, bool flagged) {
+        uint32_t shape[] = {16};
+        CoreTaskArgs args;
+        args.add_input(input);
+        create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+        args.add_output(create_infos.back());
+        args.set_allow_early_resolve(flagged);
+        MixedKernels mixed{};
+        mixed.aiv0_kernel_id = 0;
+        TaskOutputTensors out = orch.submit_task(mixed, args);
+        EXPECT_TRUE(out.task_id().is_valid());
+        return out.get_ref(0);
+    }
+
+    // One allocation recorded inside the body: a kernel-less producer whose
+    // output is ready at creation. Returns the buffer, which is how a later task
+    // names this allocation as its producer.
+    simpler::hbg::Tensor record_alloc() {
+        uint32_t shape[] = {16};
+        CoreTaskArgs args;
+        create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+        args.add_output(create_infos.back());
+        TaskOutputTensors out = orch.alloc_tensors(args);
+        EXPECT_TRUE(out.task_id().is_valid());
+        return out.get_ref(0);
+    }
+
+    // One AIV task reading both producers' outputs, in the order given.
+    TaskId record_consumer(const simpler::hbg::Tensor &first, const simpler::hbg::Tensor &second) {
+        uint32_t shape[] = {16};
+        CoreTaskArgs args;
+        args.add_input(first, second);
+        create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+        args.add_output(create_infos.back());
+        MixedKernels mixed{};
+        mixed.aiv0_kernel_id = 0;
+        TaskOutputTensors out = orch.submit_task(mixed, args);
+        EXPECT_TRUE(out.task_id().is_valid());
+        return out.task_id();
+    }
+
+    const GraphDefinition *published_definition() {
+        const GraphHostDefinitionList published = graph_host_definitions(*graph_state);
+        EXPECT_EQ(published.entries.size(), 1u);
+        if (published.entries.empty()) return nullptr;
+        const GraphHostDefinition &entry = published.entries.front();
+        EXPECT_NE(entry.object_offset, GRAPH_NO_OBJECT_OFFSET) << "the staging arena is sized to hold this image";
+        return reinterpret_cast<const GraphDefinition *>(
+            definition_staging.data() + entry.object_offset + sizeof(GraphDefinitionHeader)
+        );
+    }
+};
+
+TEST_F(HbgGraphEdQualificationTest, AllFlaggedProducersMakeCandidateAndSortItsRow) {
+    GraphTaskArgs boundary_args;
+    const simpler::hbg::Tensor boundary = begin_body(0x6ED0A001, boundary_args);
+
+    const simpler::hbg::Tensor t0 = record_task(boundary, /*flagged=*/true);
+    const simpler::hbg::Tensor t1 = record_task(boundary, /*flagged=*/true);
+    // Producers named in reverse record order: the sorted row must not depend on
+    // the order the consumer's operands were declared in.
+    ASSERT_TRUE(record_consumer(t1, t0).is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    const GraphDefinition *definition = published_definition();
+    ASSERT_NE(definition, nullptr);
+    ASSERT_EQ(definition->task_count, 3);
+    const auto *tasks = graph_definition_array<InGraphTaskDefinition>(*definition, definition->off_in_graph_tasks, 3);
+    const auto *fanin_offsets = graph_definition_array<int32_t>(*definition, definition->off_fanin_offsets, 4);
+    const auto *fanin_indices =
+        graph_definition_array<uint16_t>(*definition, definition->off_fanin_indices, definition->edge_count);
+    ASSERT_NE(tasks, nullptr);
+    ASSERT_NE(fanin_offsets, nullptr);
+    ASSERT_NE(fanin_indices, nullptr);
+
+    EXPECT_NE(tasks[2].ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_NE(tasks[0].ed_flags & ED_FLAG_TRACKED, 0);
+    EXPECT_NE(tasks[1].ed_flags & ED_FLAG_TRACKED, 0);
+    // A body root's real gate is the outer shell's activation, not this CSR.
+    EXPECT_EQ(tasks[0].ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_EQ(tasks[1].ed_flags & ED_FLAG_CANDIDATE, 0);
+    // No in-graph task reaches the device carrying the early-resolve bit.
+    EXPECT_EQ(TaskAttrs{tasks[0].task_attrs}.allow_early_resolve(), false);
+
+    ASSERT_EQ(fanin_offsets[3] - fanin_offsets[2], 2);
+    EXPECT_EQ(fanin_indices[fanin_offsets[2]], 0);
+    EXPECT_EQ(fanin_indices[fanin_offsets[2] + 1], 1);
+}
+
+TEST_F(HbgGraphEdQualificationTest, OneUnflaggedProducerDisqualifiesAndLeavesItsRowInRecordOrder) {
+    GraphTaskArgs boundary_args;
+    const simpler::hbg::Tensor boundary = begin_body(0x6ED0A002, boundary_args);
+
+    const simpler::hbg::Tensor t0 = record_task(boundary, /*flagged=*/true);
+    const simpler::hbg::Tensor t1 = record_task(boundary, /*flagged=*/false);
+    ASSERT_TRUE(record_consumer(t1, t0).is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    const GraphDefinition *definition = published_definition();
+    ASSERT_NE(definition, nullptr);
+    ASSERT_EQ(definition->task_count, 3);
+    const auto *tasks = graph_definition_array<InGraphTaskDefinition>(*definition, definition->off_in_graph_tasks, 3);
+    const auto *fanin_offsets = graph_definition_array<int32_t>(*definition, definition->off_fanin_offsets, 4);
+    const auto *fanin_indices =
+        graph_definition_array<uint16_t>(*definition, definition->off_fanin_indices, definition->edge_count);
+    ASSERT_NE(tasks, nullptr);
+    ASSERT_NE(fanin_offsets, nullptr);
+    ASSERT_NE(fanin_indices, nullptr);
+
+    EXPECT_EQ(tasks[2].ed_flags & ED_FLAG_CANDIDATE, 0);
+    // No candidate, so neither producer is tracked.
+    EXPECT_EQ(tasks[0].ed_flags & ED_FLAG_TRACKED, 0);
+    EXPECT_EQ(tasks[1].ed_flags & ED_FLAG_TRACKED, 0);
+
+    // Record order (here producer 1 before producer 0), so this fails if a
+    // non-candidate row were sorted too.
+    ASSERT_EQ(fanin_offsets[3] - fanin_offsets[2], 2);
+    EXPECT_EQ(fanin_indices[fanin_offsets[2]], 1);
+    EXPECT_EQ(fanin_indices[fanin_offsets[2] + 1], 0);
+}
+
+// An allocation is a transparent producer, not a barrier: its output is ready at
+// creation, so it must not suppress a consumer's early dispatch. The top-level
+// submit path holds the same contract by marking the alloc slot; a body holds it
+// through the recorded attrs.
+TEST_F(HbgGraphEdQualificationTest, HiddenAllocProducerDoesNotDisqualifyItsConsumer) {
+    GraphTaskArgs boundary_args;
+    const simpler::hbg::Tensor boundary = begin_body(0x6ED0A003, boundary_args);
+
+    const simpler::hbg::Tensor flagged = record_task(boundary, /*flagged=*/true);
+    const simpler::hbg::Tensor allocated = record_alloc();
+    ASSERT_TRUE(record_consumer(flagged, allocated).is_valid());
+    ASSERT_TRUE(orch.graph_end());
+
+    const GraphDefinition *definition = published_definition();
+    ASSERT_NE(definition, nullptr);
+    ASSERT_EQ(definition->task_count, 3);
+    const auto *tasks = graph_definition_array<InGraphTaskDefinition>(*definition, definition->off_in_graph_tasks, 3);
+    const auto *fanin_offsets = graph_definition_array<int32_t>(*definition, definition->off_fanin_offsets, 4);
+    ASSERT_NE(tasks, nullptr);
+    ASSERT_NE(fanin_offsets, nullptr);
+
+    // Both producers reach the consumer, and the allocation among them does not
+    // cost it the verdict.
+    ASSERT_EQ(fanin_offsets[3] - fanin_offsets[2], 2);
+    EXPECT_NE(tasks[2].ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_NE(tasks[0].ed_flags & ED_FLAG_TRACKED, 0);
+    EXPECT_NE(tasks[1].ed_flags & ED_FLAG_TRACKED, 0);
+}
+
+// The device side of a body's fanin CSR row. The scheduler reads only the CSR
+// pair and the slots it indexes, so a topology can be stated directly here
+// rather than materialized from a Definition.
+class HbgGraphWakeScanTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    SharedMemoryHandle *sm_handle = nullptr;
+    SchedulerState sched{};
+    SchedulerLayout sched_layout{};
+    GraphExecution execution{};
+    // ChipTaskStorage holds atomics, so it is neither copyable nor movable and
+    // cannot back a vector; this constructs each element in place.
+    std::unique_ptr<ChipTaskStorage[]> storage;
+    std::vector<int32_t> fanin_offsets;
+    std::vector<uint16_t> fanin_indices;
+
+    void SetUp() override {
+        sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        sched_layout = SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        sched.seed_queue_slots();
+    }
+
+    void TearDown() override {
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+
+    // `rows[i]` holds task i's producers in row order. Every task starts as a
+    // pending AIV leaf, the state materialization leaves it in.
+    void build(const std::vector<std::vector<uint16_t>> &rows) {
+        storage = std::make_unique<ChipTaskStorage[]>(rows.size());
+        fanin_offsets.assign(1, 0);
+        for (size_t i = 0; i < rows.size(); ++i) {
+            fanin_indices.insert(fanin_indices.end(), rows[i].begin(), rows[i].end());
+            fanin_offsets.push_back(static_cast<int32_t>(fanin_indices.size()));
+            ChipTaskSlotState &s = storage[i].slot;
+            s.reset_for_reuse();
+            s.in_graph_local_id = static_cast<int32_t>(i);
+            s.active_mask = ActiveMask(SUBTASK_MASK_AIV0);
+            s.graph_context = &execution;
+            s.task_state.store(CHIP_TASK_PENDING, std::memory_order_relaxed);
+        }
+        execution.task_count = static_cast<int32_t>(rows.size());
+        execution.task_storage = storage.get();
+        execution.fanin_offsets = fanin_offsets.data();
+        execution.fanin_indices = fanin_indices.data();
+    }
+
+    ChipTaskSlotState &slot(size_t i) { return storage[i].slot; }
+
+    ChipTaskSlotState *pop_ready() {
+        ChipTaskSlotState *out = nullptr;
+        const int popped = sched.ready_queues[static_cast<int32_t>(ResourceShape::AIV)].pop_batch(&out, 1);
+        return popped == 1 ? out : nullptr;
+    }
+};
+
+// Each classification resumes where the last one hung and never re-walks the
+// row's completed tail. Completion is monotone, so the resume reaches the same
+// verdict a full rescan would.
+TEST_F(HbgGraphWakeScanTest, CursorResumesAndNeverRewalks) {
+    build({{}, {}, {}, {0, 1, 2}});
+    ChipTaskSlotState &consumer = slot(3);
+
+    // Never hung: the sentinel folds the scan start to the row's tail.
+    EXPECT_EQ(consumer.wake_scan_cursor, 0xFFFF);
+    EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), 2);
+    EXPECT_EQ(consumer.wake_scan_cursor, 2);
+
+    // The hung-at producer completes: the rescan resumes at the cursor and walks
+    // down to the next unmet row entry.
+    slot(2).mark_completed();
+    EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), 1);
+    EXPECT_EQ(consumer.wake_scan_cursor, 1);
+
+    // An entry above the cursor completing does not move it — nothing re-walks
+    // that tail — and clearing the rest yields the ready verdict.
+    slot(0).mark_completed();
+    EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), 1);
+    EXPECT_EQ(consumer.wake_scan_cursor, 1);
+    slot(1).mark_completed();
+    EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), -1);
+}
+
+// The classifier names a row index, not a producer index; graph_producer_at is
+// what maps one to the other. A row that is not in producer order separates them.
+TEST_F(HbgGraphWakeScanTest, ClassifierNamesARowIndexNotAProducerIndex) {
+    build({{}, {}, {}, {2, 0, 1}});
+    ChipTaskSlotState &consumer = slot(3);
+
+    EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), 2);
+    EXPECT_EQ(&sched.graph_producer_at(execution, consumer, 2), &slot(1));
+    EXPECT_EQ(&sched.graph_producer_at(execution, consumer, 0), &slot(2));
+}
+
+// A waiter with exactly one producer is by construction waiting only on the
+// producer draining it, so the drain routes it without a classification pass.
+TEST_F(HbgGraphWakeScanTest, SingleProducerWaiterIsRoutedByTheDrain) {
+    build({{}, {0}});
+    ChipTaskSlotState &producer = slot(0);
+    ChipTaskSlotState &consumer = slot(1);
+
+    sched.register_graph_wake(execution, &producer, &consumer);
+    ASSERT_EQ(producer.wake_list_head.load(std::memory_order_relaxed), &consumer);
+
+    producer.mark_completed();
+    EXPECT_EQ(sched.drain_graph_wake_list(execution, producer), 1u);
+    EXPECT_EQ(pop_ready(), &consumer);
+    // Decided from the row's length alone, so the never-hung sentinel stands.
+    EXPECT_EQ(consumer.wake_scan_cursor, 0xFFFF);
+}
+
+// A multi-producer waiter takes the classification path instead: it re-registers
+// on the row's next unmet entry and reaches the queue only once that clears too.
+TEST_F(HbgGraphWakeScanTest, MultiProducerWaiterReRegistersUntilItsRowClears) {
+    build({{}, {}, {0, 1}});
+    ChipTaskSlotState &consumer = slot(2);
+
+    sched.register_graph_wake(execution, &slot(1), &consumer);
+    slot(1).mark_completed();
+    EXPECT_EQ(sched.drain_graph_wake_list(execution, slot(1)), 1u);
+
+    // Producer 0 is still pending, so the waiter moved rather than became ready.
+    EXPECT_EQ(pop_ready(), nullptr);
+    EXPECT_EQ(slot(0).wake_list_head.load(std::memory_order_relaxed), &consumer);
+    EXPECT_EQ(consumer.wake_scan_cursor, 0);
+
+    slot(0).mark_completed();
+    EXPECT_EQ(sched.drain_graph_wake_list(execution, slot(0)), 1u);
+    EXPECT_EQ(pop_ready(), &consumer);
+}


### PR DESCRIPTION
## Summary

Early dispatch inside a Graph body needs two things the Definition did not carry, and one of them pays off on its own. Nothing here turns in-graph early dispatch on — that is the follow-up that wires the publish chain to in-graph tasks.

**Qualification moves to recording time.** `graph_fill_definition` decides `ED_FLAG_CANDIDATE` and `ED_FLAG_TRACKED` against the Definition's own fanin CSR, applying the same conjunction the top-level submit path applies to a payload's inline fanin: every producer carries `allow_early_resolve`, the task has no dispatch predicate, its shape is dispatchable, and its internal fanin is at least one. That last term excludes a body root, whose real gate is the outer shell's activation rather than this CSR. A body's structure is fixed by its Definition, so the verdict is decided once per recorded shape and every execution replays it — per-invocation cost is zero.

The caller's early-resolve intent now survives into the recording, since that is the input being qualified, and is cleared on the way into the Definition instead. No in-graph task reaches the device carrying the bit, as before.

The device validates the flags but nothing propagates them to a slot, so **this half is inert on device**.

**A candidate's CSR row is sorted by ascending producer index.** The builder emits a producer before its consumers, so a sorted row's tail names its deepest producer — the entry a reverse scan should bet on. Non-candidate rows keep their record order, so a body with no early-resolve flags schedules exactly as it did before. That scoping is deliberate: an unconditional sort drifted flag-free workloads by ~0.5% in the qwen A/B done for #2095.

**`graph_first_unmet_producer` scans backward** to make that bet, which finishes #1924 — the top-level classifier was flipped then and its in-graph twin in the same file was not. It now resumes at a wake-scan cursor, and the drain routes a single-producer waiter straight to ready rather than rescanning a row whose only entry is the producer that just completed. Both reduce wake-list transfers and the CAS traffic they put on the lists.

Two mechanical consequences worth calling out in review:

- The classifier returns the consumer's own **CSR row index** rather than a producer index, since a row index is what a cursor can mean; `graph_producer_at` maps it back. All call sites move with it.
- `wake_scan_cursor` widens to `uint16_t`. An in-graph row is bounded by the in-graph task cap, not by `CHIP_MAX_FANIN`, so a byte would silently truncate on a large body. Its early-dispatch twin still indexes a payload's inline fanin alone and stays a byte, with a `static_assert` on each. `ChipTaskSlotState` remains one cache line.

## Testing

Re-verified after rebasing onto main now that #2130 has landed:

- [x] Simulation tests pass — a2a3 `host_build_graph` 12 passed / 7 skipped, a5 `host_build_graph` 13 passed
- [x] C++ unit tests — 137/137, including a new `test_hbg_graph_ed_qualification` (both arches) that drives the real recording path to pin the Definition's verdicts and a candidate's sorted row, and asserts a non-candidate row keeps its record order
- [x] Device A/B against `upstream/main`, 100 rounds, 8 cases, both arms sequential on pinned die 12, baseline built in its own worktree venv. Every device delta lands in -0.13% .. +0.44%, nothing near the 2% threshold, `qwen3_14b_decode` +0.01%. Full table in [this comment](https://github.com/hw-native-sys/simpler/pull/2144#issuecomment-5580444937).

  The direction flip is therefore device-neutral on this corpus, which is the honest claim — not that it helps. Worth reading alongside the coverage note above: until this PR no scene test produced an in-graph candidate, so every row the flip lands on today is one whose backward-scan rationale is heuristic rather than exact.

Checks made while reviewing the change, recorded so they need not be re-derived: the fanout CSR build and the device-side topology validation read a fanin row as an unordered set, so sorting has no positional reader; the cursor is reset per materialization by `reset_for_reuse`, so no stale cursor can survive into a later execution and shorten a scan.
