### PR TITLE
Fix: close profiler drain and mapping races

### DIFF
--- a/docs/dfx/profiling-framework.md
+++ b/docs/dfx/profiling-framework.md
@@ -406,7 +406,7 @@ mid-run by the framework.
 | `done_shards_[q]` | replenish | collector q | fixed-capacity SPSC ring |
 | `recycled_[shard][kind]` | drain shard at runtime | replenish | fixed-capacity SPSC ring; startup code may pop any shard before threads start |
 | `retired_[shard][kind]` | teardown | exceptional fallback paths | mutex-protected holding pool; not used by the hot recycle path |
-| `dev_to_host_` / block ranges | mgmt (`resolve_host_ptr`) | init/startup allocation | `mapping_mutex_`; collector touches it only in `release_owned_buffers` / `clear_mappings`, after `stop()` has joined mgmt |
+| `dev_to_host_` / block ranges | drain shards (`resolve_host_ptr`) | init/startup allocation, runtime replenish, teardown | shared `mapping_mutex_` for resolution; exclusive `mapping_mutex_` for mutation |
 | `MemoryOps` / `shared_mem_host_` / `device_id_` | both threads | start-only | `set_memory_context` is called once before threads spawn; read-only afterwards |
 | AICPU per-thread ready queues (`header->queues[q]`) | mgmt (head advance) | AICPU (tail advance) | `read_range_from_device` in split drain, then `write_range_to_device` for `queue_heads[q]` |
 | Per-instance `FreeQueue` | AICPU (head advance) | owning drain shard (tail advance) | SPSC ownership; host refreshes `head` before writing `buffer_ptrs[]` / `tail` |

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -69,8 +69,7 @@
  * SVM path).
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_BUFFER_POOL_MANAGER_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_HOST_BUFFER_POOL_MANAGER_H_
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -83,6 +82,7 @@
 #include <functional>
 #include <limits>
 #include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <type_traits>
 #include <unordered_map>
