### PR TITLE
Fix: 修正单元素维 stride 的连续性判定

### DIFF
--- a/docs/buffer-abi.md
+++ b/docs/buffer-abi.md
@@ -122,7 +122,12 @@ chip runtime, so neither an L3 builder nor an L2 caller has anything to put ther
 they live on `simpler::{hbg,tmr}::Tensor`, which `Runtime::set_orch_args` adopts
 each argument into. The same goes for `is_contiguous` and `extent_elem_cache`:
 derived from `shapes`/`strides`, and cached only where a hot path reads them per
-task.
+task. Contiguity follows PyTorch's rule for nonempty tensors: dimensions of
+size one do not constrain their stride. For example, shape `(64, 1)` with
+strides `(1, 64)` is contiguous and permits a zero-copy runtime reshape;
+strides `(2, 64)` still describe gapped storage. The boundary descriptor,
+runtime caches, and HBG graph validation use the same rule. The contiguity
+checks do not rewrite strides or change the storage extent.
 
 So a merged struct would carry ~70 B that the AICore never reads, in a type whose
 size is pinned at two cache lines precisely because the scheduler walks it per

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -306,7 +306,7 @@ inline bool graph_tensor_wire_valid(const GraphTensor &tensor) {
         const uint64_t shape = tensor.shapes[i];
         const uint64_t stride = tensor.strides[i];
         if (shape == 0 || stride == 0) return false;
-        contiguous &= stride == expected_stride;
+        contiguous &= shape == 1 || stride == expected_stride;
         if (shape - 1 > (UINT64_MAX - extent) / stride || expected_stride > UINT64_MAX / shape) return false;
         extent += (shape - 1) * stride;
         expected_stride *= shape;

--- a/src/common/host_build_graph/tensor.h
+++ b/src/common/host_build_graph/tensor.h
@@ -53,7 +53,8 @@ namespace simpler::hbg {
  * Fast-path flags on cache line 1:
  *   - manual_dep: when true, dependency tracking is creator-only (skip OverlapMap)
  *   - is_contiguous: cached PyTorch-style contiguous flag — i.e.
- *     `strides[i] == prod(shapes[i+1..ndims-1])`. When true AND start_offset==0,
+ *     `strides[i] == prod(shapes[i+1..ndims-1])` for dimensions of size > 1.
+ *     Singleton strides do not affect contiguity. When true AND start_offset==0,
  *     all hot paths can compute extent_elem from `shapes` alone and never read
  *     cache line 2. NOTE: this is strictly tighter than the pre-#808
  *     `shapes[i] == raw_shapes[i]` test, but equivalent on every view the old
@@ -83,7 +84,7 @@ struct alignas(64) Tensor {
     uint32_t ndims;                    // Number of dimensions used
     DataType dtype;                    // Data type of tensor elements
     bool manual_dep;                   // True when dependency tracking is creator-only (skip OverlapMap lookup/insert)
-    bool is_contiguous;                // Cached: strides[] == row_major_stride(shapes)
+    bool is_contiguous;                // Cached row-major contiguity, ignoring singleton strides
     AddressSpace address_space;        // HOST (default) or DEVICE (child-managed device memory; skips H2D copy)
     uint32_t shapes[MAX_TENSOR_DIMS];  // Current view shape per dimension (elements)
 
@@ -482,13 +483,13 @@ private:
     /// Recompute extent_elem_cache and is_contiguous from current shapes / stride.
     /// Called after any op that mutates view metadata. Single reverse pass:
     ///   extent_elem += (shapes[i] - 1) · strides[i]
-    ///   is_contiguous &&= (strides[i] == prod(shapes[i+1..]))
+    ///   is_contiguous &&= (shapes[i] == 1 || strides[i] == prod(shapes[i+1..]))
     void refresh_derived() {
         uint64_t e = 1;
         uint64_t expected = 1;
         bool contig = true;
         for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
-            if (strides[i] != expected) contig = false;
+            if (shapes[i] != 1 && strides[i] != expected) contig = false;
             if (shapes[i] > 0) {
                 e += static_cast<uint64_t>(shapes[i] - 1) * static_cast<uint64_t>(strides[i]);
             }

--- a/src/common/task_interface/tensor.h
+++ b/src/common/task_interface/tensor.h
@@ -113,11 +113,11 @@ struct ChipTensor {
         return last + 1;
     }
 
-    /// PyTorch-style contiguity: strides[i] == prod(shapes[i+1..ndims-1]).
+    /// PyTorch-style contiguity: only dimensions of size > 1 must have row-major strides.
     [[nodiscard]] bool is_contiguous() const {
         uint64_t expected = 1;
         for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
-            if (strides[i] != expected) return false;
+            if (shapes[i] != 1 && strides[i] != expected) return false;
             expected *= shapes[i];
         }
         return true;

--- a/src/common/tensormap_and_ringbuffer/tensor.h
+++ b/src/common/tensormap_and_ringbuffer/tensor.h
@@ -55,7 +55,8 @@ namespace simpler::tmr {
  * Fast-path flags on cache line 1:
  *   - manual_dep: when true, dependency tracking is creator-only (skip OverlapMap)
  *   - is_contiguous: cached PyTorch-style contiguous flag — i.e.
- *     `strides[i] == prod(shapes[i+1..ndims-1])`. When true AND start_offset==0,
+ *     `strides[i] == prod(shapes[i+1..ndims-1])` for dimensions of size > 1.
+ *     Singleton strides do not affect contiguity. When true AND start_offset==0,
  *     all hot paths can compute extent_elem from `shapes` alone and never read
  *     cache line 2. NOTE: this is strictly tighter than the pre-#808
  *     `shapes[i] == raw_shapes[i]` test, but equivalent on every view the old
@@ -85,7 +86,7 @@ struct alignas(64) Tensor {
     uint32_t ndims;                    // Number of dimensions used
     DataType dtype;                    // Data type of tensor elements
     bool manual_dep;                   // True when dependency tracking is creator-only (skip OverlapMap lookup/insert)
-    bool is_contiguous;                // Cached: strides[] == row_major_stride(shapes)
+    bool is_contiguous;                // Cached row-major contiguity, ignoring singleton strides
     AddressSpace address_space;        // HOST (default) or DEVICE (child-managed device memory; skips H2D copy)
     uint32_t shapes[MAX_TENSOR_DIMS];  // Current view shape per dimension (elements)
 
@@ -484,13 +485,13 @@ private:
     /// Recompute extent_elem_cache and is_contiguous from current shapes / stride.
     /// Called after any op that mutates view metadata. Single reverse pass:
     ///   extent_elem += (shapes[i] - 1) · strides[i]
-    ///   is_contiguous &&= (strides[i] == prod(shapes[i+1..]))
+    ///   is_contiguous &&= (shapes[i] == 1 || strides[i] == prod(shapes[i+1..]))
     void refresh_derived() {
         uint64_t e = 1;
         uint64_t expected = 1;
         bool contig = true;
         for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
-            if (strides[i] != expected) contig = false;
+            if (shapes[i] != 1 && strides[i] != expected) contig = false;
             if (shapes[i] > 0) {
                 e += static_cast<uint64_t>(shapes[i] - 1) * static_cast<uint64_t>(strides[i]);
             }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -517,6 +517,14 @@ add_task_interface_test(test_buffer types/test_buffer.cpp)
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
+add_task_interface_test(test_tmr_tensor_contiguity types/test_tmr_tensor_contiguity.cpp)
+target_include_directories(test_tmr_tensor_contiguity PRIVATE ${CMAKE_SOURCE_DIR}/../../../src/common)
+add_task_interface_test(test_tensor_contiguity types/test_tensor_contiguity.cpp)
+target_include_directories(test_tensor_contiguity PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/host_build_graph
+)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/types/test_tensor_contiguity.cpp
+++ b/tests/ut/cpp/types/test_tensor_contiguity.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "host_build_graph/graph_execution.h"
+#include "host_build_graph/tensor.h"
+#include "task_interface/tensor.h"
+
+[[noreturn]] void assert_impl(const char *, const char *, int) { std::abort(); }
+
+namespace {
+
+TEST(ChipTensorContiguity, SingletonStridesDoNotChangeStorageExtent) {
+    const uint32_t shapes[] = {1, 64, 1};
+    const uint32_t strides[] = {999, 1, 64};
+    const auto tensor = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 3);
+    EXPECT_TRUE(tensor.is_contiguous());
+    EXPECT_EQ(tensor.extent_elem(), 64U);
+    EXPECT_EQ(tensor.buffer.size, 64U * sizeof(float));
+    EXPECT_EQ(tensor.strides[0], 999U);
+    EXPECT_EQ(tensor.strides[2], 64U);
+}
+
+TEST(ChipTensorContiguity, SingletonDoesNotHideGappedStorage) {
+    const uint32_t shapes[] = {64, 1};
+    const uint32_t strides[] = {2, 64};
+    const auto tensor = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 2);
+    EXPECT_FALSE(tensor.is_contiguous());
+    EXPECT_EQ(tensor.extent_elem(), 127U);
+    EXPECT_EQ(tensor.buffer.size, 127U * sizeof(float));
+}
+
+TEST(HbgTensorContiguity, BoundarySingletonStridesAllowZeroCopyReshape) {
+    const uint32_t shapes[] = {1, 64, 1};
+    const uint32_t strides[] = {999, 1, 64};
+    const auto arg = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 3);
+    const auto tensor = simpler::hbg::Tensor::from_boundary(arg);
+    ASSERT_TRUE(tensor.is_contiguous);
+    EXPECT_EQ(tensor.extent_elem_cache, 64U);
+    EXPECT_EQ(tensor.strides[0], 999U);
+    EXPECT_EQ(tensor.strides[2], 64U);
+    const uint32_t reshaped[] = {1, 64};
+    const auto view = tensor.reshape(reshaped, 2);
+    EXPECT_EQ(view.buffer.addr, arg.buffer.addr);
+    EXPECT_EQ(view.start_offset, arg.start_offset);
+    EXPECT_EQ(view.strides[0], 64U);
+    EXPECT_EQ(view.strides[1], 1U);
+    EXPECT_TRUE(view.to_boundary().is_contiguous());
+}
+
+TEST(HbgTensorContiguity, TransposedColumnAllowsZeroCopyReshape) {
+    const uint32_t shapes[] = {1, 64};
+    const auto arg = make_tensor_external(reinterpret_cast<void *>(0x1000), shapes, 2);
+    const auto tensor = simpler::hbg::Tensor::from_boundary(arg).transpose(0, 1);
+    ASSERT_EQ(tensor.shapes[0], 64U);
+    ASSERT_EQ(tensor.shapes[1], 1U);
+    ASSERT_EQ(tensor.strides[0], 1U);
+    ASSERT_EQ(tensor.strides[1], 64U);
+    ASSERT_TRUE(tensor.is_contiguous);
+    const uint32_t reshaped[] = {64};
+    const auto view = tensor.reshape(reshaped, 1);
+    EXPECT_EQ(view.buffer.addr, arg.buffer.addr);
+    EXPECT_EQ(view.numel(), 64U);
+}
+
+TEST(HbgTensorContiguity, SingletonDoesNotAllowReshapingGappedStorage) {
+    const uint32_t shapes[] = {64, 1};
+    const uint32_t strides[] = {2, 64};
+    const auto arg = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 2);
+    const auto tensor = simpler::hbg::Tensor::from_boundary(arg);
+    EXPECT_FALSE(tensor.is_contiguous);
+    EXPECT_EQ(tensor.extent_elem_cache, 127U);
+    const uint32_t reshaped[] = {64};
+    EXPECT_DEATH(tensor.reshape(reshaped, 1), "");
+}
+
+TEST(GraphTensorContiguity, AcceptsSingletonStridesAndRejectsForgedFlag) {
+    const uint32_t shapes[] = {64, 1};
+    const uint32_t strides[] = {1, 64};
+    const auto arg = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 2);
+    auto packed = graph_tensor_pack(simpler::hbg::Tensor::from_boundary(arg));
+    packed.is_contiguous = 1;
+    EXPECT_TRUE(graph_tensor_wire_valid(packed));
+    packed.is_contiguous = 0;
+    EXPECT_FALSE(graph_tensor_wire_valid(packed));
+}
+
+TEST(GraphTensorContiguity, SingletonDoesNotHideGapsOrInvalidExtent) {
+    const uint32_t shapes[] = {64, 1};
+    const uint32_t strides[] = {2, 64};
+    const auto arg = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 2);
+    auto packed = graph_tensor_pack(simpler::hbg::Tensor::from_boundary(arg));
+    ASSERT_TRUE(graph_tensor_wire_valid(packed));
+    packed.is_contiguous = 1;
+    EXPECT_FALSE(graph_tensor_wire_valid(packed));
+    packed.is_contiguous = 0;
+    packed.extent_elem = 64;
+    EXPECT_FALSE(graph_tensor_wire_valid(packed));
+}
+
+}  // namespace

--- a/tests/ut/cpp/types/test_tmr_tensor_contiguity.cpp
+++ b/tests/ut/cpp/types/test_tmr_tensor_contiguity.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "task_interface/tensor.h"
+#include "tensormap_and_ringbuffer/tensor.h"
+
+[[noreturn]] void assert_impl(const char *, const char *, int) { std::abort(); }
+
+namespace {
+
+TEST(TmrTensorContiguity, BoundarySingletonStridesAllowZeroCopyReshape) {
+    const uint32_t shapes[] = {1, 64, 1};
+    const uint32_t strides[] = {999, 1, 64};
+    const auto arg = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 3);
+    const auto tensor = simpler::tmr::Tensor::from_boundary(arg);
+    ASSERT_TRUE(tensor.is_contiguous);
+    EXPECT_EQ(tensor.extent_elem_cache, 64U);
+    EXPECT_EQ(tensor.strides[0], 999U);
+    EXPECT_EQ(tensor.strides[2], 64U);
+    const uint32_t reshaped[] = {1, 64};
+    const auto view = tensor.reshape(reshaped, 2);
+    EXPECT_EQ(view.buffer.addr, arg.buffer.addr);
+    EXPECT_EQ(view.start_offset, arg.start_offset);
+    EXPECT_EQ(view.strides[0], 64U);
+    EXPECT_EQ(view.strides[1], 1U);
+    EXPECT_TRUE(view.to_boundary().is_contiguous());
+}
+
+TEST(TmrTensorContiguity, TransposedColumnAllowsZeroCopyReshape) {
+    const uint32_t shapes[] = {1, 64};
+    const auto arg = make_tensor_external(reinterpret_cast<void *>(0x1000), shapes, 2);
+    const auto tensor = simpler::tmr::Tensor::from_boundary(arg).transpose(0, 1);
+    ASSERT_EQ(tensor.shapes[0], 64U);
+    ASSERT_EQ(tensor.shapes[1], 1U);
+    ASSERT_EQ(tensor.strides[0], 1U);
+    ASSERT_EQ(tensor.strides[1], 64U);
+    ASSERT_TRUE(tensor.is_contiguous);
+    const uint32_t reshaped[] = {64};
+    const auto view = tensor.reshape(reshaped, 1);
+    EXPECT_EQ(view.buffer.addr, arg.buffer.addr);
+    EXPECT_EQ(view.numel(), 64U);
+}
+
+TEST(TmrTensorContiguity, SingletonDoesNotAllowReshapingGappedStorage) {
+    const uint32_t shapes[] = {64, 1};
+    const uint32_t strides[] = {2, 64};
+    const auto arg = make_tensor_strided(reinterpret_cast<void *>(0x1000), shapes, strides, 2);
+    const auto tensor = simpler::tmr::Tensor::from_boundary(arg);
+    EXPECT_FALSE(tensor.is_contiguous);
+    EXPECT_EQ(tensor.extent_elem_cache, 127U);
+    const uint32_t reshaped[] = {64};
+    EXPECT_DEATH(tensor.reshape(reshaped, 1), "");
+}
+
+}  // namespace


