### PR TITLE
Fix profiler collector wakeup on quiesce

### DIFF
--- a/docs/dfx/profiling-framework.md
+++ b/docs/dfx/profiling-framework.md
@@ -171,8 +171,10 @@ Provides:
   arrays; the live shard count is the runtime `min(aicpu_thread_num,
   kMaxCollectorThreads)`) — each collector drains one host ready shard and
   returns finished buffers through the matching done shard.
-- `poll_and_collect_loop` — per-shard `wait_pop_ready` with a 100 ms cv
-  tick, dispatches to `Derived::on_buffer_collected`, then calls
+- `poll_and_collect_loop` — per-shard `wait_pop_ready`; ready buffers and
+  lifecycle control requests wake it immediately, while a 100 ms cv tick is a
+  fallback for data-path notification loss and idle bookkeeping. It dispatches
+  to `Derived::on_buffer_collected`, then calls
   `manager_.notify_copy_done(...)` itself; its idle-timeout detector reports
   stalled traffic but keeps the consumer alive until execution completes.
 - `set_memory_context` / `clear_memory_context` so `Derived::init` can
@@ -376,6 +378,7 @@ the hot SPSC path and is released at teardown.
     join mgmt thread(s)     ← drain final-pass flushes the last entries into
                               ready shards before exiting
     execution_complete_ = true
+    notify ready waiters     ← lifecycle control does not wait for the cv tick
     join collector thread(s)← each shard drains once more, then exits
 
   Derived::finalize(unregister, free)

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -650,18 +650,52 @@ public:
         return true;
     }
 
-    bool wait_pop_ready(ReadyBufferInfo &out, std::chrono::milliseconds timeout, int shard_index = 0) {
+    /**
+     * Wait for a ready buffer or for an external control condition. The
+     * control predicate is level-triggered: it remains true until the caller
+     * observes the false return and handles the condition. A notification may
+     * precede this call reaching the wait, in which case the predicate itself
+     * must still make the condition observable.
+     *
+     * Returns true only when a buffer was popped. A timeout or a satisfied
+     * control predicate returns false.
+     */
+    template <typename WakePredicate>
+    bool wait_pop_ready(
+        ReadyBufferInfo &out, std::chrono::milliseconds timeout, int shard_index, const WakePredicate &wake_requested
+    ) {
         auto &shard = ready_shards_[normalize_shard(shard_index)];
         if (try_pop_ready(out, shard_index)) return true;
 
         uint64_t seen = shard.state_epoch.load(std::memory_order_acquire);
         std::unique_lock<std::mutex> lock(shard.wait_mutex);
-        if (!shard.cv.wait_for(lock, timeout, [&shard, seen] {
-                return shard.state_epoch.load(std::memory_order_acquire) != seen || !shard.queue.empty();
+        if (!shard.cv.wait_for(lock, timeout, [&shard, seen, &wake_requested] {
+                return wake_requested() || shard.state_epoch.load(std::memory_order_acquire) != seen ||
+                       !shard.queue.empty();
             })) {
             return false;
         }
         return try_pop_ready(out, shard_index);
+    }
+
+    bool wait_pop_ready(ReadyBufferInfo &out, std::chrono::milliseconds timeout, int shard_index = 0) {
+        return wait_pop_ready(out, timeout, shard_index, [] {
+            return false;
+        });
+    }
+
+    /**
+     * Wake every live ready-queue consumer after its level-triggered control
+     * state has been published. Synchronizing with each shard's wait mutex
+     * prevents a consumer from checking a false predicate and going to sleep
+     * after the control notification.
+     */
+    void notify_ready_waiters() {
+        for (int shard_index = 0; shard_index < shard_count_; shard_index++) {
+            auto &shard = ready_shards_[shard_index];
+            std::lock_guard<std::mutex> lock(shard.wait_mutex);
+            shard.cv.notify_all();
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -131,8 +131,9 @@
  *        a) flips mgmt_running_, joins the mgmt thread(s); the drain thread's
  *           final-drain pass pushes the last device-ring entries into the host
  *           ready queue shard(s) before exiting.
- *        b) execution_complete_ is set; each collector loop sees it on its
- *           next idle tick, drains its host ready queue shard, and exits.
+ *        b) execution_complete_ is set and the ready-queue waiters are
+ *           notified; each collector drains its host ready queue shard and
+ *           exits.
  *        c) collector thread(s) joined.
  *      Caller is then guaranteed the device-side ring and the host ready queue
  *      shard(s) are both empty and all collected data has been delivered to
@@ -1012,6 +1013,7 @@ public:
         // Phase two: only now can a collector's "my shard is empty" mean the
         // pipeline is empty rather than that mgmt has not pushed yet.
         collect_quiesce_epoch_.store(epoch, std::memory_order_release);
+        manager_.notify_ready_waiters();
         wait_for_epoch(collect_acked_, n, epoch);
     }
 
@@ -1039,6 +1041,7 @@ public:
             mgmt_replenish_thread_.join();
         }
         execution_complete_.store(true, std::memory_order_release);
