### PR TITLE
Fix: bound the DFX pop gate when the host never opens the freeze

### DIFF
--- a/src/common/platform/include/aicpu/profiler_device_engine.h
+++ b/src/common/platform/include/aicpu/profiler_device_engine.h
@@ -98,10 +98,16 @@ struct DeviceProfilerEngine {
         //    observes the signal and opens the freeze, the barrier sees
         //    fq_freeze_active==0 and returns at once, so this loop re-checks and
         //    bridges the host round-trip. Once frozen, the barrier spins here
-        //    until release; its timeout arms only then and is the sole give-up
-        //    (host dead/hung mid-freeze).
+        //    until release.
         // 4. Freeze released -> loop re-checks and picks up the refilled slot.
+        //
+        // The barrier's own timeout covers only step 3's park, so it cannot bound
+        // a wait the host never freezes at all. `wait_start` is this wait's single
+        // budget across every iteration, matching the ready-queue gate above, and
+        // is what makes the give-up unconditional: a host that dies before it ever
+        // answers the leader signal leaves fq_freeze_active at 0 forever.
         bool contended_signalled = false;
+        const uint64_t wait_start = get_sys_cnt_aicpu();
 
         do {
             // Step 1: Check FQ slot availability
@@ -118,9 +124,13 @@ struct DeviceProfilerEngine {
             dfx_backpressure::mark_fq_contended(header, &contended_signalled);
 
             // Step 3: Park while the host holds the freeze open; returns at once
-            // when it is not open. Timeout fires only while frozen.
+            // when it is not open.
             if (!dfx_backpressure::pop_freeze_barrier(header, Module::kBackpressureWaitCycles)) {
                 break;  // gate timeout — fall through to the single failure exit below
+            }
+
+            if (get_sys_cnt_aicpu() - wait_start >= Module::kBackpressureWaitCycles) {
+                break;  // whole-wait deadline — same exit
             }
 
             // Step 4: Gate not held (never opened yet, or released) — re-check the

--- a/tests/ut/cpp/common/test_profiler_device_engine.cpp
+++ b/tests/ut/cpp/common/test_profiler_device_engine.cpp
@@ -13,7 +13,10 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <cstdint>
+#include <thread>
 
 namespace {
 
@@ -204,6 +207,46 @@ TEST(ProfilerDeviceEngineTest, WaitForReleaseUsesCallerTimeoutBudget) {
     header.backpressure.fq_contended = 0;
     EXPECT_TRUE(dfx_backpressure::wait_for_release(&header, get_sys_cnt_aicpu(), 0));
     EXPECT_TRUE(dfx_backpressure::wait_for_release<FakeHeader>(nullptr, get_sys_cnt_aicpu(), 0));
+}
+
+// The pop gate's own barrier parks only while `fq_freeze_active` is set, so it
+// cannot bound a wait the host never answers. This is the deadline that spans
+// the whole wait — the property `docs/dfx/global-backpressure-design.md` states
+// as "every barrier and contention spin is bounded".
+//
+// Every object the worker touches is static on purpose: a regression leaves it
+// spinning forever, and a detached thread must not reference a freed frame. That
+// storage therefore outlives the test body, so each invocation has to establish
+// the state it asserts on rather than inherit it from the previous one.
+TEST(ProfilerDeviceEngineTest, PopGateGivesUpWhenTheFreezeIsNeverOpened) {
+    static FakeHeader header;
+    static FakeFreeQueue free_queue;
+    static std::atomic<bool> finished{false};
+    static std::atomic<bool> acquired{true};
+
+    header.backpressure.fq_contended = 0;
+    finished.store(false);
+    acquired.store(true);
+
+    ASSERT_EQ(free_queue.head, free_queue.tail);          // the gate finds no slot
+    ASSERT_EQ(header.backpressure.fq_freeze_active, 0u);  // and the host never freezes
+
+    std::thread worker([] {
+        uint32_t head = 0;
+        uint32_t tail = 0;
+        acquired.store(Engine::wait_for_free_queue_entry(&header, &free_queue, &head, &tail));
+        finished.store(true);
+    });
+    worker.detach();
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!finished.load() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    ASSERT_TRUE(finished.load()) << "pop gate spun with no deadline of its own while fq_freeze_active stayed 0";
+    EXPECT_FALSE(acquired.load());
+    EXPECT_EQ(header.backpressure.fq_contended, 1u);  // the leader signal was still raised
 }
 
 TEST(ProfilerDeviceEngineTest, TryPopFreeReturnsImmediatelyWhenStartupQueueIsEmpty) {


### PR DESCRIPTION
## Summary

`docs/dfx/global-backpressure-design.md` states that **"every barrier and contention spin is
bounded by `Module::kBackpressureWaitCycles`"**, and names the two cases it covers: a full
ready queue before publication, or **an empty free queue while claiming a replacement**. The
second case did not hold — this makes the code match its own design doc.

`wait_for_free_queue_entry`'s only give-up was `pop_freeze_barrier`, which spins solely while
`fq_freeze_active != 0`:

```cpp
inline bool pop_freeze_barrier(const Header *header, uint64_t timeout_cycles) {
    const uint64_t start = get_sys_cnt_aicpu();            // budget restarts every call
    while (header->backpressure.fq_freeze_active != 0) {   // only spins while frozen
        if (get_sys_cnt_aicpu() - start >= timeout_cycles) return false;
        SPIN_WAIT_HINT();
    }
    return true;                                           // not frozen -> success, at once
}
```

A lane that finds its free queue empty raises `fq_contended` and calls the barrier, but until
the host answers by opening the freeze the barrier sees a clear flag and returns success
immediately. So the outer `do { ... } while (true)` re-checked forever with no deadline of its
own, and the barrier's budget restarted on every call so it could not accumulate across
iterations either. A host that dies before it ever answers the leader signal leaves the flag at
0 permanently, and the lane spins until the OS op-execute timeout reaps the AICPU.

The ready-queue gate 40 lines above already has the right shape — one `start` taken before the
loop, checked unconditionally each iteration. This gives the pop gate the same thing. Both
gates now reach the same single failure exit, and the barrier keeps its own timeout for the
park it does cover.

## Reachability

**Latent on main.** Every path that arms the device side also reaches the host-side `start()`,
and since #2126 the collectors are resident, so a consumer is always present. It becomes
reachable as soon as a producer can run without the host having reached that point.

The `return false` exit is not new and its consequence is already designed for: the caller
keeps writing into the old buffer until the slot guard drops further records, deliberately
without bumping `dropped_record_count`. This change only adds a second way to reach that
existing exit.

## Testing

The regression test could not be written as a plain assertion — the pre-fix behaviour is an
**unbounded spin**, not a wrong answer, so a direct call would hang the suite rather than fail
it. It runs the gate on a detached thread over static storage (a regression leaves that thread
spinning, so it must not reference a freed frame) and asserts completion within five seconds.

- [x] **Negative control**: `PopGateGivesUpWhenTheFreezeIsNeverOpened` fails at **5007 ms**
      against the unpatched gate, and passes at **0.01 s** with the fix. The assertion can fire.
- [x] cpput: **135/135** (`ctest -LE requires_hardware`)
- [x] pyut: **2205 passed, 18 skipped**
- [x] `clang-format --dry-run --Werror` clean on both files

No hardware run: the change is an AICPU-side header and a host-side unit test; the touched path
is the contended branch of the pop gate, which the unit test drives directly.

## Notes

Found while scoping the remaining work on #2078, where this is cost 3. It is filed separately
because it is an independent liveness defect with an independent fix — nothing about it depends
on that issue's configuration-ownership work, and bundling a five-line device-side fix into a
five-item refactor would bury it.

Related: #2078, #995