### PR DESCRIPTION
shape=(64, 1)、stride=(1, 64) 是合法连续列向量，但上游将
单元素维的 stride 与行主序期望值比较，导致 ChipTensor 及
HBG/TMR Tensor 误判为不连续，零拷贝 reshape 随之触发断言。

- 公共 ChipTensor 和 HBG/TMR 派生缓存统一忽略 size=1 维的 stride；其他维度继续严格检查，保持存储跨度与 ABI 不变。
- HBG 图元数据校验使用相同规则，继续拒绝伪造连续标志、 跨步存储的错误标志及错误 extent，避免合法图记录被拒绝。
- 增加 10 项 C++ 回归，覆盖外部参数转换、转置列向量、 零拷贝 reshape、真实空隙拒绝及图元数据校验；更新 ABI 文档。

上游验证：
- PyPTO 747e1e4 固定 runtime 4e4d3a4 与 simpler 主线 d79c88c 均能复现：新增 10 项用例中 6 项失败、4 项通过。
- 修复后新增 10 项全部通过；同时运行既有 buffer 和 child_memory 的 23 项用例，总计 33 项通过。
- 使用当前独立工作树重新编译 CPU C++ 测试，无需 NPU。 本分支未执行 A5 真机、Python 套件或完整系统回归。

这是 0b852b1 修复语义在上游重构后的 Tensor 架构上的适配。
分支直接基于上游主线，不包含 fork 中其他 A5 L1 功能修改。