+        manager_.notify_ready_waiters();
         for (auto &thread : collector_threads_) {
             if (thread.joinable()) {
                 thread.join();
@@ -1253,9 +1256,16 @@ private:
         }
     }
 
+    bool quiesce_pending(int shard_index) const {
+        return collect_quiesce_epoch_.load(std::memory_order_acquire) !=
+               collect_acked_[shard_index].load(std::memory_order_relaxed);
+    }
+
     /**
-     * Main collector loop. Blocks on one manager ready-queue shard with a 100 ms
-     * cv-wait tick. On each hit it dispatches the buffer to Derived via
+     * Main collector loop. Blocks on one manager ready-queue shard. Ready
+     * buffers and lifecycle control requests wake it immediately; the 100 ms
+     * cv-wait tick is a fallback for missed data-path notifications and idle
+     * bookkeeping. On each hit it dispatches the buffer to Derived via
      * on_buffer_collected() and recycles the buffer. Exits only after:
      *
      *   execution_complete_ was set (by stop()) and this ready_queue shard is
@@ -1274,7 +1284,9 @@ private:
 
         while (true) {
             ReadyBufferInfo info;
-            if (manager_.wait_pop_ready(info, wait_tick, shard_index)) {
+            if (manager_.wait_pop_ready(info, wait_tick, shard_index, [this, shard_index] {
+                    return execution_complete_.load(std::memory_order_acquire) || quiesce_pending(shard_index);
+                })) {
                 consume(info, shard_index);
                 has_seen_buffer = true;
                 idle_start.reset();
@@ -1287,15 +1299,16 @@ private:
                 }
                 break;
             }
-            // Phase two of the quiescence handshake. wait_pop_ready timed out,
-            // so this shard is empty; mgmt has already reported its own sweep
+            // Phase two of the quiescence handshake. A false wait result means
+            // no ready buffer was available after either a timeout or a control
+            // wake. For a pending quiesce, mgmt has already reported its sweep
             // done for this epoch, so nothing further can arrive. Placed above
             // the has_seen_buffer guard below: a shard that never received a
             // buffer is a valid run shape and still has to report, or quiesce()
             // would wait on it forever.
             {
                 const uint64_t requested = collect_quiesce_epoch_.load(std::memory_order_acquire);
-                if (collect_acked_[shard_index].load(std::memory_order_relaxed) != requested) {
+                if (quiesce_pending(shard_index)) {
                     while (manager_.try_pop_ready(info, shard_index)) {
                         consume(info, shard_index);
                         has_seen_buffer = true;

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -327,6 +327,35 @@ TEST(BufferPoolManagerShardingTest, WaitPopReadyWakesOnProducer) {
     producer.join();
 }
 
+TEST(BufferPoolManagerShardingTest, WaitPopReadyWakesWhenControlIsRequested) {
+    using namespace std::chrono_literals;
+    profiling_common::BufferPoolManager<TestModule> manager;
+    std::atomic<bool> wake_requested{false};
+
+    std::promise<void> started_promise;
+    std::future<void> started = started_promise.get_future();
+    std::promise<bool> result_promise;
+    std::future<bool> result = result_promise.get_future();
+    std::thread consumer([&]() {
+        started_promise.set_value();
+        TestReadyBufferInfo out;
+        result_promise.set_value(manager.wait_pop_ready(out, 5s, 0, [&] {
+            return wake_requested.load(std::memory_order_acquire);
+        }));
+    });
+
+    ASSERT_EQ(started.wait_for(500ms), std::future_status::ready);
+    wake_requested.store(true, std::memory_order_release);
+    manager.notify_ready_waiters();
+
+    const auto result_status = result.wait_for(500ms);
+    EXPECT_EQ(result_status, std::future_status::ready);
+    if (result_status == std::future_status::ready) {
+        EXPECT_FALSE(result.get());
+    }
+    consumer.join();
+}
+
 TEST(BufferPoolManagerShardingTest, WaitPushReadyWakesOnConsumerAndPreservesFifo) {
     using namespace std::chrono_literals;
     using Manager = profiling_common::BufferPoolManager<TestModule>;

--- a/tests/ut/cpp/common/test_profiler_base.cpp
+++ b/tests/ut/cpp/common/test_profiler_base.cpp
@@ -270,6 +270,34 @@ TEST(ProfilerBaseTest, QuiesceWakesSilentCollector) {
     collector.stop();
 }
 
+// notify_ready_waiters() walks shards 0..shard_count_. At one shard that loop is
+// indistinguishable from one that only ever notifies shard 0, so the two tests
+// above hold no bound on it. Here every live shard carries a collector that
+// never saw a buffer: any shard the notify misses falls back to the 100 ms tick
+// and blows the bound, whichever control path published the state.
+TEST(ProfilerBaseTest, LifecycleControlWakesEverySilentCollectorShard) {
+    using namespace std::chrono_literals;
+    constexpr int kThreads = PLATFORM_MAX_AICPU_THREADS;
+
+    TestHeader header{};
+    TestCollector<PerThreadModule> collector;
+    collector.init(kThreads, &header);
+    ASSERT_EQ(collector.manager().shard_count(), kThreads);
+    collector.start(nullptr);
+    std::this_thread::sleep_for(10ms);
+
+    const auto quiesce_start = std::chrono::steady_clock::now();
+    collector.quiesce();
+    const auto quiesce_elapsed = std::chrono::steady_clock::now() - quiesce_start;
+
+    const auto stop_start = std::chrono::steady_clock::now();
+    collector.stop();
+    const auto stop_elapsed = std::chrono::steady_clock::now() - stop_start;
+
+    EXPECT_LT(quiesce_elapsed, 50ms);
+    EXPECT_LT(stop_elapsed, 50ms);
+}
+
 // A subsystem that emits nothing for a whole run is a valid shape: stop() must
 // bring the collector down via execution_complete_, NOT via the idle-timeout
 // hang detector. The guard that used to skip arming the timeout only applied

--- a/tests/ut/cpp/common/test_profiler_base.cpp
+++ b/tests/ut/cpp/common/test_profiler_base.cpp
@@ -237,6 +237,39 @@ TEST(ProfilerBaseTest, EveryLiveQueueIsDrained) {
     EXPECT_EQ(collector.collected(), kThreads);
 }
 
+TEST(ProfilerBaseTest, StopWakesSilentCollector) {
+    using namespace std::chrono_literals;
+
+    TestHeader header{};
+    TestCollector<SingleShardModule> collector;
+    collector.init(2, &header);
+    collector.start(nullptr);
+    std::this_thread::sleep_for(10ms);
+
+    const auto start = std::chrono::steady_clock::now();
+    collector.stop();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_LT(elapsed, 50ms);
+}
+
+TEST(ProfilerBaseTest, QuiesceWakesSilentCollector) {
+    using namespace std::chrono_literals;
+
+    TestHeader header{};
+    TestCollector<SingleShardModule> collector;
+    collector.init(2, &header);
+    collector.start(nullptr);
+    std::this_thread::sleep_for(10ms);
+
+    const auto start = std::chrono::steady_clock::now();
+    collector.quiesce();
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_LT(elapsed, 50ms);
+    collector.stop();
+}
+
 // A subsystem that emits nothing for a whole run is a valid shape: stop() must
 // bring the collector down via execution_complete_, NOT via the idle-timeout
 // hang detector. The guard that used to skip arming the timeout only applied


### PR DESCRIPTION
## Summary

- Wake ready-queue consumers after publishing quiesce or stop control state.
- Make the control predicate level-triggered and synchronize notifications with each shard's wait mutex, closing the notify-before-wait race.
- Keep the 100 ms tick as a fallback while documenting and testing the immediate lifecycle-control path.

`ProfilerBase::quiesce()` previously published `collect_quiesce_epoch_` and waited for acknowledgements without waking collectors blocked in `wait_pop_ready()`. An idle collector therefore acknowledged only after the 100 ms timeout. Enabled collectors are quiesced serially, so the delay could accumulate.

## Performance

A2/A3 onboard, `tensormap_and_ringbuffer/paged_attention_unroll::Case1`, Chip swimlane level 4, three measured single-run processes after one warmup per arm:

| Median | Before | After |
| --- | ---: | ---: |
| `chip.run.runner_run` | 108.92 ms | 9.49 ms |
| Device wall | 1.60 ms | 1.64 ms |
| Complete `chip.run` | 225.62 ms | 127.73 ms |

Each artifact contained 1,024 AICore tasks and 1,280 orchestrator phases. Record counts matched across all runs.

## Testing

- `ctest --test-dir tests/ut/cpp/build -R 'test_(profiler_base|buffer_pool_manager)$' --output-on-failure`
- Control wakeup test repeated 1,000 times
- Combined quiesce/stop/drain tests repeated 100 times
- `pre-commit` hooks, including clang-tidy, cpplint, clang-format, and markdownlint
- A2/A3 onboard paged-attention A/B through an allocated `task-submit` device

Fixes #2150