@@ -428,6 +428,7 @@ public:
      * HAL mappings are not touched.
      */
     void clear_mappings() {
+        std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
         for (auto &kv : dev_to_host_) {
             if (kv.second != nullptr && malloc_shadows_.erase(kv.second) > 0) {
                 std::free(kv.second);
@@ -454,6 +455,7 @@ public:
      */
     template <typename ReleaseFn>
     void release_all_owned(const ReleaseFn &release_fn) {
+        std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
         for (auto &shard_pools : recycled_) {
             for (auto &pool : shard_pools)
                 pool.clear();
@@ -759,7 +761,7 @@ public:
         }
         *host_ptr_out = host_ptr;
         {
-            std::scoped_lock<std::mutex> lock(mapping_mutex_);
+            std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
             dev_to_host_[dev_ptr] = host_ptr;
             block_ranges_.push_back(
                 BlockRange{
@@ -783,7 +785,7 @@ public:
         void *host_ptr = nullptr;
         bool free_host_shadow = false;
         {
-            std::scoped_lock<std::mutex> lock(mapping_mutex_);
+            std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
             auto it = dev_to_host_.find(release_ptr);
             host_ptr = (it != dev_to_host_.end()) ? it->second : nullptr;
             if (it != dev_to_host_.end()) {
@@ -804,7 +806,7 @@ public:
             ops_.free_(release_ptr);
         }
         {
-            std::scoped_lock<std::mutex> lock(mapping_mutex_);
+            std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
             released_allocations_.erase(release_ptr);
         }
         if (free_host_shadow) {
@@ -814,11 +816,12 @@ public:
 
     /**
      * Resolve a device pointer to the host-mapped pointer recorded at
-     * alloc_and_register_block / register_mapping time. Mappings are built
-     * during init/proactive refill and are immutable while mgmt/collector
-     * threads run, so this hot path is read-only and lock-free.
+     * alloc_and_register_block / register_mapping time. Runtime replenishment
+     * may grow the exact and range mappings while drain shards resolve buffers,
+     * so readers hold a shared lock across both lookups.
      */
     void *resolve_host_ptr(void *dev_ptr) const {
+        std::shared_lock<std::shared_mutex> lock(mapping_mutex_);
         const auto &exact_mappings = dev_to_host_;
         auto it = exact_mappings.find(dev_ptr);
         if (it != exact_mappings.end()) return it->second;
@@ -835,7 +838,7 @@ public:
      * to be able to resolve them later.
      */
     void register_mapping(void *dev_ptr, void *host_ptr) {
-        std::scoped_lock<std::mutex> lock(mapping_mutex_);
+        std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
         dev_to_host_[dev_ptr] = host_ptr;
     }
 
@@ -847,7 +850,7 @@ public:
      */
     void add_malloc_shadow(void *host_ptr) {
         if (host_ptr != nullptr) {
-            std::scoped_lock<std::mutex> lock(mapping_mutex_);
+            std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
             malloc_shadows_.insert(host_ptr);
         }
     }
@@ -966,7 +969,7 @@ public:
      * the pointer itself.
      */
     void *release_pointer_for(void *dev_ptr) const {
-        std::scoped_lock<std::mutex> lock(mapping_mutex_);
+        std::shared_lock<std::shared_mutex> lock(mapping_mutex_);
         return allocation_base_for_locked(dev_ptr);
     }
 
@@ -976,7 +979,7 @@ public:
      */
     bool claim_release_pointer(void *dev_ptr, void **release_ptr_out) {
         if (release_ptr_out == nullptr) return false;
-        std::scoped_lock<std::mutex> lock(mapping_mutex_);
+        std::unique_lock<std::shared_mutex> lock(mapping_mutex_);
         void *release_ptr = tracked_allocation_base_for_locked(dev_ptr);
         if (release_ptr == nullptr) {
             *release_ptr_out = nullptr;
@@ -1108,7 +1111,7 @@ private:
     std::array<DoneQueueShard, kMaxCollectorShards> done_shards_;
 
     // Host-side pointer mappings are shared across all collector shards.
-    mutable std::mutex mapping_mutex_;
+    mutable std::shared_mutex mapping_mutex_;
 
     // dev → host exact mappings plus block ranges for carved buffers.
     std::unordered_map<void *, void *> dev_to_host_;
@@ -1130,5 +1133,3 @@ private:
 };
 
 }  // namespace profiling_common
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_BUFFER_POOL_MANAGER_H_

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -190,8 +190,7 @@
  *       Used in the idle-timeout log line (e.g. "ChipSwimlane", "PMU", "ArgsDump").
  */
 
-#ifndef SRC_COMMON_PLATFORM_INCLUDE_HOST_PROFILER_BASE_H_
-#define SRC_COMMON_PLATFORM_INCLUDE_HOST_PROFILER_BASE_H_
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -1188,6 +1187,8 @@ private:
         int idle_busy_polls = 0;
 
         while (mgmt_running_.load(std::memory_order_relaxed)) {
+            // An ack covers only a sweep that starts after this epoch is observed.
+            const uint64_t requested = drain_quiesce_epoch_.load(std::memory_order_acquire);
             bool found_any = false;
             for (int q = queue_start; q < queue_count_; q += queue_stride) {
                 ReadyEntry entry;
@@ -1205,7 +1206,6 @@ private:
             // precondition) nothing can arrive behind this report, so it is the
             // quiescent condition for phase one.
             if (!found_any) {
-                const uint64_t requested = drain_quiesce_epoch_.load(std::memory_order_acquire);
                 if (drain_acked_[queue_start].load(std::memory_order_relaxed) != requested) {
                     drain_acked_[queue_start].store(requested, std::memory_order_release);
                 }
@@ -1359,5 +1359,3 @@ private:
 };
 
 }  // namespace profiling_common
-
-#endif  // SRC_COMMON_PLATFORM_INCLUDE_HOST_PROFILER_BASE_H_

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -953,6 +953,68 @@ TEST(BufferPoolManagerShardingTest, BlockBatchCarvesRangeMappingsAndReleasesBase
     manager.clear_mappings();
 }
 
+TEST(BufferPoolManagerShardingTest, ConcurrentBlockRegistrationAndResolutionPreservesMappings) {
+    using Manager = profiling_common::BufferPoolManager<TestModule>;
+
+    Manager manager;
+    profiling_common::MemoryOps ops;
+    ops.alloc = [](size_t size) {
+        return std::malloc(size);
+    };
+    ops.reg = [](void *dev_ptr, size_t /*size*/, int /*device_id*/, void **host_ptr_out) {
+        *host_ptr_out = dev_ptr;
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, nullptr, 0, 0);
+
+    void *stable_host = nullptr;
+    void *stable_dev = manager.alloc_and_register_block(64, &stable_host);
+    ASSERT_NE(stable_dev, nullptr);
+    ASSERT_EQ(stable_host, stable_dev);
+    void *inner_dev = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(stable_dev) + 1);
+    void *inner_host = reinterpret_cast<void *>(reinterpret_cast<uintptr_t>(stable_host) + 1);
+
+    std::atomic<int> readers_ready{0};
+    std::atomic<bool> start{false};
+    std::atomic<bool> writer_done{false};
+    std::atomic<int> failures{0};
+    auto resolve_until_done = [&](void *dev_ptr, void *expected_host_ptr) {
+        readers_ready.fetch_add(1, std::memory_order_release);
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        do {
+            if (manager.resolve_host_ptr(dev_ptr) != expected_host_ptr) {
+                failures.fetch_add(1, std::memory_order_relaxed);
+            }
+            std::this_thread::yield();
+        } while (!writer_done.load(std::memory_order_acquire));
+    };
+
+    std::thread exact_reader(resolve_until_done, stable_dev, stable_host);
+    std::thread range_reader(resolve_until_done, inner_dev, inner_host);
+    while (readers_ready.load(std::memory_order_acquire) != 2) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+
+    constexpr int kAdditionalBlocks = 2048;
+    for (int i = 0; i < kAdditionalBlocks; i++) {
+        void *host_ptr = nullptr;
+        if (manager.alloc_and_register_block(64, &host_ptr) == nullptr || host_ptr == nullptr) {
+            failures.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    writer_done.store(true, std::memory_order_release);
+    exact_reader.join();
+    range_reader.join();
+
+    EXPECT_EQ(failures.load(std::memory_order_relaxed), 0);
+    manager.release_all_owned([](void *p) {
+        std::free(p);
+    });
+}
+
 TEST(BufferPoolManagerShardingTest, FreeBufferAllowsAllocationAddressReuse) {
     using Manager = profiling_common::BufferPoolManager<TestModule>;
 

--- a/tests/ut/cpp/common/test_profiler_base.cpp
+++ b/tests/ut/cpp/common/test_profiler_base.cpp
@@ -27,10 +27,14 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <functional>
+#include <mutex>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace {
@@ -130,13 +134,14 @@ public:
 
     // Stand-in for a real Derived::init(): latch the thread count and hand the
     // base an identity-mapped (SVM-style) memory context.
-    void init(int aicpu_thread_num, void *shm) {
+    void
+    init(int aicpu_thread_num, void *shm, std::function<int(void *, const void *, size_t)> copy_from_device = nullptr) {
         this->set_aicpu_thread_num(aicpu_thread_num);
         this->set_memory_context(
             [](size_t size) {
                 return std::malloc(size);
             },
-            /*register_cb=*/nullptr, /*free_cb=*/nullptr, /*copy_to_device=*/nullptr, /*copy_from_device=*/nullptr, shm,
+            /*register_cb=*/nullptr, /*free_cb=*/nullptr, /*copy_to_device=*/nullptr, std::move(copy_from_device), shm,
             shm, sizeof(TestHeader), /*device_id=*/0
         );
     }
@@ -147,16 +152,18 @@ private:
     std::atomic<int> last_shard_{-1};
 };
 
-// Publish one buffer on device queue `q`, exactly as DeviceProfilerEngine's
-// enqueue_ready does: write the entry, then advance the tail. The buffer must
-// already be known to the manager — process_entry drops any entry whose device
-// pointer has no host mapping.
+// The buffer mapping is immutable while collector threads run.
 template <typename Collector>
-void publish(Collector &collector, TestHeader &header, int q, uint64_t *buffer) {
+void register_buffer(Collector &collector, uint64_t *buffer) {
     collector.manager().register_mapping(buffer, buffer);  // SVM-style identity map
+}
+
+// Publish one buffer on device queue `q` with DeviceProfilerEngine's entry-before-tail ordering.
+void publish(TestHeader &header, int q, uint64_t *buffer) {
     uint32_t tail = header.queue_tails[q];
     header.queues[q][tail].buffer_ptr = reinterpret_cast<uint64_t>(buffer);
     header.queues[q][tail].buffer_seq = 0;
+    wmb();
     header.queue_tails[q] = (tail + 1) % kReadyQueueSize;
 }
 
@@ -205,9 +212,10 @@ TEST(ProfilerBaseTest, SingleDrainThreadScansEveryLiveQueue) {
     TestCollector<SingleShardModule> collector;
     collector.init(kThreads, &header);
     ASSERT_EQ(collector.manager().shard_count(), 1);
+    register_buffer(collector, &buffer);
 
     collector.start(nullptr);
-    publish(collector, header, kOrchQueue, &buffer);
+    publish(header, kOrchQueue, &buffer);
 
     EXPECT_TRUE(wait_for_collected(collector, 1, std::chrono::seconds(5)));
     collector.stop();
@@ -226,10 +234,13 @@ TEST(ProfilerBaseTest, EveryLiveQueueIsDrained) {
 
     TestCollector<PerThreadModule> collector;
     collector.init(kThreads, &header);
+    for (int q = 0; q < kThreads; q++) {
+        register_buffer(collector, &buffers[q]);
+    }
     collector.start(nullptr);
 
     for (int q = 0; q < kThreads; q++) {
-        publish(collector, header, q, &buffers[q]);
+        publish(header, q, &buffers[q]);
     }
 
     EXPECT_TRUE(wait_for_collected(collector, kThreads, std::chrono::seconds(5)));
@@ -245,15 +256,16 @@ TEST(ProfilerBaseTest, EveryLiveQueueIsDrained) {
 // a regression shows up as a hang or an early-abandoned shard, not a flake.
 TEST(ProfilerBaseTest, SilentRunDoesNotTripIdleTimeout) {
     TestHeader header{};
+    uint64_t buffer = 0;
     TestCollector<SingleShardModule> collector;
     collector.init(2, &header);
+    register_buffer(collector, &buffer);
 
     collector.start(nullptr);
     std::this_thread::sleep_for(std::chrono::seconds(3));  // > kIdleTimeoutSec
 
     // The collector must still be alive and able to take a late buffer.
-    uint64_t buffer = 0;
-    publish(collector, header, 1, &buffer);
+    publish(header, 1, &buffer);
     EXPECT_TRUE(wait_for_collected(collector, 1, std::chrono::seconds(5)));
 
     collector.stop();
@@ -264,20 +276,22 @@ TEST(ProfilerBaseTest, CollectorStaysAliveAfterArmedIdleTimeout) {
     using namespace std::chrono_literals;
 
     TestHeader header{};
+    uint64_t first_buffer = 0;
+    uint64_t late_buffer = 0;
     TestCollector<SingleShardModule, 0> collector;
     collector.init(2, &header);
+    register_buffer(collector, &first_buffer);
+    register_buffer(collector, &late_buffer);
     collector.start(nullptr);
 
-    uint64_t first_buffer = 0;
-    publish(collector, header, 1, &first_buffer);
+    publish(header, 1, &first_buffer);
     EXPECT_TRUE(wait_for_collected(collector, 1, 5s));
 
     // Once traffic has armed the idle detector, a zero-second timeout fires on
     // the next empty poll. The collector must report it without exiting.
     std::this_thread::sleep_for(250ms);
 
-    uint64_t late_buffer = 0;
-    publish(collector, header, 1, &late_buffer);
+    publish(header, 1, &late_buffer);
     EXPECT_TRUE(wait_for_collected(collector, 2, 5s));
 
     collector.stop();
@@ -297,10 +311,14 @@ TEST(ProfilerBaseTest, QuiesceDrainsWithoutRetiringThreads) {
 
     TestCollector<PerThreadModule> collector;
     collector.init(kThreads, &header);
+    for (int q = 0; q < kThreads; q++) {
+        register_buffer(collector, &first[q]);
+        register_buffer(collector, &second[q]);
+    }
     collector.start(nullptr);
 
     for (int q = 0; q < kThreads; q++) {
-        publish(collector, header, q, &first[q]);
+        publish(header, q, &first[q]);
     }
     collector.quiesce();
     // No wait_for_collected here on purpose: quiesce() must have delivered
@@ -309,7 +327,7 @@ TEST(ProfilerBaseTest, QuiesceDrainsWithoutRetiringThreads) {
     EXPECT_EQ(collector.collected(), kThreads);
 
     for (int q = 0; q < kThreads; q++) {
-        publish(collector, header, q, &second[q]);
+        publish(header, q, &second[q]);
     }
     collector.quiesce();
     EXPECT_EQ(collector.collected(), 2 * kThreads);
@@ -318,22 +336,124 @@ TEST(ProfilerBaseTest, QuiesceDrainsWithoutRetiringThreads) {
     EXPECT_EQ(collector.collected(), 2 * kThreads);
 }
 
+TEST(ProfilerBaseTest, QuiesceAcknowledgementRequiresPostRequestSweep) {
+    using namespace std::chrono_literals;
+
+    TestHeader header{};
+    uint64_t buffer = 0;
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    int queue_zero_reads = 0;
+    bool first_sweep_paused = false;
+    bool second_sweep_paused = false;
+    bool release_first_sweep = false;
+    bool release_second_sweep = false;
+
+    auto gated_copy = [&](void * /*dst*/, const void *src, size_t /*size*/) {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        if (src == &header.queue_heads[0]) {
+            queue_zero_reads++;
+            if (queue_zero_reads == 2) {
+                second_sweep_paused = true;
+                gate_cv.notify_all();
+                gate_cv.wait(lock, [&]() {
+                    return release_second_sweep;
+                });
+            }
+        } else if (src == &header.queue_heads[1] && !first_sweep_paused) {
+            first_sweep_paused = true;
+            gate_cv.notify_all();
+            gate_cv.wait(lock, [&]() {
+                return release_first_sweep;
+            });
+        }
+        return 0;
+    };
+
+    TestCollector<SingleShardModule> collector;
+    collector.init(2, &header, gated_copy);
+    register_buffer(collector, &buffer);
+    collector.start(nullptr);
+
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        if (!gate_cv.wait_for(lock, 2s, [&]() {
+                return first_sweep_paused;
+            })) {
+            release_first_sweep = true;
+            release_second_sweep = true;
+            lock.unlock();
+            gate_cv.notify_all();
+            collector.stop();
+            FAIL() << "drain did not reach the first sweep gate";
+        }
+    }
+
+    // Queue zero is published only after this sweep has already observed it empty.
+    publish(header, 0, &buffer);
+    std::atomic<bool> quiesce_started{false};
+    std::atomic<bool> quiesce_done{false};
+    std::thread quiesce_thread([&]() {
+        quiesce_started.store(true, std::memory_order_release);
+        collector.quiesce();
+        quiesce_done.store(true, std::memory_order_release);
+    });
+    while (!quiesce_started.load(std::memory_order_acquire)) {
+        std::this_thread::yield();
+    }
+    std::this_thread::sleep_for(100ms);
+
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_first_sweep = true;
+    }
+    gate_cv.notify_all();
+
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        if (!gate_cv.wait_for(lock, 2s, [&]() {
+                return second_sweep_paused;
+            })) {
+            release_second_sweep = true;
+            lock.unlock();
+            gate_cv.notify_all();
+            quiesce_thread.join();
+            collector.stop();
+            FAIL() << "drain did not reach the post-request sweep gate";
+        }
+    }
+
+    std::this_thread::sleep_for(250ms);
+    const bool completed_before_post_request_sweep = quiesce_done.load(std::memory_order_acquire);
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_second_sweep = true;
+    }
+    gate_cv.notify_all();
+
+    quiesce_thread.join();
+    EXPECT_FALSE(completed_before_post_request_sweep);
+    EXPECT_EQ(collector.collected(), 1);
+    collector.stop();
+}
+
 // A subsystem that emitted nothing still has to complete the handshake. The
 // collector loop skips its idle bookkeeping for a shard that has never seen a
 // buffer, so an ack placed behind that guard would leave quiesce() waiting
 // forever on a silent run — a hang, not a wrong count.
 TEST(ProfilerBaseTest, QuiesceCompletesOnASilentCollector) {
     TestHeader header{};
+    uint64_t buffer = 0;
     TestCollector<SingleShardModule> collector;
     collector.init(2, &header);
+    register_buffer(collector, &buffer);
     collector.start(nullptr);
 
     collector.quiesce();
     EXPECT_EQ(collector.collected(), 0);
 
     // Still live afterwards.
-    uint64_t buffer = 0;
-    publish(collector, header, 1, &buffer);
+    publish(header, 1, &buffer);
     collector.quiesce();
     EXPECT_EQ(collector.collected(), 1);
 


### PR DESCRIPTION
## Problem

Runtime replenishment can append to `dev_to_host_` and `block_ranges_`
while drain shards call `resolve_host_ptr()`. The writer held
`mapping_mutex_`, but the reader relied on an invalid immutability assumption,
so container rehash or reallocation could race with lookup.

The drain loop also loaded the requested quiesce epoch after scanning its
queues. A sweep that began before the request could therefore acknowledge the
new epoch and let export begin before records published during that sweep were
drained.

Follow-up to #2127.

## Changes

- Protect exact and block-range resolution with a shared mapping lock while
  keeping runtime mutation under the exclusive lock.
- Observe the requested quiesce epoch before each full drain sweep and only
  acknowledge that epoch after the sweep reports no work.
- Add concurrent exact/range mapping coverage and a gated regression test for
  the stale-sweep acknowledgement ordering.
- Make the test publisher follow device entry-before-tail ordering, document
  the mapping ownership contract, and apply the repository's `#pragma once`
  convention to the touched headers.

## Reviewer guide

The main correctness boundaries are the lifetime of the shared mapping lock in
`resolve_host_ptr()` and the placement of the acquire-load before the complete
queue sweep in `mgmt_drain_loop()`.

## Testing

- [x] Full no-hardware C++ unit suite: 135/135 passed
- [x] `test_profiler_base`: 10/10 passed
- [x] New quiesce regression: old implementation failed; fixed implementation
  passed 20 consecutive runs
- [x] Concurrent mapping test passed under ThreadSanitizer
- [x] Concurrent mapping test passed 50 consecutive runs
