### PR TITLE
feat(a5): add RDMA deferred completion backend for tensormap_and_ringbuffer

### DIFF
--- a/docs/comm-domain.md
+++ b/docs/comm-domain.md
@@ -216,7 +216,7 @@ symmetric window is realized:
 | Window memory | POSIX shm + `ftruncate`, mmap'd per rank | a2a3: Fabric V2 handle exchange (`ACL_MEM_SHARE_HANDLE_TYPE_FABRIC`), falling back to VMM + shareable-handle IPC where Fabric is unsupported. a5: VMM shareable handles only. Cross-card P2P via `aclrtDeviceEnablePeerAccess` on both |
 | Subset barrier | shm-header atomic, `allocation_id`-scoped | file barriers, `allocation_id`-scoped |
 | Window init | window zeroed before the subset barrier (`memset`) | window zeroed before the handle is announced (`aclrtMemset`) |
-| Async-DMA workspace | opt-in per Worker (`enable_sdma`, provisions inert 16 KiB scratch without STARS streams) | a2a3: opt-in per Worker (`enable_sdma`); a5: SDMA by default, URMA as an opt-in alternative |
+| Async-DMA workspace | opt-in per Worker (`enable_sdma`, provisions inert 16 KiB scratch without STARS streams) | a2a3: opt-in per Worker (`enable_sdma`); a5: SDMA by default, URMA or RDMA as an opt-in alternative |
 
 The window is zero-initialized on both backends so scratch/signal protocols see
 a known starting state (matching the historical static-path contract).
@@ -277,6 +277,17 @@ kernel's `get_dma_workspace` is unverified rather than closed. Simulation, a5,
 and provider-disabled builds fail Worker init fast when it is set. A5 provisions
 its communication-context SDMA workspace by default; this is separate from
 the Worker-level workspace mechanism controlled by `enable_sdma`.
+
+On a5, `SIMPLER_ENABLE_PTO_RDMA_WORKSPACE=ON` selects the HNS1825 RDMA
+workspace overlay instead. RDMA is mutually exclusive with the SDMA and URMA
+overlays because `CommContext` exposes a single `workSpace`/`workSpaceSize`
+pair. The first RDMA integration only supports `orch.allocate_domain()`
+dynamic domains; it does not support `comm_derive_context()`, sim platforms,
+a2a3, or `host_build_graph`. RDMA kernels derive remote WQE addresses from the
+RDMA workspace peer MR base plus a local-window offset, not from
+`CommContext::windowsIn[peer]` — the symmetric window is a low-GM-segment
+`aclrtMalloc` buffer the HNS1825 NIC can DMA to, and peers are reached over
+RoCE by rkey + VA.
 
 ---
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -214,6 +214,11 @@ A `pto_isa.pin` bump changes the SDMA headers embedded by
 `host_runtime.so`. Install-time runtime builds and run-time kernel compilation
 both read `pto_isa.pin`; use a different ISA revision by updating that file.
 
+The a5 RDMA workspace is an explicit opt-in overlay enabled with
+`SIMPLER_ENABLE_PTO_RDMA_WORKSPACE=ON`. It requires a `pto_isa.pin` revision
+that provides the PTO-ISA RDMA/HNS1825 headers and is mutually exclusive with
+the SDMA and URMA workspace overlays.
+
 ### Runtime binary lookup
 
 Scene tests load pre-built runtime binaries from `build/lib/`. These are produced

--- a/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/kernel_rdma_deferred_completion_consumer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/kernel_rdma_deferred_completion_consumer.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "rdma_deferred_completion_common.h"
+
+namespace {
+
+inline __aicore__ bool
+tput_slot_matches(__gm__ float *slot, uint32_t elem_count, uint32_t peer, __gm__ int32_t *status) {
+    for (uint32_t i = 0; i < elem_count; ++i) {
+        float expected = static_cast<float>(peer * 100000 + static_cast<int>(i));
+        if (slot[i] != expected) {
+            rdma_deferred_completion::set_status(status, rdma_deferred_completion::Status::kTputMismatch, i, peer);
+            status[3] = static_cast<int32_t>(slot[i]);
+            status[4] = static_cast<int32_t>(expected);
+            status[5] = static_cast<int32_t>(slot[0]);
+            status[6] = static_cast<int32_t>(slot[elem_count - 1]);
+            return false;
+        }
+    }
+    return true;
+}
+
+inline __aicore__ bool tget_matches(
+    __gm__ float *slot, uint32_t elem_count, uint32_t peer, __gm__ int32_t *status, int32_t which, int32_t marker_sum,
+    int32_t expected_marker_sum, __gm__ float *other_slot
+) {
+    for (uint32_t i = 0; i < elem_count; ++i) {
+        float expected = static_cast<float>(peer * 100000 + static_cast<int>(i));
+        if (slot[i] != expected) {
+            rdma_deferred_completion::set_status(status, rdma_deferred_completion::Status::kTgetMismatch, i, peer);
+            status[3] = static_cast<int32_t>(slot[i]);
+            status[4] = which;
+            status[5] = marker_sum;
+            status[6] = expected_marker_sum;
+            status[7] = static_cast<int32_t>(other_slot[0]);
+            return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *tget0_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *tget1_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *tput_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *tget0_marker_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+    __gm__ Tensor *tget1_marker_tensor = reinterpret_cast<__gm__ Tensor *>(args[4]);
+    __gm__ Tensor *tput0_marker_tensor = reinterpret_cast<__gm__ Tensor *>(args[5]);
+    __gm__ Tensor *tput1_marker_tensor = reinterpret_cast<__gm__ Tensor *>(args[6]);
+    __gm__ Tensor *status_tensor = reinterpret_cast<__gm__ Tensor *>(args[7]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[8]);
+    uint32_t elem_count = static_cast<uint32_t>(args[9]);
+
+    __gm__ float *tget0 = rdma_deferred_completion::tensor_data<float>(tget0_tensor);
+    __gm__ float *tget1 = rdma_deferred_completion::tensor_data<float>(tget1_tensor);
+    __gm__ float *tput = rdma_deferred_completion::tensor_data<float>(tput_tensor);
+    __gm__ int32_t *tget0_marker = rdma_deferred_completion::tensor_data<int32_t>(tget0_marker_tensor);
+    __gm__ int32_t *tget1_marker = rdma_deferred_completion::tensor_data<int32_t>(tget1_marker_tensor);
+    __gm__ int32_t *tput0_marker = rdma_deferred_completion::tensor_data<int32_t>(tput0_marker_tensor);
+    __gm__ int32_t *tput1_marker = rdma_deferred_completion::tensor_data<int32_t>(tput1_marker_tensor);
+    __gm__ int32_t *status = rdma_deferred_completion::tensor_data<int32_t>(status_tensor);
+
+    if (!rdma_deferred_completion::validate_comm(comm_ctx, elem_count, status)) {
+        return;
+    }
+    uint32_t peer = rdma_deferred_completion::peer_rank(comm_ctx);
+    int32_t expected_marker_sum = static_cast<int32_t>((elem_count > 1 ? 2 : 1) * 2);
+    int32_t tget_marker_sum = tget0_marker[0] + tget1_marker[0];
+
+    if (!tget_matches(tget0, elem_count, peer, status, 0, tget_marker_sum, expected_marker_sum, tget1)) {
+        return;
+    }
+    if (!tget_matches(tget1, elem_count, peer, status, 1, tget_marker_sum, expected_marker_sum, tget0)) {
+        return;
+    }
+
+    uint64_t peer_base = rdma_deferred_completion::remote_base(comm_ctx, peer);
+    uint64_t tput_slot_offset = rdma_deferred_completion::local_offset(comm_ctx, tput) +
+                                static_cast<uint64_t>(comm_ctx->rankId) * elem_count * sizeof(float);
+    __gm__ float *remote_tput_slot = reinterpret_cast<__gm__ float *>(peer_base + tput_slot_offset);
+    __gm__ float *scratch = tput + static_cast<uint64_t>(comm_ctx->rankNum) * elem_count;
+    auto local_scratch = rdma_deferred_completion::global_float(scratch, elem_count);
+    auto remote_tput = rdma_deferred_completion::global_float(remote_tput_slot, elem_count);
+    auto rdma_scratch = rdma_deferred_completion::rdma_scratch_tile();
+    pto::comm::AsyncSession readback_session;
+    if (!pto::comm::BuildAsyncSession<pto::comm::DmaEngine::RDMA>(
+            rdma_scratch, reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace), comm_ctx->rankId, readback_session, 2
+        )) {
+        rdma_deferred_completion::set_status(
+            status, rdma_deferred_completion::Status::kTputReadbackFailed, elem_count, peer
+        );
+        return;
+    }
+    auto readback_event =
+        pto::comm::TGET_ASYNC<pto::comm::DmaEngine::RDMA>(local_scratch, remote_tput, readback_session, peer);
+    if (!rdma_deferred_completion::wait_rdma_bounded(readback_event, readback_session)) {
+        rdma_deferred_completion::set_status(
+            status, rdma_deferred_completion::Status::kTputReadbackFailed, elem_count, peer
+        );
+        return;
+    }
+
+    if (tput_slot_matches(scratch, elem_count, comm_ctx->rankId, status)) {
+        rdma_deferred_completion::set_status(status, rdma_deferred_completion::Status::kOk, elem_count, peer);
+        status[3] = tget_marker_sum;
+        status[4] = tput0_marker[0] + tput1_marker[0];
+        status[5] = expected_marker_sum;
+        return;
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/kernel_rdma_deferred_completion_tget.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/kernel_rdma_deferred_completion_tget.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "rdma_deferred_completion_common.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *send_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *tget_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *marker_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+    uint32_t elem_count = static_cast<uint32_t>(args[5]);
+
+    __gm__ float *send = rdma_deferred_completion::tensor_data<float>(send_tensor);
+    __gm__ float *tget = rdma_deferred_completion::tensor_data<float>(tget_tensor);
+    __gm__ int32_t *marker = rdma_deferred_completion::tensor_data<int32_t>(marker_tensor);
+    if (!rdma_deferred_completion::validate_comm(comm_ctx, elem_count, marker)) {
+        return;
+    }
+    uint32_t peer = rdma_deferred_completion::peer_rank(comm_ctx);
+    uint64_t peer_base = rdma_deferred_completion::remote_base(comm_ctx, peer);
+    uint64_t send_offset = rdma_deferred_completion::local_offset(comm_ctx, send);
+    __gm__ float *remote_send = reinterpret_cast<__gm__ float *>(peer_base + send_offset);
+
+    uint32_t first_count = rdma_deferred_completion::first_chunk_count(elem_count);
+    uint32_t second_count = rdma_deferred_completion::second_chunk_count(elem_count);
+    AsyncCtx async_ctx = get_async_ctx(args);
+
+    auto local_tget = rdma_deferred_completion::global_float(tget, first_count);
+    auto remote_send_g = rdma_deferred_completion::global_float(remote_send, first_count);
+    auto rdma_scratch = rdma_deferred_completion::rdma_scratch_tile();
+    uint32_t request_count = 1;
+    pto2::rdma_backend::RdmaSubmitStatus submit_status = pto2::rdma_backend::submit_rdma_request_status(
+        async_ctx, RdmaTget(
+                       local_tget, remote_send_g, rdma_scratch, reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace),
+                       peer, comm_ctx->rankId, 0
+                   )
+    );
+    if (submit_status != pto2::rdma_backend::RdmaSubmitStatus::OK) {
+        rdma_deferred_completion::store_marker(marker, static_cast<int32_t>(submit_status));
+        return;
+    }
+    if (second_count != 0) {
+        request_count++;
+        auto local_tget_tail = rdma_deferred_completion::global_float(tget + first_count, second_count);
+        auto remote_send_tail = rdma_deferred_completion::global_float(remote_send + first_count, second_count);
+        submit_status = pto2::rdma_backend::submit_rdma_request_status(
+            async_ctx, RdmaTget(
+                           local_tget_tail, remote_send_tail, rdma_scratch,
+                           reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace), peer, comm_ctx->rankId, 1
+                       )
+        );
+        if (submit_status != pto2::rdma_backend::RdmaSubmitStatus::OK) {
+            rdma_deferred_completion::store_marker(marker, static_cast<int32_t>(submit_status));
+            return;
+        }
+    }
+    rdma_deferred_completion::store_marker(marker, static_cast<int32_t>(request_count));
+}

--- a/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/kernel_rdma_deferred_completion_tput.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/kernel_rdma_deferred_completion_tput.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "rdma_deferred_completion_common.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *send_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *tput_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *marker_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+    uint32_t elem_count = static_cast<uint32_t>(args[5]);
+
+    __gm__ float *send = rdma_deferred_completion::tensor_data<float>(send_tensor);
+    __gm__ float *tput = rdma_deferred_completion::tensor_data<float>(tput_tensor);
+    __gm__ int32_t *marker = rdma_deferred_completion::tensor_data<int32_t>(marker_tensor);
+    if (!rdma_deferred_completion::validate_comm(comm_ctx, elem_count, marker)) {
+        return;
+    }
+    uint32_t peer = rdma_deferred_completion::peer_rank(comm_ctx);
+    uint64_t peer_base = rdma_deferred_completion::remote_base(comm_ctx, peer);
+    uint64_t tput_slot_offset = rdma_deferred_completion::local_offset(comm_ctx, tput) +
+                                static_cast<uint64_t>(comm_ctx->rankId) * elem_count * sizeof(float);
+    __gm__ float *remote_tput_slot = reinterpret_cast<__gm__ float *>(peer_base + tput_slot_offset);
+
+    uint32_t first_count = rdma_deferred_completion::first_chunk_count(elem_count);
+    uint32_t second_count = rdma_deferred_completion::second_chunk_count(elem_count);
+    AsyncCtx async_ctx = get_async_ctx(args);
+
+    auto local_send = rdma_deferred_completion::global_float(send, first_count);
+    auto remote_tput = rdma_deferred_completion::global_float(remote_tput_slot, first_count);
+    auto rdma_scratch = rdma_deferred_completion::rdma_scratch_tile();
+    uint32_t request_count = 1;
+    pto2::rdma_backend::RdmaSubmitStatus submit_status = pto2::rdma_backend::submit_rdma_request_status(
+        async_ctx, RdmaTput(
+                       remote_tput, local_send, rdma_scratch, reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace),
+                       peer, comm_ctx->rankId, 0
+                   )
+    );
+    if (submit_status != pto2::rdma_backend::RdmaSubmitStatus::OK) {
+        rdma_deferred_completion::store_marker(marker, static_cast<int32_t>(submit_status));
+        return;
+    }
+    if (second_count != 0) {
+        request_count++;
+        auto local_send_tail = rdma_deferred_completion::global_float(send + first_count, second_count);
+        auto remote_tput_tail = rdma_deferred_completion::global_float(remote_tput_slot + first_count, second_count);
+        submit_status = pto2::rdma_backend::submit_rdma_request_status(
+            async_ctx, RdmaTput(
+                           remote_tput_tail, local_send_tail, rdma_scratch,
+                           reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace), peer, comm_ctx->rankId, 1
+                       )
+        );
+        if (submit_status != pto2::rdma_backend::RdmaSubmitStatus::OK) {
+            rdma_deferred_completion::store_marker(marker, static_cast<int32_t>(submit_status));
+            return;
+        }
+    }
+    rdma_deferred_completion::store_marker(marker, static_cast<int32_t>(request_count));
+}

--- a/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/rdma_deferred_completion_common.h
+++ b/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv/rdma_deferred_completion_common.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#ifdef MEMORY_BASE
+#undef MEMORY_BASE
+#endif
+#ifndef REGISTER_BASE
+#define REGISTER_BASE
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#ifdef PTO_RDMA_SUPPORTED
+#include "pto/comm/async/rdma/rdma_async_intrin.hpp"
+#endif
+
+#include "backend/rdma/rdma_completion_kernel.h"
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+namespace rdma_deferred_completion {
+
+using ShapeDyn = pto::Shape<1, 1, 1, 1, pto::DYNAMIC>;
+using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, 1>;
+using GlobalFloat = pto::GlobalTensor<float, ShapeDyn, StrideDyn>;
+#ifdef PTO_RDMA_SUPPORTED
+constexpr uint32_t kRdmaScratchBytes = pto::comm::rdma::kRdmaScratchBytes;
+#else
+constexpr uint32_t kRdmaScratchBytes = pto::comm::sdma::UB_ALIGN_SIZE;
+#endif
+using RdmaScratchTile = pto::Tile<pto::TileType::Vec, uint8_t, 1, kRdmaScratchBytes>;
+
+constexpr uint32_t kMaxRemoteWritePollIters = 10000000;
+constexpr uint32_t kRdmaScratchOffset = 0;
+
+enum class Status : int32_t {
+    kOk = 0,
+    kUnsupported = 1,
+    kInvalidComm = 2,
+    kInvalidElementCount = 3,
+    kSubmitFailed = 4,
+    kTputReadbackFailed = 5,
+    kTgetMismatch = 100,
+    kTputMismatch = 200,
+};
+
+inline __aicore__ void set_status(__gm__ int32_t *status, Status code, int32_t detail0 = 0, int32_t detail1 = 0) {
+    status[0] = static_cast<int32_t>(code);
+    status[1] = detail0;
+    status[2] = detail1;
+}
+
+template <typename T>
+inline __aicore__ __gm__ T *tensor_data(__gm__ Tensor *tensor) {
+    return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
+}
+
+inline __aicore__ bool validate_comm(__gm__ CommContext *comm_ctx, uint32_t elem_count, __gm__ int32_t *status) {
+#ifndef PTO_RDMA_SUPPORTED
+    (void)comm_ctx;
+    (void)elem_count;
+    set_status(status, Status::kUnsupported);
+    return false;
+#else
+    if (comm_ctx == nullptr || comm_ctx->rankNum != 2 || comm_ctx->rankId >= comm_ctx->rankNum ||
+        comm_ctx->workSpace == 0 || comm_ctx->windowsIn[comm_ctx->rankId] == 0) {
+        set_status(status, Status::kInvalidComm);
+        return false;
+    }
+    if (elem_count == 0) {
+        set_status(status, Status::kInvalidElementCount);
+        return false;
+    }
+    return true;
+#endif
+}
+
+inline __aicore__ uint32_t peer_rank(__gm__ CommContext *comm_ctx) {
+    return (comm_ctx->rankId + 1u) % comm_ctx->rankNum;
+}
+
+inline __aicore__ GlobalFloat global_float(__gm__ float *ptr, uint32_t elem_count) {
+    ShapeDyn shape(1, 1, 1, 1, elem_count);
+    StrideDyn stride(elem_count, elem_count, elem_count, elem_count, 1);
+    return GlobalFloat(ptr, shape, stride);
+}
+
+inline __aicore__ RdmaScratchTile rdma_scratch_tile() {
+    RdmaScratchTile scratch;
+    TASSIGN(scratch, kRdmaScratchOffset);
+    return scratch;
+}
+
+inline __aicore__ uint32_t first_chunk_count(uint32_t elem_count) {
+    return elem_count > 1 ? elem_count / 2 : elem_count;
+}
+
+inline __aicore__ uint32_t second_chunk_count(uint32_t elem_count) {
+    return elem_count - first_chunk_count(elem_count);
+}
+
+inline __aicore__ void store_marker(__gm__ int32_t *marker, int32_t value) {
+    marker[0] = value;
+    pto2::detail::defer_flush_range(marker, sizeof(int32_t));
+}
+
+template <typename Event, typename Session>
+inline __aicore__ bool wait_rdma_bounded(const Event &event, const Session &session) {
+    for (uint32_t i = 0; i < kMaxRemoteWritePollIters; ++i) {
+        if (event.Test(session)) {
+            return event.Wait(session);
+        }
+    }
+    return false;
+}
+
+inline __aicore__ uint64_t remote_base(__gm__ CommContext *comm_ctx, uint32_t peer) {
+#ifdef PTO_RDMA_SUPPORTED
+    return pto2::rdma_backend::peer_mr_base_addr(reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace), peer);
+#else
+    (void)comm_ctx;
+    (void)peer;
+    return 0;
+#endif
+}
+
+template <typename T>
+inline __aicore__ uint64_t local_offset(__gm__ CommContext *comm_ctx, __gm__ T *ptr) {
+    return reinterpret_cast<uint64_t>(ptr) - comm_ctx->windowsIn[comm_ctx->rankId];
+}
+
+}  // namespace rdma_deferred_completion

--- a/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/orchestration/rdma_deferred_completion_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/orchestration/rdma_deferred_completion_orch.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <stdint.h>
+
+#include "platform_comm/comm_context.h"
+#include "orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) OrchestrationConfig
+rdma_deferred_completion_orchestration_config(const ChipTaskArgs &orch_args) {
+    (void)orch_args;
+    return OrchestrationConfig{.expected_arg_count = 6};
+}
+
+__attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_config(const ChipTaskArgs &orch_args) {
+    return rdma_deferred_completion_orchestration_config(orch_args);
+}
+
+__attribute__((visibility("default"))) void rdma_deferred_completion_orchestration(const ChipTaskArgs &orch_args) {
+    if (orch_args.tensor_count() + orch_args.scalar_count() != 6) {
+        LOG_ERROR("rdma_deferred_completion_demo: expected 6 args");
+        return;
+    }
+
+    const simpler::tmr::Tensor &send = orch_args.tensor(0).ref();
+    const simpler::tmr::Tensor &tget_recv = orch_args.tensor(1).ref();
+    const simpler::tmr::Tensor &tput_recv = orch_args.tensor(2).ref();
+    const simpler::tmr::Tensor &status = orch_args.tensor(3).ref();
+    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+    const uint32_t elem_count = static_cast<uint32_t>(orch_args.scalar(1));
+
+    uint32_t marker_shape[1] = {1};
+    uint32_t tget_view_shape[1] = {elem_count};
+    uint32_t tget0_view_offset[1] = {0};
+    uint32_t tget1_view_offset[1] = {elem_count};
+    simpler::tmr::Tensor tget0_recv = tget_recv.view(tget_view_shape, tget0_view_offset);
+    simpler::tmr::Tensor tget1_recv = tget_recv.view(tget_view_shape, tget1_view_offset);
+
+    // The HNS1825 RDMA session uses one SQ per peer; serialize producer posts through marker dependencies.
+
+    CoreTaskArgs tget0_args;
+    TensorCreateInfo tget_marker_info(marker_shape, 1, DataType::INT32);
+    tget0_args.add_input(send);
+    tget0_args.add_output(tget0_recv);
+    tget0_args.add_output(tget_marker_info);
+    tget0_args.add_input(send);
+    tget0_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    tget0_args.add_scalar(elem_count);
+    TaskOutputTensors tget0_outputs = rt_submit_aiv_task(0, tget0_args);
+    simpler::tmr::Tensor tget0_tmp = tget0_recv;
+    simpler::tmr::Tensor tget0_marker = tget0_outputs.get_ref(0);
+
+    CoreTaskArgs tget1_args;
+    tget1_args.add_input(send);
+    tget1_args.add_output(tget1_recv);
+    tget1_args.add_output(tget_marker_info);
+    tget1_args.add_input(tget0_marker);
+    tget1_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    tget1_args.add_scalar(elem_count);
+    TaskOutputTensors tget1_outputs = rt_submit_aiv_task(0, tget1_args);
+    simpler::tmr::Tensor tget1_tmp = tget1_recv;
+    simpler::tmr::Tensor tget1_marker = tget1_outputs.get_ref(0);
+
+    CoreTaskArgs tput0_args;
+    TensorCreateInfo marker_info(marker_shape, 1, DataType::INT32);
+    tput0_args.add_input(send);
+    tput0_args.add_input(tput_recv);
+    tput0_args.add_output(marker_info);
+    tput0_args.add_input(tget1_marker);
+    tput0_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    tput0_args.add_scalar(elem_count);
+    TaskOutputTensors tput0_outputs = rt_submit_aiv_task(1, tput0_args);
+    simpler::tmr::Tensor tput0_marker = tput0_outputs.get_ref(0);
+
+    CoreTaskArgs tput1_args;
+    tput1_args.add_input(send);
+    tput1_args.add_input(tput_recv);
+    tput1_args.add_output(marker_info);
+    tput1_args.add_input(tput0_marker);
+    tput1_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    tput1_args.add_scalar(elem_count);
+    TaskOutputTensors tput1_outputs = rt_submit_aiv_task(1, tput1_args);
+    simpler::tmr::Tensor tput1_marker = tput1_outputs.get_ref(0);
+
+    CoreTaskArgs consumer_args;
+    consumer_args.add_input(tget0_tmp);
+    consumer_args.add_input(tget1_tmp);
+    consumer_args.add_input(tput_recv);
+    consumer_args.add_input(tget0_marker);
+    consumer_args.add_input(tget1_marker);
+    consumer_args.add_input(tput0_marker);
+    consumer_args.add_input(tput1_marker);
+    consumer_args.add_output(status);
+    consumer_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    consumer_args.add_scalar(elem_count);
+    rt_submit_aiv_task(2, consumer_args);
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/test_rdma_deferred_completion_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/test_rdma_deferred_completion_demo.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Real A5 RDMA deferred completion smoke test."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import pytest
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    CommBufferSpec,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DTYPE_NBYTES = 4
+STATUS_WORDS = 8
+RDMA_DATA_OFFSET_NBYTES = 64 * 4
+CASES = (64, 16384)
+
+
+def rdma_workspace_enabled() -> bool:
+    return os.environ.get("SIMPLER_ENABLE_PTO_RDMA_WORKSPACE", "").strip().upper() in {"1", "ON", "TRUE", "YES", "Y"}
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x]
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        return list(range(lo, hi + 1))
+    return [int(spec)]
+
+
+def build_chip_callable(platform: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root()
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+
+    children = []
+    for func_id, rel, signature in [
+        (
+            0,
+            "kernels/aiv/kernel_rdma_deferred_completion_tget.cpp",
+            [ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN, ArgDirection.IN, ArgDirection.IN],
+        ),
+        (
+            1,
+            "kernels/aiv/kernel_rdma_deferred_completion_tput.cpp",
+            [ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT, ArgDirection.IN, ArgDirection.IN, ArgDirection.IN],
+        ),
+        (
+            2,
+            "kernels/aiv/kernel_rdma_deferred_completion_consumer.cpp",
+            [
+                ArgDirection.IN,
+                ArgDirection.IN,
+                ArgDirection.IN,
+                ArgDirection.IN,
+                ArgDirection.IN,
+                ArgDirection.IN,
+                ArgDirection.IN,
+                ArgDirection.OUT,
+                ArgDirection.IN,
+                ArgDirection.IN,
+            ],
+        ),
+    ]:
+        kernel = kc.compile_incore(
+            source_path=os.path.join(HERE, rel),
+            core_type="aiv",
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=extra_includes,
+        )
+        if not platform.endswith("sim"):
+            kernel = extract_text_section(kernel)
+        children.append((func_id, CoreCallable.build(signature=signature, binary=kernel)))
+
+    orch = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/rdma_deferred_completion_orch.cpp"),
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
+    )
+    return ChipCallable.build(
+        signature=[
+            ArgDirection.IN,
+            ArgDirection.INOUT,
+            ArgDirection.INOUT,
+            ArgDirection.OUT,
+            ArgDirection.IN,
+            ArgDirection.IN,
+        ],
+        func_name="rdma_deferred_completion_orchestration",
+        config_name="rdma_deferred_completion_orchestration_config",
+        binary=orch,
+        children=children,
+    )
+
+
+def _send_pattern(rank: int, count: int) -> torch.Tensor:
+    return torch.tensor([float(rank * 100000 + i) for i in range(count)], dtype=torch.float32).share_memory_()
+
+
+def _zero_float(count: int) -> torch.Tensor:
+    return torch.zeros(count, dtype=torch.float32).share_memory_()
+
+
+def _zero_i32(count: int) -> torch.Tensor:
+    return torch.zeros(count, dtype=torch.int32).share_memory_()
+
+
+def _status_i32(count: int) -> torch.Tensor:
+    return torch.full((count,), -1, dtype=torch.int32).share_memory_()
+
+
+def _make_case_buffers(elem_count: int, nranks: int):
+    tget_elems = nranks * elem_count
+    tput_elems = (nranks + 1) * elem_count
+    return {
+        "send_host": [_send_pattern(rank, elem_count) for rank in range(nranks)],
+        "tget_zero": [_zero_float(tget_elems) for _ in range(nranks)],
+        "tput_zero": [_zero_float(tput_elems) for _ in range(nranks)],
+        "status": [_status_i32(STATUS_WORDS) for _ in range(nranks)],
+    }
+
+
+def _run_case_on_worker(worker: Worker, chip_handle, elem_count: int, nranks: int, case_buffers) -> bool:
+    if nranks != 2:
+        raise ValueError(f"rdma_deferred_completion_demo needs exactly 2 devices, got {nranks}")
+
+    send_nbytes = elem_count * DTYPE_NBYTES
+    tget_elems = nranks * elem_count
+    tget_nbytes = tget_elems * DTYPE_NBYTES
+    tput_elems = (nranks + 1) * elem_count
+    tput_nbytes = tput_elems * DTYPE_NBYTES
+    window_size = max(RDMA_DATA_OFFSET_NBYTES + send_nbytes + tget_nbytes + tput_nbytes, 4 * 1024 * 1024)
+
+    send_host = case_buffers["send_host"]
+    tget_zero = case_buffers["tget_zero"]
+    tput_zero = case_buffers["tput_zero"]
+    status = case_buffers["status"]
+
+    # In L3 distributed mode, host buffers for copy_to must be Worker Buffer handles
+    # backed by POSIX shared memory (worker.create_buffer).
+    send_buf = [worker.create_buffer(send_nbytes) for _ in range(nranks)]
+    tget_buf = [worker.create_buffer(tget_nbytes) for _ in range(nranks)]
+    tput_buf = [worker.create_buffer(tput_nbytes) for _ in range(nranks)]
+    for r in range(nranks):
+        s_shm, tg_shm, tp_shm = send_buf[r].shm, tget_buf[r].shm, tput_buf[r].shm
+        assert s_shm is not None and s_shm.buf is not None
+        assert tg_shm is not None and tg_shm.buf is not None
+        assert tp_shm is not None and tp_shm.buf is not None
+        torch.frombuffer(s_shm.buf, dtype=torch.float32, count=elem_count).copy_(send_host[r])
+        torch.frombuffer(tg_shm.buf, dtype=torch.float32, count=tget_elems).copy_(tget_zero[r])
+        torch.frombuffer(tp_shm.buf, dtype=torch.float32, count=tput_elems).copy_(tput_zero[r])
+
+    def orch_fn(orch, _args, cfg):
+        with orch.allocate_domain(
+            name=f"rdma_deferred_completion_{elem_count}",
+            workers=list(range(nranks)),
+            window_size=window_size,
+            buffers=[
+                CommBufferSpec(
+                    name="rdma_reserved",
+                    dtype="int32",
+                    count=RDMA_DATA_OFFSET_NBYTES // 4,
+                    nbytes=RDMA_DATA_OFFSET_NBYTES,
+                ),
+                CommBufferSpec(name="send", dtype="float32", count=elem_count, nbytes=send_nbytes),
+                CommBufferSpec(name="tget_recv", dtype="float32", count=tget_elems, nbytes=tget_nbytes),
+                CommBufferSpec(name="tput_recv", dtype="float32", count=tput_elems, nbytes=tput_nbytes),
+            ],
+        ) as handle:
+            for rank in range(nranks):
+                domain = handle[rank]
+                orch.copy_to(domain.buffers["send"], send_buf[rank])
+                orch.copy_to(domain.buffers["tget_recv"], tget_buf[rank])
+                orch.copy_to(domain.buffers["tput_recv"], tput_buf[rank])
+
+            for rank in range(nranks):
+                domain = handle[rank]
+                args = TaskArgs()
+                args.add_tensor(
+                    domain.buffers["send"].tensor((elem_count,), DataType.FLOAT32),
+                    TensorArgType.INPUT,
+                )
+                args.add_tensor(
+                    domain.buffers["tget_recv"].tensor((tget_elems,), DataType.FLOAT32),
+                    TensorArgType.INOUT,
+                )
+                args.add_tensor(
+                    domain.buffers["tput_recv"].tensor((tput_elems,), DataType.FLOAT32),
+                    TensorArgType.INOUT,
+                )
+                args.add_tensor(make_tensor_arg(worker, status[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_scalar(domain.device_ctx)
+                args.add_scalar(elem_count)
+                orch.submit_next_level(chip_handle, args, cfg, worker=rank)
+
+    try:
+        worker.run(orch_fn, args=None, config=CallConfig())
+    except RuntimeError:
+        _print_status(elem_count, status)
+        raise
+    finally:
+        for r in range(nranks):
+            worker.release_buffer(send_buf[r])
+            worker.release_buffer(tget_buf[r])
+            worker.release_buffer(tput_buf[r])
+
+    return _print_status(elem_count, status)
+
+
+def run_case(platform: str, device_ids: list[int], elem_count: int, *, build: bool = False) -> bool:
+    if platform != "a5":
+        raise ValueError("rdma_deferred_completion_demo requires platform 'a5'; a5sim cannot validate real RDMA")
+    if len(device_ids) != 2:
+        raise ValueError(f"rdma_deferred_completion_demo needs exactly 2 devices, got {device_ids}")
+
+    case_buffers = _make_case_buffers(elem_count, len(device_ids))
+    chip_callable = build_chip_callable(platform)
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        build=build,
+    )
+    chip_handle = worker.register(chip_callable)
+    try:
+        worker.init()
+        return _run_case_on_worker(worker, chip_handle, elem_count, len(device_ids), case_buffers)
+    finally:
+        worker.close()
+
+
+def _print_status(elem_count: int, status: list[torch.Tensor]) -> bool:
+    ok = True
+    for rank, rank_status in enumerate(status):
+        words = [int(x) for x in rank_status.tolist()]
+        print(f"[rdma_deferred_completion_demo] count={elem_count} rank={rank} status={words}")
+        ok = ok and words[0] == 0 and words[1] == elem_count
+    return ok
+
+
+def run(platform: str = "a5", device_ids: list[int] | None = None, *, build: bool = False, repeat: int = 1) -> int:
+    if device_ids is None:
+        device_ids = [0, 1]
+    if platform != "a5":
+        raise ValueError("rdma_deferred_completion_demo requires platform 'a5'; a5sim cannot validate real RDMA")
+    if len(device_ids) != 2:
+        raise ValueError(f"rdma_deferred_completion_demo needs exactly 2 devices, got {device_ids}")
+    if repeat < 1:
+        raise ValueError(f"rdma_deferred_completion_demo repeat must be >= 1, got {repeat}")
+    ok = True
+    for iteration in range(repeat):
+        if repeat > 1:
+            print(f"[rdma_deferred_completion_demo] iteration={iteration + 1}/{repeat}")
+        for elem_count in CASES:
+            ok = run_case(platform, device_ids, elem_count, build=build) and ok
+    return 0 if ok else 1
+
+
+@pytest.mark.requires_hardware
+@pytest.mark.platforms(["a5"])
+@pytest.mark.device_count(2)
+def test_rdma_deferred_completion_demo(st_platform, st_device_ids) -> None:
+    if not rdma_workspace_enabled():
+        pytest.skip("rdma_deferred_completion_demo requires SIMPLER_ENABLE_PTO_RDMA_WORKSPACE=ON")
+    assert run(st_platform, [int(st_device_ids[0]), int(st_device_ids[1])]) == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a5")
+    parser.add_argument("-d", "--device", default="0-1")
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--repeat", type=int, default=1)
+    args = parser.parse_args()
+    return run(args.platform, parse_device_range(args.device), build=args.build, repeat=args.repeat)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -80,6 +80,19 @@ def _executable_cache_identity(executable: str) -> dict[str, object]:
         return {"name": os.path.basename(executable), "error": type(error).__name__}
 
 
+def _cmake_bool_env_enabled(name: str, default: bool = False) -> bool:
+    """Interpret a CMake-style boolean env var (ON/OFF/1/0/TRUE/FALSE/YES/NO)."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    normalized = value.strip().upper()
+    if normalized in {"1", "ON", "TRUE", "YES", "Y"}:
+        return True
+    if normalized in {"0", "OFF", "FALSE", "NO", "N"}:
+        return False
+    return default
+
+
 class KernelCompiler:
     """
     Compiler for PTO kernels and orchestration functions.
@@ -214,6 +227,60 @@ class KernelCompiler:
             str(Path(__file__).resolve().parent / "incore"),
             str(self.project_root / "src" / "common" / "platform" / "include"),
         ]
+
+    def _incore_feature_defines(self) -> list[str]:
+        """Feature macros forwarded to incore compiles for the RDMA overlay."""
+        if self.platform == "a5" and _cmake_bool_env_enabled("SIMPLER_ENABLE_PTO_RDMA_WORKSPACE", default=False):
+            return ["-DPTO_RDMA_SUPPORTED", "-DPTO_RDMA_BACKEND_HNS_1825_SUPPORTED"]
+        return []
+
+    @staticmethod
+    def _pto_isa_include_dirs(pto_isa_root: str) -> list[str]:
+        """PTO-ISA include roots; RDMA intrinsics live under pkg_inc."""
+        include_dirs = [os.path.join(pto_isa_root, "include")]
+        pkg_inc = os.path.join(pto_isa_root, "pkg_inc")
+        if os.path.isdir(pkg_inc):
+            include_dirs.append(pkg_inc)
+        return include_dirs
+
+    def get_ascend_incore_include_dirs(self) -> list[str]:
+        """CANN device headers used by PTO-ISA backend-only includes."""
+        ascend_home = env_manager.get("ASCEND_HOME_PATH")
+        if not ascend_home:
+            return []
+        roots = [Path(ascend_home)]
+        roots += [Path(ascend_home) / arch for arch in ("aarch64-linux", "x86_64-linux")]
+
+        candidates: list[Path] = []
+        for root in roots:
+            candidates.extend(
+                [
+                    root / "include",
+                    root / "include" / "external",
+                    root / "include" / "c_api",
+                    root / "include" / "c_api" / "internal",
+                    root / "asc" / "include",
+                    root / "asc" / "include" / "interface",
+                    root / "asc" / "include" / "basic_api",
+                    root / "asc" / "include" / "basic_api" / "interface",
+                    root / "ascendc" / "include",
+                    root / "ascendc" / "include" / "basic_api",
+                    root / "ascendc" / "include" / "basic_api" / "interface",
+                ]
+            )
+        for header in ("kernel_operator_sys_var_intf.h", "kernel_operator_sys_var_intf_impl.h"):
+            try:
+                candidates.extend(path.parent for path in Path(ascend_home).rglob(header))
+            except OSError:
+                continue
+
+        include_dirs = []
+        seen = set()
+        for path in candidates:
+            if path.is_dir() and path not in seen:
+                include_dirs.append(str(path))
+                seen.add(path)
+        return include_dirs
 
     def _get_orchestration_config(self, runtime_name: str) -> tuple[list[str], list[str]]:
         """
@@ -504,9 +571,6 @@ class KernelCompiler:
         if pto_isa_root is None:
             raise ValueError("pto_isa_root is required for incore compilation")
 
-        pto_include = os.path.join(pto_isa_root, "include")
-        pto_pto_include = os.path.join(pto_isa_root, "include", "pto")
-
         # Generate output path
         output_path = self._make_temp_path(
             prefix=f"{os.path.basename(source_path)}.incore_", suffix=".o", build_dir=build_dir
@@ -514,9 +578,15 @@ class KernelCompiler:
 
         # Build command from toolchain
         cmd = [self.ccec.cxx_path, *self.ccec.get_compile_flags(core_type=core_type)]
-        cmd.extend([f"-I{compiler_visible_path(pto_include)}", f"-I{compiler_visible_path(pto_pto_include)}"])
+        cmd += self._incore_feature_defines()
+        for include_dir in self._pto_isa_include_dirs(pto_isa_root):
+            cmd.append(f"-I{compiler_visible_path(include_dir)}")
+            cmd.append(f"-I{compiler_visible_path(os.path.join(include_dir, 'pto'))}")
 
         for inc_dir in self.get_incore_include_dirs():
+            cmd.append(f"-I{compiler_visible_path(inc_dir)}")
+
+        for inc_dir in self.get_ascend_incore_include_dirs():
             cmd.append(f"-I{compiler_visible_path(inc_dir)}")
 
         if extra_include_dirs:

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -396,9 +396,24 @@ class RuntimeBuilder:
                 defines["SIMPLER_RUNTIME_NAME"] = name
                 if build_pto_isa_commit:
                     defines["SIMPLER_PTO_ISA_BUILD_COMMIT"] = build_pto_isa_commit
-                for opt_in_define in ("SIMPLER_ENABLE_PTO_URMA_WORKSPACE",):
+                # Forward the async-workspace overlay env selects to host CMake.
+                # URMA is the default overlay; an explicit SDMA or RDMA overlay
+                # turns it off so the CMake mutual-exclusion check stays clear.
+                overlay_defines = {}
+                for opt_in_define in (
+                    "SIMPLER_ENABLE_PTO_SDMA_WORKSPACE",
+                    "SIMPLER_ENABLE_PTO_URMA_WORKSPACE",
+                    "SIMPLER_ENABLE_PTO_RDMA_WORKSPACE",
+                ):
                     if os.environ.get(opt_in_define, "").upper() in {"1", "ON", "TRUE", "YES"}:
-                        defines[opt_in_define] = "ON"
+                        overlay_defines[opt_in_define] = "ON"
+                if overlay_defines:
+                    defines.update(overlay_defines)
+                    if (
+                        "SIMPLER_ENABLE_PTO_SDMA_WORKSPACE" in overlay_defines
+                        or "SIMPLER_ENABLE_PTO_RDMA_WORKSPACE" in overlay_defines
+                    ) and "SIMPLER_ENABLE_PTO_URMA_WORKSPACE" not in overlay_defines:
+                        defines["SIMPLER_ENABLE_PTO_URMA_WORKSPACE"] = "OFF"
             cmake_defines = defines or None
             # compile() adds a {target}/ subdirectory inside build_dir
             cache_dir = self._CACHE_DIR / arch / variant / name

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -37,14 +37,34 @@ endif()
 set(ASCEND_ARCH_HOME "${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux")
 
 option(SIMPLER_ENABLE_PTO_URMA_WORKSPACE "Enable a5 PTO URMA workspace overlay" OFF)
-# SDMA is the default a5 async-workspace backend. URMA remains an explicit
-# alternative because CommContext exposes one workSpace/workSpaceSize pair.
-# SIMPLER_ENABLE_PTO_SDMA_WORKSPACE is an internal compile marker, not a
+option(SIMPLER_ENABLE_PTO_RDMA_WORKSPACE "Enable a5 PTO RDMA workspace overlay" OFF)
+# SDMA is the default a5 async-workspace backend. URMA and RDMA remain
+# explicit alternatives because CommContext exposes one workSpace/workSpaceSize
+# pair. SIMPLER_ENABLE_PTO_SDMA_WORKSPACE is an internal compile marker, not a
 # user-configurable option.
-if(SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
+if(SIMPLER_ENABLE_PTO_URMA_WORKSPACE OR SIMPLER_ENABLE_PTO_RDMA_WORKSPACE)
     set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE OFF)
 else()
     set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ON)
+endif()
+
+# Only one async-workspace overlay may be selected; CommContext carries a
+# single workSpace/workSpaceSize pair shared by every backend.
+set(SIMPLER_PTO_ASYNC_WORKSPACE_OVERLAY_COUNT 0)
+foreach(OVERLAY
+        SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
+        SIMPLER_ENABLE_PTO_URMA_WORKSPACE
+        SIMPLER_ENABLE_PTO_RDMA_WORKSPACE)
+    if(${OVERLAY})
+        math(EXPR SIMPLER_PTO_ASYNC_WORKSPACE_OVERLAY_COUNT "${SIMPLER_PTO_ASYNC_WORKSPACE_OVERLAY_COUNT} + 1")
+    endif()
+endforeach()
+if(SIMPLER_PTO_ASYNC_WORKSPACE_OVERLAY_COUNT GREATER 1)
+    message(FATAL_ERROR
+        "Only one PTO async workspace overlay may be enabled at a time "
+        "(SDMA=${SIMPLER_ENABLE_PTO_SDMA_WORKSPACE}, "
+        "URMA=${SIMPLER_ENABLE_PTO_URMA_WORKSPACE}, "
+        "RDMA=${SIMPLER_ENABLE_PTO_RDMA_WORKSPACE})")
 endif()
 
 # Pin-resolved checkout path is passed by RuntimeBuilder as -DPTO_ISA_ROOT=
@@ -55,6 +75,19 @@ if(NOT PTO_ISA_ROOT)
         "-DPTO_ISA_ROOT=<pin-resolved path> (needs pto-isa host headers)")
 endif()
 list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${PTO_ISA_ROOT}/include")
+if(EXISTS "${PTO_ISA_ROOT}/pkg_inc")
+    list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "${PTO_ISA_ROOT}/pkg_inc")
+endif()
+
+# The RDMA overlay needs the pto-isa RDMA/HNS1825 headers (rdma_workspace_manager).
+if(SIMPLER_ENABLE_PTO_RDMA_WORKSPACE)
+    if(NOT EXISTS "${PTO_ISA_ROOT}/include/pto/comm/async/rdma/rdma_workspace_manager.hpp" AND
+       NOT EXISTS "${PTO_ISA_ROOT}/pkg_inc/pto/comm/async/rdma/rdma_workspace_manager.hpp")
+        message(FATAL_ERROR
+            "PTO RDMA workspace overlay requires pto-isa RDMA headers "
+            "(${PTO_ISA_ROOT}/include/pto/comm/async/rdma/rdma_workspace_manager.hpp or pkg_inc equivalent not found)")
+    endif()
+endif()
 
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS
 set(HOST_RUNTIME_SOURCES "")
@@ -140,7 +173,17 @@ if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
     target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)
 endif()
 if(SIMPLER_ENABLE_PTO_URMA_WORKSPACE)
-    target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_URMA_WORKSPACE=1)
+    target_compile_definitions(host_runtime PRIVATE
+        SIMPLER_ENABLE_PTO_URMA_WORKSPACE=1
+        PTO_URMA_SUPPORTED
+    )
+endif()
+if(SIMPLER_ENABLE_PTO_RDMA_WORKSPACE)
+    target_compile_definitions(host_runtime PRIVATE
+        SIMPLER_ENABLE_PTO_RDMA_WORKSPACE=1
+        PTO_RDMA_SUPPORTED
+        PTO_RDMA_BACKEND_HNS_1825_SUPPORTED
+    )
 endif()
 
 # Bake the resolved pto-isa commit into the compile command because the

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -29,10 +29,15 @@
 #include "common/unified_log.h"
 #include "host/file_marker_handshake.h"
 
+#include <array>
 #include <chrono>
+#include <cctype>
+#include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <dlfcn.h>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <sstream>
@@ -51,6 +56,12 @@
 #endif
 #ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
 #include "pto/comm/async/urma/urma_workspace_manager.hpp"
+#endif
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+#ifndef __gm__
+#define __gm__
+#endif
+#include "pto/comm/async/rdma/rdma_workspace_manager.hpp"
 #endif
 
 // Thin wrappers around the HCCL public APIs we use. Kept as a translation
@@ -86,6 +97,9 @@ struct DomainAllocation {
 #ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> urma_workspace;
 #endif
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    std::unique_ptr<pto::comm::rdma::RdmaWorkspaceManager> rdma_workspace;
+#endif
     CommContext *device_ctx = nullptr;  // aclrtMalloc'd CommContext mirror
 };
 
@@ -109,6 +123,9 @@ struct CommHandle_ {
 #endif
 #ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> urma_workspace;
+#endif
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    std::unique_ptr<pto::comm::rdma::RdmaWorkspaceManager> rdma_workspace;
 #endif
 };
 
@@ -240,6 +257,18 @@ static void release_own_vmm_window(void *va, aclrtDrvMemHandle handle) {
     }
 }
 
+// RDMA-aware raw-window release for domain_alloc_via_ipc failure paths: under
+// the RDMA overlay the buffer is a plain low-segment aclrtMalloc pointer and
+// must be aclrtFree'd (never unmap/release a non-VMM address); otherwise it is
+// a VMM-mapped VA released via release_own_vmm_window.
+static void release_domain_window_raw(void *buf, aclrtDrvMemHandle handle) {
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    if (buf != nullptr) aclrtFree(buf);
+#else
+    release_own_vmm_window(buf, handle);
+#endif
+}
+
 // Release every per-peer VMM import recorded on a domain allocation and clear
 // the list, so a re-release is a no-op.  Own window and device_ctx are freed
 // separately by the caller.
@@ -248,6 +277,22 @@ static void release_domain_peer_windows(DomainAllocation &alloc) {
         release_own_vmm_window(pw.first, pw.second);
     }
     alloc.peer_windows.clear();
+}
+
+// Release the own local window.  Under the RDMA overlay the window is a plain
+// low-segment aclrtMalloc pointer (own_handle == nullptr); otherwise it is a
+// VMM-mapped VA with a physical handle.
+static void release_domain_local_buffer(DomainAllocation &alloc) {
+    if (alloc.local_buf == nullptr) return;
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    aclrtFree(alloc.local_buf);
+    alloc.local_buf = nullptr;
+    alloc.own_handle = nullptr;
+#else
+    release_own_vmm_window(alloc.local_buf, alloc.own_handle);
+    alloc.local_buf = nullptr;
+    alloc.own_handle = nullptr;
+#endif
 }
 
 }  // namespace
@@ -361,10 +406,14 @@ constexpr uint64_t kIpcAnnounceMagic = 0x49504344334d4549ULL;  // "IPCD3MEI"
 
 struct IpcAnnounceFile {
     uint64_t magic;
-    int32_t pid;
-    uint32_t rank;
-    int32_t device_id;          // ACL logic device id this rank is bound to.
     uint64_t shareable_handle;  // aclrtMemExportToShareableHandle output
+    uint64_t symmetric_addr;
+    int32_t pid;
+    int32_t device_id;  // ACL logic device id this rank is bound to.
+    uint32_t rank;
+    uint32_t phy_id;
+    uint16_t roce_base_port;
+    char roce_ip[64];
 };
 
 // Announce file path shares the `barrier_<prefix>_..._<rank>.ready` shape so
@@ -380,10 +429,10 @@ static bool ipc_write_announce(
 ) {
     IpcAnnounceFile a{};
     a.magic = kIpcAnnounceMagic;
+    a.shareable_handle = shareable_handle;
     a.pid = pid;
     a.rank = static_cast<uint32_t>(rank);
     a.device_id = device_id;
-    a.shareable_handle = shareable_handle;
     std::string p = ipc_announce_path(rootinfo, rank, run_token);
     std::string tmp = p + ".tmp." + std::to_string(getpid());
     {
@@ -677,14 +726,21 @@ domain_announce_path(const std::string &rootinfo, uint64_t allocation_id, uint32
 
 static bool domain_write_announce(
     const std::string &rootinfo, uint64_t allocation_id, uint32_t domain_rank, uint64_t run_token, int32_t pid,
-    int32_t device_id, uint64_t shareable_handle
+    int32_t device_id, uint64_t shareable_handle, uint64_t symmetric_addr = 0, uint32_t phy_id = 0,
+    uint16_t roce_base_port = 0, const char *roce_ip = nullptr
 ) {
     IpcAnnounceFile a{};
     a.magic = kIpcAnnounceMagic;
+    a.shareable_handle = shareable_handle;
+    a.symmetric_addr = symmetric_addr;
     a.pid = pid;
     a.rank = domain_rank;
     a.device_id = device_id;
-    a.shareable_handle = shareable_handle;
+    a.phy_id = phy_id;
+    a.roce_base_port = roce_base_port;
+    if (roce_ip != nullptr) {
+        std::snprintf(a.roce_ip, sizeof(a.roce_ip), "%s", roce_ip);
+    }
     std::string p = domain_announce_path(rootinfo, allocation_id, domain_rank, run_token);
     std::string tmp = p + ".tmp." + std::to_string(getpid());
     {
@@ -784,6 +840,7 @@ static uint64_t urma_workspace_bytes(uint32_t rank_count) {
            static_cast<uint64_t>(rank_count) *
                (2ULL * sizeof(UrmaWQCtx) * qp_num + 2ULL * sizeof(UrmaCqCtx) * qp_num + sizeof(UrmaMemInfo) * qp_num);
 }
+#endif
 
 static bool rank_ids_are_dense_prefix(const uint32_t *rank_ids, size_t rank_count) {
     if (rank_ids == nullptr) return false;
@@ -793,6 +850,7 @@ static bool rank_ids_are_dense_prefix(const uint32_t *rank_ids, size_t rank_coun
     return true;
 }
 
+#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
 static bool init_urma_workspace(
     CommHandle h, uint32_t rank_id, uint32_t rank_count, void *symmetric_addr, uint64_t symmetric_size,
     std::unique_ptr<pto::comm::urma::UrmaWorkspaceManager> &workspace
@@ -834,7 +892,11 @@ static bool ensure_base_urma_workspace(CommHandle h) {
 static void reset_domain_urma_workspace(DomainAllocation &alloc) {
 #ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     alloc.urma_workspace.reset();
-#else
+#endif
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    alloc.rdma_workspace.reset();
+#endif
+#if !defined(SIMPLER_ENABLE_PTO_URMA_WORKSPACE) && !defined(SIMPLER_ENABLE_PTO_RDMA_WORKSPACE)
     (void)alloc;
 #endif
 }
@@ -842,10 +904,440 @@ static void reset_domain_urma_workspace(DomainAllocation &alloc) {
 static void reset_base_urma_workspace(CommHandle h) {
 #ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE
     h->urma_workspace.reset();
-#else
+#endif
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    h->rdma_workspace.reset();
+#endif
+#if !defined(SIMPLER_ENABLE_PTO_URMA_WORKSPACE) && !defined(SIMPLER_ENABLE_PTO_RDMA_WORKSPACE)
     (void)h;
 #endif
 }
+
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+struct RdmaBootstrapInfo {
+    uint32_t phy_id = 0;
+    std::string local_ip;
+    uint16_t base_port = 60032;
+};
+
+constexpr const char *kDefaultRdmaRootinfoPath = "/etc/hccl_rootinfo.json";
+constexpr const char *kDefaultVirtualTopologyPath = "/var/run/ascend-topologyd/virtualTopology.xml";
+
+static bool rdma_split_csv_env(const char *name, std::vector<std::string> &out) {
+    const char *value = std::getenv(name);
+    if (value == nullptr) return false;
+    std::stringstream ss(value);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+        size_t b = item.find_first_not_of(" \t");
+        if (b == std::string::npos) continue;
+        size_t e = item.find_last_not_of(" \t");
+        out.push_back(item.substr(b, e - b + 1));
+    }
+    return !out.empty();
+}
+
+static bool rdma_resolve_phy_id_from_runtime(uint32_t &phy_id) {
+    using GetDevFn = int (*)(int32_t *);
+    using MapFn = int (*)(int32_t, int32_t *);
+
+    auto getDev = reinterpret_cast<GetDevFn>(dlsym(RTLD_DEFAULT, "aclrtGetDevice"));
+    auto byUser = reinterpret_cast<MapFn>(dlsym(RTLD_DEFAULT, "aclrtGetPhyDevIdByUserDevId"));
+    auto byLogic = reinterpret_cast<MapFn>(dlsym(RTLD_DEFAULT, "aclrtGetPhyDevIdByLogicDevId"));
+    auto byIndex = reinterpret_cast<MapFn>(dlsym(RTLD_DEFAULT, "rtGetDevicePhyIdByIndex"));
+    if (getDev == nullptr) return false;
+
+    int32_t user_id = -1;
+    if (getDev(&user_id) != 0 || user_id < 0) return false;
+
+    int32_t phy = -1;
+    if (byUser != nullptr && byUser(user_id, &phy) == 0 && phy >= 0) {
+        phy_id = static_cast<uint32_t>(phy);
+        return true;
+    }
+    if (byLogic != nullptr && byLogic(user_id, &phy) == 0 && phy >= 0) {
+        phy_id = static_cast<uint32_t>(phy);
+        return true;
+    }
+    if (byIndex != nullptr && byIndex(user_id, &phy) == 0 && phy >= 0) {
+        phy_id = static_cast<uint32_t>(phy);
+        return true;
+    }
+    return false;
+}
+
+static bool rdma_resolve_phy_id(uint32_t base_rank, uint32_t rank_count, int device_id, uint32_t &phy_id) {
+    std::vector<std::string> phy_ids;
+    if (rdma_split_csv_env("PTO_ROCE_PHYIDS", phy_ids) && phy_ids.size() == rank_count && base_rank < phy_ids.size()) {
+        char *end = nullptr;
+        unsigned long parsed = std::strtoul(phy_ids[base_rank].c_str(), &end, 10);
+        if (end != phy_ids[base_rank].c_str() && *end == '\0' && parsed <= UINT_MAX) {
+            phy_id = static_cast<uint32_t>(parsed);
+            return true;
+        }
+    }
+    if (rdma_resolve_phy_id_from_runtime(phy_id)) return true;
+    phy_id = static_cast<uint32_t>(device_id);
+    LOG_WARN("[comm] RDMA phyId resolution unavailable, falling back to device id %d", device_id);
+    return true;
+}
+
+static bool parse_u16_env(const char *name, uint16_t &out) {
+    const char *value = std::getenv(name);
+    if (value == nullptr || *value == '\0') return true;
+    char *end = nullptr;
+    unsigned long parsed = std::strtoul(value, &end, 10);
+    if (end == value || *end != '\0' || parsed > 65535UL) return false;
+    out = static_cast<uint16_t>(parsed);
+    return true;
+}
+
+static bool rdma_extract_uint_after_key(
+    const std::string &s, const std::string &key, size_t from, uint32_t &value, size_t &key_pos
+) {
+    size_t p = s.find(key, from);
+    if (p == std::string::npos) return false;
+    key_pos = p;
+    p += key.size();
+    while (p < s.size() && (s[p] == ':' || std::isspace(static_cast<unsigned char>(s[p])) || s[p] == '"'))
+        ++p;
+    size_t start = p;
+    while (p < s.size() && std::isdigit(static_cast<unsigned char>(s[p])))
+        ++p;
+    if (p == start) return false;
+    value = static_cast<uint32_t>(std::strtoul(s.substr(start, p - start).c_str(), nullptr, 10));
+    return true;
+}
+
+static bool rdma_extract_quoted_after_key(
+    const std::string &s, const std::string &key, size_t from, std::string &out, size_t limit
+) {
+    size_t p = s.find(key, from);
+    if (p == std::string::npos || p >= limit) return false;
+    p = s.find('"', p + key.size());
+    if (p == std::string::npos || p >= limit) return false;
+    size_t start = p + 1;
+    size_t end = s.find('"', start);
+    if (end == std::string::npos || end > limit) return false;
+    out = s.substr(start, end - start);
+    return true;
+}
+
+static bool rdma_looks_like_ipv4(const std::string &value) {
+    int dots = 0;
+    for (char c : value) {
+        if (c == '.') {
+            ++dots;
+        } else if (!std::isdigit(static_cast<unsigned char>(c))) {
+            return false;
+        }
+    }
+    return dots == 3 && !value.empty();
+}
+
+static bool rdma_first_ipv4_in_line(const std::string &line, std::string &ip) {
+    size_t p = 0;
+    while (p < line.size()) {
+        while (p < line.size() && !std::isdigit(static_cast<unsigned char>(line[p])))
+            ++p;
+        size_t start = p;
+        while (p < line.size() && (std::isdigit(static_cast<unsigned char>(line[p])) || line[p] == '.'))
+            ++p;
+        if (p > start) {
+            std::string candidate = line.substr(start, p - start);
+            if (rdma_looks_like_ipv4(candidate) && candidate != "255.255.255.0") {
+                ip = candidate;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+static bool rdma_resolve_local_ip_from_hccn_tool(int device_id, std::string &ip) {
+    if (device_id < 0) return false;
+
+    char cmd[256];
+    std::snprintf(
+        cmd, sizeof(cmd), "/usr/local/Ascend/driver/tools/hccn_tool -g -dev_info -i %d 2>/dev/null", device_id
+    );
+    std::array<char, 512> buffer{};
+    std::string output;
+    FILE *pipe = popen(cmd, "r");
+    if (pipe != nullptr) {
+        while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+            output += buffer.data();
+        }
+        pclose(pipe);
+    }
+    if (output.empty()) {
+        std::snprintf(cmd, sizeof(cmd), "hccn_tool -g -dev_info -i %d 2>/dev/null", device_id);
+        pipe = popen(cmd, "r");
+        if (pipe != nullptr) {
+            while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) != nullptr) {
+                output += buffer.data();
+            }
+            pclose(pipe);
+        }
+    }
+
+    size_t pos = 0;
+    while (pos < output.size()) {
+        size_t nl = output.find('\n', pos);
+        if (nl == std::string::npos) nl = output.size();
+        std::string line = output.substr(pos, nl - pos);
+        if (line.find('|') != std::string::npos && rdma_first_ipv4_in_line(line, ip)) return true;
+        pos = nl + 1;
+    }
+    return false;
+}
+
+static const char *rdma_rootinfo_path() {
+    const char *path = std::getenv("PTO_ROCE_ROOTINFO");
+    return path != nullptr && *path != '\0' ? path : kDefaultRdmaRootinfoPath;
+}
+
+static bool rdma_resolve_local_ip_from_rootinfo(uint32_t phy_id, std::string &ip, const char *rootinfo_path) {
+    std::ifstream f(rootinfo_path);
+    if (!f.is_open()) return false;
+
+    std::stringstream ss;
+    ss << f.rdbuf();
+    const std::string s = ss.str();
+    if (s.empty()) return false;
+
+    const std::string device_key = "\"device_id\"";
+    const std::string addr_key = "\"addr\"";
+    size_t scan = 0;
+    while (scan < s.size()) {
+        uint32_t dev = 0;
+        size_t dev_key_pos = 0;
+        if (!rdma_extract_uint_after_key(s, device_key, scan, dev, dev_key_pos)) break;
+
+        size_t next_dev = s.find(device_key, dev_key_pos + device_key.size());
+        size_t block_end = next_dev == std::string::npos ? s.size() : next_dev;
+        if (dev == phy_id) {
+            size_t clos = s.find("\"CLOS\"", dev_key_pos);
+            if (clos == std::string::npos || clos >= block_end) return false;
+            size_t cur = clos;
+            std::string candidate;
+            while (rdma_extract_quoted_after_key(s, addr_key, cur, candidate, block_end)) {
+                if (rdma_looks_like_ipv4(candidate)) {
+                    ip = candidate;
+                    return true;
+                }
+                size_t adv = s.find(addr_key, cur);
+                if (adv == std::string::npos || adv >= block_end) break;
+                cur = adv + addr_key.size();
+            }
+            return false;
+        }
+        scan = block_end;
+    }
+    return false;
+}
+
+static bool rdma_resolve_local_ip_from_virtual_topology(uint32_t phy_id, std::string &ip) {
+    if (phy_id > static_cast<uint32_t>(INT_MAX)) return false;
+    using ResolveFn = int (*)(int, char *, size_t);
+
+    void *topo_handle = nullptr;
+    auto resolve = reinterpret_cast<ResolveFn>(dlsym(RTLD_DEFAULT, "GetRoceIpFromXml"));
+    if (resolve == nullptr) {
+        topo_handle = dlopen("libtopoaddrinfo.so", RTLD_NOW | RTLD_LOCAL);
+        if (topo_handle == nullptr) return false;
+        resolve = reinterpret_cast<ResolveFn>(dlsym(topo_handle, "GetRoceIpFromXml"));
+    }
+
+    char buffer[64] = {0};
+    const bool ok = resolve != nullptr && resolve(static_cast<int>(phy_id), buffer, sizeof(buffer)) == 0 &&
+                    rdma_looks_like_ipv4(buffer);
+    if (ok) ip = buffer;
+    if (topo_handle != nullptr) dlclose(topo_handle);
+    return ok;
+}
+
+static bool rdma_resolve_local_ip_from_env(uint32_t base_rank, uint32_t rank_count, std::string &ip) {
+    const char *local_ip = std::getenv("PTO_ROCE_LOCAL_IP");
+    if (local_ip != nullptr && rdma_looks_like_ipv4(local_ip)) {
+        ip = local_ip;
+        return true;
+    }
+    std::vector<std::string> ips;
+    if (rdma_split_csv_env("PTO_ROCE_IPS", ips) && ips.size() == rank_count && base_rank < ips.size() &&
+        rdma_looks_like_ipv4(ips[base_rank])) {
+        ip = ips[base_rank];
+        return true;
+    }
+    return false;
+}
+
+static bool
+resolve_rdma_bootstrap(CommHandle h, uint32_t base_rank, uint32_t rank_count, int device_id, RdmaBootstrapInfo &out) {
+    if (h == nullptr || device_id < 0) {
+        return false;
+    }
+
+    if (!rdma_resolve_phy_id(base_rank, rank_count, device_id, out.phy_id)) return false;
+    const char *rootinfo_path = rdma_rootinfo_path();
+    if (!rdma_resolve_local_ip_from_rootinfo(out.phy_id, out.local_ip, rootinfo_path) &&
+        !rdma_resolve_local_ip_from_virtual_topology(out.phy_id, out.local_ip) &&
+        !rdma_resolve_local_ip_from_env(base_rank, rank_count, out.local_ip) &&
+        !rdma_resolve_local_ip_from_hccn_tool(device_id, out.local_ip)) {
+        LOG_ERROR(
+            "[comm rank %d] RDMA bootstrap failed to resolve local RoCE IP "
+            "(no usable %s CLOS entry, no usable %s, and no PTO_ROCE_LOCAL_IP / PTO_ROCE_IPS)",
+            h->rank, rootinfo_path, kDefaultVirtualTopologyPath
+        );
+        return false;
+    }
+    if (!parse_u16_env("PTO_ROCE_BASE_PORT", out.base_port)) {
+        LOG_ERROR("[comm rank %d] invalid PTO_ROCE_BASE_PORT", h->rank);
+        return false;
+    }
+    return !out.local_ip.empty();
+}
+
+static uint64_t rdma_workspace_bytes(uint32_t rank_count) {
+    using namespace pto::comm::rdma;
+    using namespace pto::comm::rdma::hns_1825;
+    constexpr uint32_t qp_num = 1;
+    return sizeof(RdmaInfo) +
+           static_cast<uint64_t>(rank_count) *
+               (2ULL * sizeof(RoceSqCtx) * qp_num + 2ULL * sizeof(RoceCqCtx) * qp_num + sizeof(RdmaMemInfo));
+}
+
+// The HNS1825 RDMA NIC can only DMA to the low GM segment. Native pto-isa
+// tests aclrtMalloc(HUGE_FIRST) into 0x1200... (e.g. 0x120000017000, 0x12004c600000)
+// and pass; a VMM window reserved with hint=0 lands at 0x1240...000000, which the
+// NIC never reaches — WQEs are consumed but no CQE ever appears. aclrtMalloc is
+// not guaranteed to avoid that high region, so retry a bounded number of times
+// and reject any buffer at or above the VMM region start (0x1240...000000).
+// Used only for the RDMA overlay's symmetric buffer; the non-RDMA VMM path is
+// unchanged.
+static bool aclrt_malloc_low_segment(void **out, size_t size) {
+    constexpr uint32_t kMaxAttempts = 16;
+    constexpr uintptr_t kVmmRegionStart = UINT64_C(0x124000000000);
+    for (uint32_t attempt = 0; attempt < kMaxAttempts; ++attempt) {
+        void *buf = nullptr;
+        if (aclrtMalloc(&buf, size, ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS || buf == nullptr) {
+            continue;
+        }
+        if (reinterpret_cast<uintptr_t>(buf) < kVmmRegionStart) {
+            *out = buf;
+            return true;
+        }
+        aclrtFree(buf);
+    }
+    return false;
+}
+
+// Patch every SQ context's dbCos field in the RDMA device workspace so the
+// AICore rings the SQ hardware doorbell with the NIC-configured class of
+// service. The workspace is device memory (aclrtMalloc'd by the pto-isa
+// workspace manager); we read it back, fix the byte at each RoceSqCtx.dbCos
+// (offset 89), and write it back. See the caller comment for why dbCos must
+// match the NIC.
+static void patch_rdma_workspace_db_cos(void *workspace_addr, uint32_t rank_count) {
+    using namespace pto::comm::rdma;
+    using namespace pto::comm::rdma::hns_1825;
+    if (workspace_addr == nullptr || rank_count == 0) return;
+    constexpr uint8_t kExpectedDbCos = 4;  // NIC-configured cos observed on native pto-isa
+    const uint64_t workspace_size = rdma_workspace_bytes(rank_count);
+    std::vector<uint8_t> buf(workspace_size);
+    if (aclrtMemcpy(buf.data(), buf.size(), workspace_addr, buf.size(), ACL_MEMCPY_DEVICE_TO_HOST) != ACL_SUCCESS) {
+        LOG_ERROR("[comm] rdma workspace dbCos patch: D2H read failed");
+        return;
+    }
+    RdmaInfo *info = reinterpret_cast<RdmaInfo *>(buf.data());
+    const uint64_t sq_ptr = info->sqPtr;
+    if (sq_ptr == 0) return;
+    bool patched = false;
+    for (uint32_t rank = 0; rank < rank_count; ++rank) {
+        const uint64_t sq_off = sq_ptr - reinterpret_cast<uint64_t>(workspace_addr) + rank * sizeof(RoceSqCtx);
+        if (sq_off + sizeof(RoceSqCtx) > buf.size()) return;
+        uint8_t *db_cos = buf.data() + sq_off + offsetof(RoceSqCtx, dbCos);
+        if (*db_cos == 0) {
+            *db_cos = kExpectedDbCos;
+            patched = true;
+        }
+    }
+    if (patched) {
+        if (aclrtMemcpy(workspace_addr, buf.size(), buf.data(), buf.size(), ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+            LOG_ERROR("[comm] rdma workspace dbCos patch: H2D write failed");
+            return;
+        }
+    }
+    LOG_INFO(
+        "[comm] rdma workspace dbCos patch %s (rank_count=%u)", patched ? "applied" : "already-correct",
+        static_cast<unsigned>(rank_count)
+    );
+}
+
+static bool init_rdma_workspace(
+    CommHandle h, uint32_t domain_rank, uint32_t rank_count, const RdmaBootstrapInfo &bootstrap,
+    const std::vector<IpcAnnounceFile> &peers, void *symmetric_addr, uint64_t symmetric_size,
+    std::unique_ptr<pto::comm::rdma::RdmaWorkspaceManager> &workspace
+) {
+    if (workspace) return workspace->GetWorkspaceAddr() != nullptr;
+    if (h == nullptr || symmetric_addr == nullptr || symmetric_size == 0 || domain_rank >= rank_count ||
+        peers.size() != rank_count) {
+        return false;
+    }
+
+    pto::comm::rdma::WorkspaceConfig config{};
+    config.rankId = domain_rank;
+    config.rankCount = rank_count;
+    config.phyId = bootstrap.phy_id;
+    config.localIp = bootstrap.local_ip;
+    config.basePort = bootstrap.base_port;
+    config.symmetricAddr = symmetric_addr;
+    config.symmetricSize = symmetric_size;
+    config.peerIps.resize(rank_count);
+    config.peerPhyIds.resize(rank_count);
+    config.peerSymAddrs.resize(rank_count);
+    for (uint32_t p = 0; p < rank_count; ++p) {
+        if (peers[p].roce_base_port != bootstrap.base_port || peers[p].roce_ip[0] == '\0' ||
+            peers[p].symmetric_addr == 0) {
+            LOG_ERROR("[comm rank %d] RDMA peer metadata invalid for domain rank %u", h->rank, p);
+            return false;
+        }
+        config.peerIps[p] = peers[p].roce_ip;
+        config.peerPhyIds[p] = peers[p].phy_id;
+        config.peerSymAddrs[p] = peers[p].symmetric_addr;
+    }
+
+    auto manager = std::make_unique<pto::comm::rdma::RdmaWorkspaceManager>();
+    const auto init_result = manager->Init(config);
+    if (init_result != pto::comm::rdma::WorkspaceInitResult::READY) {
+        LOG_ERROR(
+            "[comm rank %d] RDMA workspace init failed (result=%u rank_id=%u rank_count=%u phy_id=%u ip=%s "
+            "base_port=%u peer0_phy=%u peer0_ip=%s peer0_addr=0x%llx peer1_phy=%u peer1_ip=%s "
+            "peer1_addr=0x%llx size=%llu)",
+            h->rank, static_cast<unsigned>(init_result), domain_rank, rank_count, bootstrap.phy_id,
+            bootstrap.local_ip.c_str(), static_cast<unsigned>(bootstrap.base_port),
+            rank_count > 0 ? peers[0].phy_id : 0, rank_count > 0 ? peers[0].roce_ip : "",
+            static_cast<unsigned long long>(rank_count > 0 ? peers[0].symmetric_addr : 0),
+            rank_count > 1 ? peers[1].phy_id : 0, rank_count > 1 ? peers[1].roce_ip : "",
+            static_cast<unsigned long long>(rank_count > 1 ? peers[1].symmetric_addr : 0),
+            static_cast<unsigned long long>(symmetric_size)
+        );
+        return false;
+    }
+
+    // The HNS1825 SQ hardware doorbell encodes the QP's class of service in a
+    // cos field; if it does not match the NIC's configured value the NIC
+    // silently ignores the doorbell (WQEs posted, software doorbell written,
+    // but nothing is consumed). The workspace's sq context dbCos is decoded by
+    // pto-isa from the HCOMM DbVendorSpecified field; on some pins it resolves
+    // to 0 while the NIC expects 4 (as native pto-isa tests observe). Patch the
+    // device workspace so AICore rings the doorbell with the NIC-configured cos.
+    patch_rdma_workspace_db_cos(manager->GetWorkspaceAddr(), static_cast<uint32_t>(rank_count));
+
+    workspace = std::move(manager);
+    return true;
+}
+#endif
 
 // Performs the per-allocation Path-D dance for one subset rank.  rank_ids
 // must list participating BASE-COMM rank ids in domain rank order; this
@@ -859,10 +1351,12 @@ static int domain_alloc_via_ipc(
     CommHandle h, uint64_t allocation_id, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank,
     uint64_t win_size, DomainAllocation *out
 ) {
+    (void)rank_ids;
     const std::string &rootinfo = h->rootinfo_path;
     const uint64_t run_token = h->run_token;
     const int subset_n = static_cast<int>(rank_count);
     const int my_dr = static_cast<int>(domain_rank);
+    aclError aret = ACL_SUCCESS;  // shared by both allocation branches and the ctx upload below
 
     int32_t myDevice = -1;
     if (aclrtGetDevice(&myDevice) != ACL_SUCCESS) {
@@ -870,8 +1364,24 @@ static int domain_alloc_via_ipc(
         return -1;
     }
 
-    // VMM own-window allocation; see alloc_windows_via_ipc for step-by-step
-    // rationale.
+    // Own-window allocation.  The non-RDMA path uses the VMM shareable-handle
+    // dance (see alloc_windows_via_ipc for step-by-step rationale) so peers can
+    // import each other's VA.  The RDMA overlay instead aclrtMallocs a buffer
+    // in the low GM segment (0x1200...) that the HNS1825 NIC can DMA to — a VMM
+    // window reserved with hint=0 lands at 0x1240...000000, which the NIC never
+    // reaches (WQEs consumed, no CQE).  RDMA reaches peers via rkey+VA, so no
+    // shareable handle is exchanged.
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    void *localBuf = nullptr;
+    if (!aclrt_malloc_low_segment(&localBuf, win_size)) {
+        LOG_ERROR("[comm rank %d] alloc_domain: low-segment aclrtMalloc failed", h->rank);
+        return -1;
+    }
+    const uint64_t aligned_size = win_size;
+    aclrtDrvMemHandle handle = nullptr;  // unused for aclrtMalloc (VMM-only)
+    uint64_t shareableHandle = 0;        // RDMA reaches peers via rkey; no shareable handle
+#else
+    uint64_t shareableHandle = 0;
     aclrtPhysicalMemProp prop{};
     prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
     prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
@@ -879,7 +1389,7 @@ static int domain_alloc_via_ipc(
     prop.location.id = static_cast<uint32_t>(myDevice);
     prop.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
     size_t granularity = 0;
-    aclError aret = aclrtMemGetAllocationGranularity(&prop, ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM, &granularity);
+    aret = aclrtMemGetAllocationGranularity(&prop, ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM, &granularity);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: GetAllocationGranularity -> %d", h->rank, static_cast<int>(aret));
         return -1;
@@ -915,18 +1425,18 @@ static int domain_alloc_via_ipc(
     aret = aclrtMemSetAccess(localBuf, aligned_size, &accessDesc, 1);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: MemSetAccess -> %d", h->rank, static_cast<int>(aret));
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
-    uint64_t shareableHandle = 0;
     aret = aclrtMemExportToShareableHandle(
         handle, ACL_MEM_HANDLE_TYPE_NONE, ACL_RT_VMM_EXPORT_FLAG_DISABLE_PID_VALIDATION, &shareableHandle
     );
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: ExportToShareableHandle -> %d", h->rank, static_cast<int>(aret));
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
+#endif
 
     // Wipe before the handle is published. Publication is the point from which
     // a peer may import this window and store into it — a barrier signal lands
@@ -937,14 +1447,27 @@ static int domain_alloc_via_ipc(
     aret = aclrtMemset(localBuf, aligned_size, 0, aligned_size);
     if (aret != ACL_SUCCESS) {
         LOG_ERROR("[comm rank %d] alloc_domain: aclrtMemset -> %d", h->rank, static_cast<int>(aret));
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
 
     const int32_t myPid = static_cast<int32_t>(getpid());
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    RdmaBootstrapInfo rdma_bootstrap{};
+    if (!resolve_rdma_bootstrap(h, domain_rank, static_cast<uint32_t>(rank_count), myDevice, rdma_bootstrap)) {
+        release_domain_window_raw(localBuf, handle);
+        return -1;
+    }
+    if (!domain_write_announce(
+            rootinfo, allocation_id, domain_rank, run_token, myPid, myDevice, shareableHandle,
+            reinterpret_cast<uint64_t>(localBuf), rdma_bootstrap.phy_id, rdma_bootstrap.base_port,
+            rdma_bootstrap.local_ip.c_str()
+        )) {
+#else
     if (!domain_write_announce(rootinfo, allocation_id, domain_rank, run_token, myPid, myDevice, shareableHandle)) {
+#endif
         LOG_ERROR("[comm rank %d] alloc_domain: write_announce failed", h->rank);
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
     std::vector<IpcAnnounceFile> peers(subset_n);
@@ -955,11 +1478,17 @@ static int domain_alloc_via_ipc(
             peers[p].rank = domain_rank;
             peers[p].device_id = myDevice;
             peers[p].shareable_handle = shareableHandle;
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+            peers[p].symmetric_addr = reinterpret_cast<uint64_t>(localBuf);
+            peers[p].phy_id = rdma_bootstrap.phy_id;
+            peers[p].roce_base_port = rdma_bootstrap.base_port;
+            std::snprintf(peers[p].roce_ip, sizeof(peers[p].roce_ip), "%s", rdma_bootstrap.local_ip.c_str());
+#endif
             continue;
         }
         if (!domain_read_announce(rootinfo, allocation_id, static_cast<uint32_t>(p), run_token, &peers[p])) {
             LOG_ERROR("[comm rank %d] alloc_domain: read_announce(peer_dr=%d) timed out", h->rank, p);
-            release_own_vmm_window(localBuf, handle);
+            release_domain_window_raw(localBuf, handle);
             return -1;
         }
     }
@@ -971,6 +1500,11 @@ static int domain_alloc_via_ipc(
     // and per device-pair; once any allocation opens a pair, later ones simply
     // observe it. The enable is the operative call (resolves the peer physical
     // id via the HCCL adapter and opens the HCCS route).
+    //
+    // The RDMA overlay reaches peers over RoCE (HCOMM channel), not HCCS, so
+    // the HCCS peer-access enable/confirm dance is skipped there; the
+    // file_barrier below still synchronizes the announce exchange.
+#ifndef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
     for (int p = 0; p < subset_n; ++p) {
         if (p == my_dr) continue;
         aclError r = aclrtDeviceEnablePeerAccess(peers[p].device_id, 0);
@@ -998,7 +1532,7 @@ static int domain_alloc_via_ipc(
                     "[comm rank %d] alloc_domain: PeerAccessStatus(local_dev=%d peer_dev=%d) -> %d", h->rank, myDevice,
                     peers[p].device_id, static_cast<int>(r)
                 );
-                release_own_vmm_window(localBuf, handle);
+                release_domain_window_raw(localBuf, handle);
                 return -1;
             }
             if (status == 1) break;
@@ -1013,11 +1547,12 @@ static int domain_alloc_via_ipc(
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
     }
+#endif
 
     // With DISABLE_PID_VALIDATION the import can proceed once peers have
     // published their shareable handles (read above) and P2P is up.
     if (!file_barrier(rootinfo, my_dr, subset_n, domain_barrier_tag(allocation_id, "p2p_ready"), run_token)) {
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
 
@@ -1048,7 +1583,7 @@ static int domain_alloc_via_ipc(
             )) {
             reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
-            release_own_vmm_window(localBuf, handle);
+            release_domain_window_raw(localBuf, handle);
             return -1;
         }
         domain_workspace_addr = reinterpret_cast<uint64_t>(out->urma_workspace->GetWorkspaceAddr());
@@ -1056,6 +1591,19 @@ static int domain_alloc_via_ipc(
     } else {
         LOG_WARN("[comm rank %d] alloc_domain: URMA workspace disabled for non-dense rank mapping", h->rank);
     }
+#endif
+#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
+    if (!init_rdma_workspace(
+            h, domain_rank, static_cast<uint32_t>(rank_count), rdma_bootstrap, peers, localBuf, aligned_size,
+            out->rdma_workspace
+        )) {
+        reset_domain_urma_workspace(*out);
+        release_domain_peer_windows(*out);
+        release_domain_window_raw(localBuf, handle);
+        return -1;
+    }
+    domain_workspace_addr = reinterpret_cast<uint64_t>(out->rdma_workspace->GetWorkspaceAddr());
+    domain_workspace_size = rdma_workspace_bytes(static_cast<uint32_t>(rank_count));
 #endif
 
     CommContext ctx{};
@@ -1067,6 +1615,11 @@ static int domain_alloc_via_ipc(
     ctx.windowsIn[my_dr] = reinterpret_cast<uint64_t>(localBuf);
     // Import each peer's shareable handle onto our device; see the symmetry
     // note in alloc_windows_via_ipc (one win_size, shared chip granularity).
+    //
+    // The RDMA overlay reaches peers over RoCE via rkey+VA (PeerMrBaseAddr),
+    // and the RDMA kernels only ever read windowsIn[own], so no peer VA import
+    // is needed there — the loop below is skipped and peer_windows stays empty.
+#ifndef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE
     for (int p = 0; p < subset_n; ++p) {
         if (p == my_dr) continue;
         aclrtDrvMemHandle peerHandle = nullptr;
@@ -1078,7 +1631,7 @@ static int domain_alloc_via_ipc(
             );
             reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
-            release_own_vmm_window(localBuf, handle);
+            release_domain_window_raw(localBuf, handle);
             return -1;
         }
         void *peerVa = nullptr;
@@ -1091,7 +1644,7 @@ static int domain_alloc_via_ipc(
             aclrtFreePhysical(peerHandle);
             reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
-            release_own_vmm_window(localBuf, handle);
+            release_domain_window_raw(localBuf, handle);
             return -1;
         }
         aret = aclrtMapMem(peerVa, aligned_size, 0, peerHandle, 0);
@@ -1101,7 +1654,7 @@ static int domain_alloc_via_ipc(
             aclrtFreePhysical(peerHandle);
             reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
-            release_own_vmm_window(localBuf, handle);
+            release_domain_window_raw(localBuf, handle);
             return -1;
         }
         aret = aclrtMemSetAccess(peerVa, aligned_size, &accessDesc, 1);
@@ -1114,12 +1667,13 @@ static int domain_alloc_via_ipc(
             aclrtFreePhysical(peerHandle);
             reset_domain_urma_workspace(*out);
             release_domain_peer_windows(*out);
-            release_own_vmm_window(localBuf, handle);
+            release_domain_window_raw(localBuf, handle);
             return -1;
         }
         out->peer_windows.emplace_back(peerVa, peerHandle);
         ctx.windowsIn[p] = reinterpret_cast<uint64_t>(peerVa);
     }
+#endif
 
     void *newDevMem = nullptr;
     aret = aclrtMalloc(&newDevMem, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
@@ -1127,7 +1681,7 @@ static int domain_alloc_via_ipc(
         LOG_ERROR("[comm rank %d] alloc_domain: ctx aclrtMalloc -> %d", h->rank, static_cast<int>(aret));
         reset_domain_urma_workspace(*out);
         release_domain_peer_windows(*out);
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
     aret = aclrtMemcpy(newDevMem, sizeof(CommContext), &ctx, sizeof(CommContext), ACL_MEMCPY_HOST_TO_DEVICE);
@@ -1136,7 +1690,7 @@ static int domain_alloc_via_ipc(
         aclrtFree(newDevMem);
         reset_domain_urma_workspace(*out);
         release_domain_peer_windows(*out);
-        release_own_vmm_window(localBuf, handle);
+        release_domain_window_raw(localBuf, handle);
         return -1;
     }
     out->device_ctx = reinterpret_cast<CommContext *>(newDevMem);
@@ -1230,8 +1784,10 @@ extern "C" int comm_derive_context(
     }
 
     CommContext ctx{};
-    ctx.workSpace = h->host_ctx.workSpace;
-    ctx.workSpaceSize = h->host_ctx.workSpaceSize;
+    if (rank_ids_are_dense_prefix(rank_ids, rank_count)) {
+        ctx.workSpace = h->host_ctx.workSpace;
+        ctx.workSpaceSize = h->host_ctx.workSpaceSize;
+    }
     ctx.rankId = domain_rank;
     ctx.rankNum = static_cast<uint32_t>(rank_count);
     ctx.winSize = window_size;
@@ -1380,7 +1936,7 @@ comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_co
     // handle.
     release_domain_peer_windows(*alloc);
     if (alloc->local_buf) {
-        release_own_vmm_window(alloc->local_buf, alloc->own_handle);
+        release_domain_local_buffer(*alloc);
         alloc->local_buf = nullptr;
         alloc->own_handle = nullptr;
     }
@@ -1443,7 +1999,7 @@ extern "C" int comm_destroy(CommHandle h) try {
         if (alloc->device_ctx) aclrtFree(alloc->device_ctx);
         reset_domain_urma_workspace(*alloc);
         release_domain_peer_windows(*alloc);
-        if (alloc->local_buf) release_own_vmm_window(alloc->local_buf, alloc->own_handle);
+        if (alloc->local_buf) release_domain_local_buffer(*alloc);
     }
     h->domain_allocations.clear();
     reset_base_urma_workspace(h);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
@@ -36,6 +36,7 @@ inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 #define COMPLETION_TYPE_COUNTER 0
 #define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
 #define COMPLETION_TYPE_URMA_EVENT_HANDLE 2
+#define COMPLETION_TYPE_RDMA_EVENT_HANDLE 3
 
 // DeferredCompletionEntry / DeferredCompletionSlab back the per-task scratch
 // area that AICore writes into to record "this completion has to be observed

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 
 #include "aicpu/platform_regs.h"
+#include "backend/rdma/rdma_completion_scheduler.h"
 #include "backend/sdma/sdma_completion_scheduler.h"
 #include "backend/urma/urma_completion_scheduler.h"
 #include "intrinsic.h"
@@ -65,6 +66,8 @@ inline CompletionPollResult counter_poll_op(const CompletionCondition &cond) {
     if (cond.counter_addr == nullptr) {
         return {CompletionPollState::FAILED, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID};
     }
+    uintptr_t line = reinterpret_cast<uintptr_t>(cond.counter_addr) & ~(uintptr_t(CHIP_ALIGN_SIZE) - 1u);
+    cache_invalidate_range(reinterpret_cast<const void *>(line), CHIP_ALIGN_SIZE);
     return {
         *cond.counter_addr >= cond.expected_value ? CompletionPollState::READY : CompletionPollState::PENDING,
         SIMPLER_ERROR_NONE
@@ -89,11 +92,20 @@ inline void urma_event_handle_retire_op(CompletionCondition &cond) {
     pto2::urma_backend::retire_urma_event_handle(cond.addr, cond.backend_cookie);
 }
 
+inline CompletionPollResult rdma_event_handle_poll_op(const CompletionCondition &cond) {
+    return pto2::rdma_backend::poll_rdma_event_handle(cond.addr, cond.backend_cookie);
+}
+
+inline void rdma_event_handle_retire_op(CompletionCondition &cond) {
+    pto2::rdma_backend::retire_rdma_event_handle(cond.addr, cond.backend_cookie);
+}
+
 inline const CompletionBackendOps *completion_backend_ops_for(int completion_type) {
     static const CompletionBackendOps kOps[] = {
         {counter_poll_op, counter_retire_op},                      // COMPLETION_TYPE_COUNTER = 0
         {sdma_event_record_poll_op, sdma_event_record_retire_op},  // COMPLETION_TYPE_SDMA_EVENT_RECORD = 1
         {urma_event_handle_poll_op, urma_event_handle_retire_op},  // COMPLETION_TYPE_URMA_EVENT_HANDLE = 2
+        {rdma_event_handle_poll_op, rdma_event_handle_retire_op},  // COMPLETION_TYPE_RDMA_EVENT_HANDLE = 3
     };
     constexpr int kOpsCount = static_cast<int>(sizeof(kOps) / sizeof(kOps[0]));
     if (completion_type < 0 || completion_type >= kOpsCount) return nullptr;
@@ -312,6 +324,8 @@ struct AsyncWaitList {
         int thread_idx
 #endif
     );
+
+    void log_diagnostics(AICoreCompletionMailbox *aicore_mailbox);
 };
 
 #endif  // PTO_ASYNC_WAIT_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/rdma_completion_kernel.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/rdma_completion_kernel.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_RDMA_RDMA_COMPLETION_KERNEL_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_RDMA_RDMA_COMPLETION_KERNEL_H_
+
+#include <stdint.h>
+
+#if defined(__CPU_SIM)
+#include <type_traits>
+#else
+#include "async_kernel_api.h"
+
+#include <pto/comm/async_common/async_event_impl.hpp>
+#if defined(PTO_RDMA_SUPPORTED)
+#include <pto/comm/async/rdma/rdma_async_intrin.hpp>
+#endif
+#endif
+
+#include "aicore_completion_mailbox_types.h"
+#include "intrinsic.h"
+#include "completion_token.h"
+#include "runtime_status.h"
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+#ifndef __gm__
+#define __gm__
+#endif
+
+#if defined(__CPU_SIM)
+namespace pto {
+namespace comm {
+enum class DmaEngine : uint8_t {
+    SDMA = 0,
+    URMA = 1,
+    RDMA = 3,
+};
+}  // namespace comm
+}  // namespace pto
+#endif
+
+enum class RdmaOp : uint8_t {
+    TGET = 0,
+    TPUT = 1,
+};
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+struct RdmaRequestDescriptor {
+    RdmaOp op;
+    DstTensor dst;
+    SrcTensor src;
+    ScratchTileT scratch;
+    __gm__ uint8_t *workspace;
+    uint32_t peer_rank;
+    uint32_t local_rank;
+    uint32_t sync_id;
+};
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> RdmaTget(
+    const DstTensor &dst, const SrcTensor &src, const ScratchTileT &scratch, __gm__ uint8_t *workspace,
+    uint32_t peer_rank, uint32_t local_rank, uint32_t sync_id = 0
+) {
+    return RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{RdmaOp::TGET, dst,       src,        scratch,
+                                                                     workspace,    peer_rank, local_rank, sync_id};
+}
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> RdmaTput(
+    const DstTensor &dst, const SrcTensor &src, const ScratchTileT &scratch, __gm__ uint8_t *workspace,
+    uint32_t peer_rank, uint32_t local_rank, uint32_t sync_id = 0
+) {
+    return RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{RdmaOp::TPUT, dst,       src,        scratch,
+                                                                     workspace,    peer_rank, local_rank, sync_id};
+}
+
+namespace pto2::detail {
+
+enum class RdmaEventRegistrationResult : int32_t {
+    OK = 0,
+    INVALID_EVENT = -31,
+    REGISTRATION_FAILED = -32,
+};
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ RdmaEventRegistrationResult register_rdma_async_event_status(
+    AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
+);
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ bool register_rdma_async_event(
+    AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
+);
+
+}  // namespace pto2::detail
+
+namespace pto2::rdma_backend {
+
+enum class RdmaSubmitStatus : int32_t {
+    OK = 0,
+    BUILD_SESSION_FAILED = -30,
+    INVALID_EVENT = -31,
+    REGISTRATION_FAILED = -32,
+    UNSUPPORTED = -33,
+};
+
+inline __aicore__ uint64_t peer_mr_base_addr(__gm__ uint8_t *workspace, uint32_t peer) {
+#if defined(PTO_RDMA_SUPPORTED)
+    return pto::comm::rdma::PeerMrBaseAddr(workspace, peer);
+#else
+    (void)workspace;
+    (void)peer;
+    return 0;
+#endif
+}
+
+template <typename T>
+inline __aicore__ __gm__ T *peer_mr_ptr(__gm__ uint8_t *workspace, uint32_t peer, uint64_t local_offset) {
+    return reinterpret_cast<__gm__ T *>(peer_mr_base_addr(workspace, peer) + local_offset);
+}
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ RdmaSubmitStatus
+submit_rdma_request_status(AsyncCtx &ctx, RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> desc) {
+#if defined(PTO_RDMA_SUPPORTED)
+    pto::comm::AsyncSession session;
+    if (!pto::comm::BuildAsyncSession<pto::comm::DmaEngine::RDMA>(
+            desc.scratch, desc.workspace, desc.local_rank, session, desc.sync_id
+        )) {
+        pto2::detail::defer_error(ctx, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+        return RdmaSubmitStatus::BUILD_SESSION_FAILED;
+    }
+
+    pto::comm::AsyncEvent event;
+    if (desc.op == RdmaOp::TGET) {
+        event = pto::comm::TGET_ASYNC<pto::comm::DmaEngine::RDMA>(desc.dst, desc.src, session, desc.peer_rank);
+    } else {
+        event = pto::comm::TPUT_ASYNC<pto::comm::DmaEngine::RDMA>(desc.dst, desc.src, session, desc.peer_rank);
+    }
+    const pto2::detail::RdmaEventRegistrationResult reg_result =
+        pto2::detail::register_rdma_async_event_status(ctx, event, session, desc.workspace);
+    if (reg_result != pto2::detail::RdmaEventRegistrationResult::OK) {
+        return reg_result == pto2::detail::RdmaEventRegistrationResult::INVALID_EVENT ?
+                   RdmaSubmitStatus::INVALID_EVENT :
+                   RdmaSubmitStatus::REGISTRATION_FAILED;
+    }
+    pto2::detail::defer_flush(ctx);
+    return RdmaSubmitStatus::OK;
+#else
+    (void)desc;
+    pto2::detail::defer_error(ctx, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+    return RdmaSubmitStatus::UNSUPPORTED;
+#endif
+}
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ bool
+submit_rdma_request(AsyncCtx &ctx, RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> desc) {
+    return submit_rdma_request_status(ctx, desc) == RdmaSubmitStatus::OK;
+}
+
+}  // namespace pto2::rdma_backend
+
+namespace pto2::detail {
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ RdmaEventRegistrationResult register_rdma_async_event_status(
+    AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
+) {
+    if (!ctx.task_token.is_valid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        (void)event.Wait(session);
+        return RdmaEventRegistrationResult::OK;
+    }
+    if (event.handle == 0) {
+        return RdmaEventRegistrationResult::OK;
+    }
+
+    const uint32_t engine = static_cast<uint32_t>(event.engine);
+    if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::RDMA) || workspace == nullptr) {
+        defer_error(ctx, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+        (void)event.Wait(session);
+        return RdmaEventRegistrationResult::INVALID_EVENT;
+    }
+
+    CompletionToken token{
+        event.handle,
+        0,
+        COMPLETION_ENGINE_ROCE,
+        COMPLETION_TYPE_RDMA_EVENT_HANDLE,
+        reinterpret_cast<uint64_t>(workspace),
+    };
+    if (!register_completion_condition(ctx, token)) {
+        defer_error(ctx, SIMPLER_ERROR_ASYNC_REGISTRATION_FAILED);
+        (void)event.Wait(session);
+        return RdmaEventRegistrationResult::REGISTRATION_FAILED;
+    }
+    return RdmaEventRegistrationResult::OK;
+}
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ bool register_rdma_async_event(
+    AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session, __gm__ uint8_t *workspace
+) {
+    return register_rdma_async_event_status(ctx, event, session, workspace) == RdmaEventRegistrationResult::OK;
+}
+
+}  // namespace pto2::detail
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ bool
+send_request_entry(AsyncCtx &ctx, RdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> desc) {
+    return pto2::rdma_backend::submit_rdma_request(ctx, desc);
+}
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_RDMA_RDMA_COMPLETION_KERNEL_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/rdma_completion_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/rdma_completion_scheduler.h
@@ -1,0 +1,578 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+#include "aicore_completion_mailbox.h"
+#include "common/unified_log.h"
+#include "completion_token.h"
+#include "runtime_status.h"
+
+namespace pto2::rdma_backend {
+
+inline constexpr uint32_t kHandleRankIdShift = 32;
+inline constexpr uint32_t kCqeBytes = 64;
+inline constexpr uint32_t kCqUpdateCiMask = 0xffffffu;
+inline constexpr uint32_t kRdmaWorkspaceMagic = 0x52444d41u;
+inline constexpr uint32_t kRdmaWorkspaceVersion = 1u;
+inline constexpr uint32_t kRdmaBackendHns1825 = 1u;
+inline constexpr uint32_t kRdmaErrorRank = 0xffffffffu;
+
+enum class RdmaDbMode : int32_t {
+    INVALID_DB = -1,
+    HW_DB = 0,
+    SW_DB = 1,
+};
+
+struct RdmaInfo {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t backend;
+    uint32_t qp_num;
+    uint32_t rank_count;
+    uint32_t reserved;
+    uint64_t sq_ptr;
+    uint64_t rq_ptr;
+    uint64_t scq_ptr;
+    uint64_t rcq_ptr;
+    uint64_t mem_ptr;
+};
+
+struct RdmaWqCtx {
+    uint32_t wqn;
+    uint64_t buf_addr;
+    uint32_t wqe_size;
+    uint32_t depth;
+    uint64_t head_addr;
+    uint64_t tail_addr;
+    RdmaDbMode db_mode;
+    uint64_t db_addr;
+    uint32_t sl;
+    uint64_t amo_addr;
+    uint32_t amo_lkey;
+    uint64_t db_sw_addr;
+    uint8_t mtu_shift;
+    uint8_t db_cos;
+    uint8_t reserved[6];
+};
+
+struct RdmaCqCtx {
+    uint32_t cqn;
+    uint64_t buf_addr;
+    uint32_t cqe_size;
+    uint32_t depth;
+    uint64_t head_addr;
+    uint64_t tail_addr;
+    RdmaDbMode db_mode;
+    uint64_t db_addr;
+    uint64_t db_sw_addr;
+};
+
+struct Hns1825Cqe {
+    uint32_t owner_id_qpn;
+    uint32_t op_sr_wqebb;
+    uint32_t byte_cnt;
+    uint32_t imm_data;
+    uint32_t rsvd_dw5;
+    uint32_t wqe_num;
+    uint32_t vlan_queue_index;
+    uint8_t syndrome;
+    uint8_t rsvd;
+    uint16_t wqe_counter;
+};
+
+struct RdmaMemInfo {
+    uint64_t size;
+    uint64_t addr;
+    uint32_t lkey;
+    uint32_t rkey;
+};
+
+static_assert(sizeof(RdmaInfo) == 64, "RDMA info ABI drift");
+static_assert(offsetof(RdmaInfo, sq_ptr) == 24, "RDMA info ABI drift");
+static_assert(sizeof(RdmaWqCtx) == 96, "RDMA WQ context ABI drift");
+static_assert(offsetof(RdmaWqCtx, db_addr) == 48, "RDMA WQ context ABI drift");
+static_assert(offsetof(RdmaWqCtx, db_sw_addr) == 80, "RDMA WQ context ABI drift");
+static_assert(offsetof(RdmaWqCtx, mtu_shift) == 88, "RDMA WQ context ABI drift");
+static_assert(offsetof(RdmaWqCtx, db_cos) == 89, "RDMA WQ context ABI drift");
+static_assert(sizeof(RdmaCqCtx) == 64, "RDMA CQ context ABI drift");
+static_assert(offsetof(RdmaCqCtx, db_addr) == 48, "RDMA CQ context ABI drift");
+static_assert(offsetof(RdmaCqCtx, db_sw_addr) == 56, "RDMA CQ context ABI drift");
+static_assert(sizeof(Hns1825Cqe) == 32, "RDMA CQE ABI drift");
+static_assert(sizeof(RdmaMemInfo) == 24, "RDMA memory-info ABI drift");
+
+inline uint64_t encode_rdma_event_handle(uint32_t dest_rank, uint32_t target_head) {
+    return (static_cast<uint64_t>(dest_rank) << kHandleRankIdShift) | static_cast<uint64_t>(target_head);
+}
+
+inline bool is_rdma_error_handle(uint64_t handle) {
+    return static_cast<uint32_t>(handle >> kHandleRankIdShift) == kRdmaErrorRank;
+}
+
+inline void decode_rdma_event_handle(uint64_t handle, uint32_t &dest_rank, uint32_t &target_head) {
+    dest_rank = static_cast<uint32_t>(handle >> kHandleRankIdShift);
+    target_head = static_cast<uint32_t>(handle & 0xFFFFFFFFu);
+}
+
+inline uintptr_t cache_line(const volatile void *addr) {
+    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(CHIP_ALIGN_SIZE) - 1u);
+}
+
+inline void invalidate_object(const volatile void *addr, std::size_t size) {
+    const uintptr_t object_addr = reinterpret_cast<uintptr_t>(addr);
+    const uintptr_t begin = cache_line(addr);
+    const uintptr_t end = (object_addr + size + CHIP_ALIGN_SIZE - 1u) & ~(uintptr_t(CHIP_ALIGN_SIZE) - 1u);
+    cache_invalidate_range(reinterpret_cast<const void *>(begin), end - begin);
+}
+
+inline bool has_reached(uint32_t current, uint32_t target) { return static_cast<int32_t>(current - target) >= 0; }
+
+inline bool is_power_of_two(uint32_t value) { return value != 0 && (value & (value - 1u)) == 0; }
+
+inline bool is_hns1825_cqe_owner_ready(bool owner, uint32_t cur_tail, uint32_t cq_ring) {
+    const bool expected_owner = (cur_tail & cq_ring) == 0;
+    return owner != expected_owner;
+}
+
+inline uint32_t htobe32(uint32_t value) { return __builtin_bswap32(value); }
+
+inline uint32_t load_device_u32(uint64_t addr) {
+    auto *ptr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+    return __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+}
+
+inline uint32_t load_device_u32_or_zero(uint64_t addr) { return addr != 0 ? load_device_u32(addr) : 0; }
+
+inline RdmaWqCtx load_wq_ctx(uint64_t wq_ptr, uint64_t ctx_index) {
+    auto *wq_entry = reinterpret_cast<volatile RdmaWqCtx *>(
+        static_cast<uintptr_t>(wq_ptr + ctx_index * static_cast<uint64_t>(sizeof(RdmaWqCtx)))
+    );
+    invalidate_object(wq_entry, sizeof(*wq_entry));
+
+    RdmaWqCtx wq_ctx{};
+    wq_ctx.wqn = __atomic_load_n(&wq_entry->wqn, __ATOMIC_ACQUIRE);
+    wq_ctx.buf_addr = __atomic_load_n(&wq_entry->buf_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.wqe_size = __atomic_load_n(&wq_entry->wqe_size, __ATOMIC_ACQUIRE);
+    wq_ctx.depth = __atomic_load_n(&wq_entry->depth, __ATOMIC_ACQUIRE);
+    wq_ctx.head_addr = __atomic_load_n(&wq_entry->head_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.tail_addr = __atomic_load_n(&wq_entry->tail_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.db_addr = __atomic_load_n(&wq_entry->db_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.db_sw_addr = __atomic_load_n(&wq_entry->db_sw_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.mtu_shift = __atomic_load_n(&wq_entry->mtu_shift, __ATOMIC_ACQUIRE);
+    wq_ctx.db_cos = __atomic_load_n(&wq_entry->db_cos, __ATOMIC_ACQUIRE);
+    return wq_ctx;
+}
+
+inline RdmaCqCtx load_cq_ctx(uint64_t cq_ptr, uint64_t ctx_index) {
+    auto *cq_entry = reinterpret_cast<volatile RdmaCqCtx *>(
+        static_cast<uintptr_t>(cq_ptr + ctx_index * static_cast<uint64_t>(sizeof(RdmaCqCtx)))
+    );
+    invalidate_object(cq_entry, sizeof(*cq_entry));
+
+    RdmaCqCtx cq_ctx{};
+    cq_ctx.cqn = __atomic_load_n(&cq_entry->cqn, __ATOMIC_ACQUIRE);
+    cq_ctx.buf_addr = __atomic_load_n(&cq_entry->buf_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.cqe_size = __atomic_load_n(&cq_entry->cqe_size, __ATOMIC_ACQUIRE);
+    cq_ctx.depth = __atomic_load_n(&cq_entry->depth, __ATOMIC_ACQUIRE);
+    cq_ctx.head_addr = __atomic_load_n(&cq_entry->head_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.tail_addr = __atomic_load_n(&cq_entry->tail_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.db_addr = __atomic_load_n(&cq_entry->db_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.db_sw_addr = __atomic_load_n(&cq_entry->db_sw_addr, __ATOMIC_ACQUIRE);
+    return cq_ctx;
+}
+
+inline RdmaMemInfo load_mem_info(uint64_t mem_ptr, uint64_t rank) {
+    auto *mem_entry = reinterpret_cast<volatile RdmaMemInfo *>(
+        static_cast<uintptr_t>(mem_ptr + rank * static_cast<uint64_t>(sizeof(RdmaMemInfo)))
+    );
+    invalidate_object(mem_entry, sizeof(*mem_entry));
+
+    RdmaMemInfo mem{};
+    mem.size = __atomic_load_n(&mem_entry->size, __ATOMIC_ACQUIRE);
+    mem.addr = __atomic_load_n(&mem_entry->addr, __ATOMIC_ACQUIRE);
+    mem.lkey = __atomic_load_n(&mem_entry->lkey, __ATOMIC_ACQUIRE);
+    mem.rkey = __atomic_load_n(&mem_entry->rkey, __ATOMIC_ACQUIRE);
+    return mem;
+}
+
+inline bool is_cq_ctx_valid(const RdmaCqCtx &cq_ctx, uint32_t cqe_size) {
+    return cqe_size >= sizeof(Hns1825Cqe) && cqe_size <= kCqeBytes && cq_ctx.buf_addr != 0 && cq_ctx.tail_addr != 0 &&
+           cq_ctx.db_sw_addr != 0 && is_power_of_two(cq_ctx.depth);
+}
+
+inline void log_rdma_wq_snapshot(const char *queue_name, const RdmaWqCtx &wq_ctx, int32_t entry_idx, int32_t cond_idx) {
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] %s wqn=%u depth=%u wqe_size=%u head=%u tail=%u db_sw_be=0x%x "
+        "buf=0x%llx head_addr=0x%llx tail_addr=0x%llx db_hw=0x%llx db_sw=0x%llx mtu_shift=%u",
+        entry_idx, cond_idx, queue_name, wq_ctx.wqn, wq_ctx.depth, wq_ctx.wqe_size,
+        load_device_u32_or_zero(wq_ctx.head_addr), load_device_u32_or_zero(wq_ctx.tail_addr),
+        load_device_u32_or_zero(wq_ctx.db_sw_addr), static_cast<unsigned long long>(wq_ctx.buf_addr),
+        static_cast<unsigned long long>(wq_ctx.head_addr), static_cast<unsigned long long>(wq_ctx.tail_addr),
+        static_cast<unsigned long long>(wq_ctx.db_addr), static_cast<unsigned long long>(wq_ctx.db_sw_addr),
+        static_cast<unsigned>(wq_ctx.mtu_shift)
+    );
+}
+
+inline void log_rdma_mem_snapshot(
+    const char *mem_name, const RdmaMemInfo &mem, uint32_t rank, int32_t entry_idx, int32_t cond_idx
+) {
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] %s rank=%u addr=0x%llx size=%llu lkey=0x%x rkey=0x%x", entry_idx, cond_idx,
+        mem_name, rank, static_cast<unsigned long long>(mem.addr), static_cast<unsigned long long>(mem.size), mem.lkey,
+        mem.rkey
+    );
+}
+
+inline void log_rdma_wqe_snapshot(
+    const char *queue_name, const RdmaWqCtx &wq_ctx, uint32_t wqe_index, int32_t entry_idx, int32_t cond_idx
+) {
+    const uint32_t wqe_size = wq_ctx.wqe_size == 0 ? kCqeBytes : wq_ctx.wqe_size;
+    if (wq_ctx.buf_addr == 0 || wq_ctx.depth == 0 || !is_power_of_two(wq_ctx.depth) || wqe_size < kCqeBytes) {
+        return;
+    }
+    const uint64_t wqe_addr =
+        wq_ctx.buf_addr + static_cast<uint64_t>(wqe_index & (wq_ctx.depth - 1)) * static_cast<uint64_t>(wqe_size);
+    auto *wqe = reinterpret_cast<volatile uint64_t *>(static_cast<uintptr_t>(wqe_addr));
+    invalidate_object(wqe, kCqeBytes);
+    const uint64_t word0 = __atomic_load_n(&wqe[0], __ATOMIC_ACQUIRE);
+    const uint64_t word1 = __atomic_load_n(&wqe[1], __ATOMIC_ACQUIRE);
+    const uint64_t word2 = __atomic_load_n(&wqe[2], __ATOMIC_ACQUIRE);
+    const uint64_t word3 = __atomic_load_n(&wqe[3], __ATOMIC_ACQUIRE);
+    const uint64_t word4 = __atomic_load_n(&wqe[4], __ATOMIC_ACQUIRE);
+    const uint64_t word5 = __atomic_load_n(&wqe[5], __ATOMIC_ACQUIRE);
+    const uint64_t word6 = __atomic_load_n(&wqe[6], __ATOMIC_ACQUIRE);
+    const uint64_t word7 = __atomic_load_n(&wqe[7], __ATOMIC_ACQUIRE);
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] %s wqe index=%u addr=0x%llx raw64="
+        "0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx,0x%llx",
+        entry_idx, cond_idx, queue_name, wqe_index, static_cast<unsigned long long>(wqe_addr),
+        static_cast<unsigned long long>(word0), static_cast<unsigned long long>(word1),
+        static_cast<unsigned long long>(word2), static_cast<unsigned long long>(word3),
+        static_cast<unsigned long long>(word4), static_cast<unsigned long long>(word5),
+        static_cast<unsigned long long>(word6), static_cast<unsigned long long>(word7)
+    );
+}
+
+inline void log_rdma_cqe_snapshot(
+    const char *queue_name, const RdmaCqCtx &cq_ctx, uint32_t cur_tail, uint32_t cqe_size, int32_t entry_idx,
+    int32_t cond_idx
+) {
+    if (!is_cq_ctx_valid(cq_ctx, cqe_size)) {
+        return;
+    }
+    const uint64_t cqe_addr =
+        cq_ctx.buf_addr + static_cast<uint64_t>(cqe_size) * static_cast<uint64_t>(cur_tail & (cq_ctx.depth - 1));
+    auto *cqe = reinterpret_cast<volatile Hns1825Cqe *>(static_cast<uintptr_t>(cqe_addr));
+    invalidate_object(cqe, sizeof(*cqe));
+    const uint32_t owner_id_qpn = __atomic_load_n(&cqe->owner_id_qpn, __ATOMIC_ACQUIRE);
+    const uint32_t op_sr_wqebb = __atomic_load_n(&cqe->op_sr_wqebb, __ATOMIC_ACQUIRE);
+    constexpr uint32_t kOwnerShift = 31;
+    constexpr uint32_t kCqeOpcodeShift = 27;
+    constexpr uint32_t kCqeOpcodeMask = 0x1f;
+    const bool owner = (owner_id_qpn & (1u << kOwnerShift)) != 0;
+    const uint32_t cqe_type = (op_sr_wqebb >> kCqeOpcodeShift) & kCqeOpcodeMask;
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] %s cqe addr=0x%llx owner=%u ready=%u type=0x%x "
+        "owner_id_qpn=0x%x op_sr_wqebb=0x%x syndrome=0x%x",
+        entry_idx, cond_idx, queue_name, static_cast<unsigned long long>(cqe_addr), static_cast<unsigned>(owner),
+        static_cast<unsigned>(is_hns1825_cqe_owner_ready(owner, cur_tail, cq_ctx.depth)), cqe_type, owner_id_qpn,
+        op_sr_wqebb, static_cast<unsigned>(__atomic_load_n(&cqe->syndrome, __ATOMIC_ACQUIRE))
+    );
+}
+
+inline void log_rdma_cq_snapshot(
+    const char *queue_name, const RdmaCqCtx &cq_ctx, uint32_t target_head, int32_t entry_idx, int32_t cond_idx
+) {
+    const uint32_t cqe_size = cq_ctx.cqe_size == 0 ? kCqeBytes : cq_ctx.cqe_size;
+    const uint32_t cur_head = load_device_u32_or_zero(cq_ctx.head_addr);
+    const uint32_t cur_tail = load_device_u32_or_zero(cq_ctx.tail_addr);
+    const bool ctx_valid = is_cq_ctx_valid(cq_ctx, cqe_size);
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] %s cqn=%u depth=%u cqe_size=%u cur_head=%u cur_tail=%u target_head=%u "
+        "db_sw_be=0x%x cq_buf=0x%llx cq_head=0x%llx cq_tail=0x%llx cq_db_sw=0x%llx valid=%u",
+        entry_idx, cond_idx, queue_name, cq_ctx.cqn, cq_ctx.depth, cqe_size, cur_head, cur_tail, target_head,
+        load_device_u32_or_zero(cq_ctx.db_sw_addr), static_cast<unsigned long long>(cq_ctx.buf_addr),
+        static_cast<unsigned long long>(cq_ctx.head_addr), static_cast<unsigned long long>(cq_ctx.tail_addr),
+        static_cast<unsigned long long>(cq_ctx.db_sw_addr), static_cast<unsigned>(ctx_valid)
+    );
+    log_rdma_cqe_snapshot(queue_name, cq_ctx, cur_tail, cqe_size, entry_idx, cond_idx);
+}
+
+inline void store_device_u32(uint64_t addr, uint32_t value) {
+    auto *ptr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+    __atomic_store_n(ptr, value, __ATOMIC_RELEASE);
+#if defined(__aarch64__)
+    __asm__ __volatile__("dsb sy" ::: "memory");
+#else
+    __atomic_thread_fence(__ATOMIC_SEQ_CST);
+#endif
+}
+
+inline void update_tail_info(const RdmaCqCtx &cq_ctx, const RdmaWqCtx & /*wq_ctx*/, uint32_t cur_tail) {
+    if (cq_ctx.tail_addr != 0) {
+        store_device_u32(cq_ctx.tail_addr, cur_tail);
+    }
+    if (cq_ctx.db_sw_addr != 0) {
+        store_device_u32(cq_ctx.db_sw_addr, htobe32(cur_tail & kCqUpdateCiMask));
+    }
+}
+
+// HNS1825 SQ hardware doorbell bit layout (mirrors pto-isa Hns1825SqDb).
+// AICore posts WQEs and rings this doorbell via st_dev in RingSqDoorbell; if
+// that write never reaches the NIC (head advances, software doorbell written,
+// but NIC never consumes), re-issuing the 64-bit doorbell from AICPU can
+// confirm whether the write path is the gap. This is a diagnostic helper: it
+// reproduces pto-isa's doorbell encoding and stores it to db_addr.
+inline void ring_sq_doorbell_from_aicpu(const RdmaWqCtx &wq_ctx, uint32_t cur_head) {
+    constexpr uint32_t kPiHighShift = 8;
+    constexpr uint32_t kPiFieldShift = 32;
+    constexpr uint32_t kDbTypeSq = 21;
+    constexpr uint32_t kSgidIdx = 1;
+    constexpr uint32_t kCntxSize = 1;
+    // Bit layout mirrors pto-isa Hns1825SqDb: qpn[19:0] cntx_size[21:20]
+    // rsvd0[22] c[23] cos[26:24] type[31:27] pi[39:32] rsvd1[47:40]
+    // xrc_vld[48] rsvd2[49] mtu_shift[52:50] sgid_index[59:53] sub_type[63:60].
+    uint64_t dbValue = 0;
+    dbValue |= static_cast<uint64_t>(wq_ctx.wqn & 0xfffffULL);                                  // qpn
+    dbValue |= static_cast<uint64_t>(kCntxSize) << 20;                                          // cntx_size
+    dbValue |= static_cast<uint64_t>(wq_ctx.db_cos & 0x7ULL) << 24;                             // cos (from workspace)
+    dbValue |= static_cast<uint64_t>(kDbTypeSq) << 27;                                          // type
+    dbValue |= static_cast<uint64_t>(wq_ctx.mtu_shift & 0x7ULL) << 50;                          // mtu_shift
+    dbValue |= static_cast<uint64_t>(kSgidIdx & 0x7fULL) << 53;                                 // sgid_index
+    dbValue |= ((static_cast<uint64_t>(cur_head >> kPiHighShift) & 0xffULL) << kPiFieldShift);  // PI high bits
+    if (wq_ctx.db_addr != 0) {
+        auto *db = reinterpret_cast<volatile uint64_t *>(static_cast<uintptr_t>(wq_ctx.db_addr));
+        __atomic_store_n(db, dbValue, __ATOMIC_RELEASE);
+        LOG_INFO(
+            "[ASYNC_WAIT RDMA] AICPU re-ring SQ doorbell db_addr=0x%llx head=%u db_cos=%u dbValue=0x%llx",
+            static_cast<unsigned long long>(wq_ctx.db_addr), cur_head, static_cast<unsigned>(wq_ctx.db_cos),
+            static_cast<unsigned long long>(dbValue)
+        );
+    }
+}
+
+inline CompletionPollResult poll_rdma_event_handle(uint64_t event_handle, uint64_t workspace_addr) {
+    if (event_handle == 0) {
+        return {CompletionPollState::READY, SIMPLER_ERROR_NONE};
+    }
+    if (is_rdma_error_handle(event_handle) || workspace_addr == 0) {
+        LOG_ERROR(
+            "RDMA completion invalid: bad handle/workspace handle=0x%llx workspace=0x%llx is_error=%u",
+            static_cast<unsigned long long>(event_handle), static_cast<unsigned long long>(workspace_addr),
+            static_cast<unsigned>(is_rdma_error_handle(event_handle))
+        );
+        return {CompletionPollState::FAILED, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+
+    uint32_t dest_rank = 0;
+    uint32_t target_head = 0;
+    decode_rdma_event_handle(event_handle, dest_rank, target_head);
+    if (target_head == 0) {
+        return {CompletionPollState::READY, SIMPLER_ERROR_NONE};
+    }
+
+    auto *info = reinterpret_cast<volatile RdmaInfo *>(static_cast<uintptr_t>(workspace_addr));
+    invalidate_object(info, sizeof(*info));
+    const uint32_t magic = __atomic_load_n(&info->magic, __ATOMIC_ACQUIRE);
+    const uint32_t version = __atomic_load_n(&info->version, __ATOMIC_ACQUIRE);
+    const uint32_t backend = __atomic_load_n(&info->backend, __ATOMIC_ACQUIRE);
+    const uint32_t qp_num = __atomic_load_n(&info->qp_num, __ATOMIC_ACQUIRE);
+    const uint32_t rank_count = __atomic_load_n(&info->rank_count, __ATOMIC_ACQUIRE);
+    const uint64_t sq_ptr = __atomic_load_n(&info->sq_ptr, __ATOMIC_ACQUIRE);
+    const uint64_t scq_ptr = __atomic_load_n(&info->scq_ptr, __ATOMIC_ACQUIRE);
+    if (magic != kRdmaWorkspaceMagic || version != kRdmaWorkspaceVersion || backend != kRdmaBackendHns1825 ||
+        qp_num == 0 || dest_rank >= rank_count || sq_ptr == 0 || scq_ptr == 0) {
+        LOG_ERROR(
+            "RDMA completion invalid: workspace metadata handle=0x%llx workspace=0x%llx dest_rank=%u target_head=%u "
+            "magic=0x%x version=%u backend=%u qp_num=%u rank_count=%u sq=0x%llx scq=0x%llx",
+            static_cast<unsigned long long>(event_handle), static_cast<unsigned long long>(workspace_addr), dest_rank,
+            target_head, magic, version, backend, qp_num, rank_count, static_cast<unsigned long long>(sq_ptr),
+            static_cast<unsigned long long>(scq_ptr)
+        );
+        return {CompletionPollState::FAILED, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+
+    const uint64_t ctx_index = static_cast<uint64_t>(dest_rank) * qp_num;
+    auto *cq_entry = reinterpret_cast<volatile RdmaCqCtx *>(
+        static_cast<uintptr_t>(scq_ptr + ctx_index * static_cast<uint64_t>(sizeof(RdmaCqCtx)))
+    );
+    auto *wq_entry = reinterpret_cast<volatile RdmaWqCtx *>(
+        static_cast<uintptr_t>(sq_ptr + ctx_index * static_cast<uint64_t>(sizeof(RdmaWqCtx)))
+    );
+    invalidate_object(cq_entry, sizeof(*cq_entry));
+    invalidate_object(wq_entry, sizeof(*wq_entry));
+
+    RdmaCqCtx cq_ctx{};
+    cq_ctx.buf_addr = __atomic_load_n(&cq_entry->buf_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.cqe_size = __atomic_load_n(&cq_entry->cqe_size, __ATOMIC_ACQUIRE);
+    cq_ctx.depth = __atomic_load_n(&cq_entry->depth, __ATOMIC_ACQUIRE);
+    cq_ctx.tail_addr = __atomic_load_n(&cq_entry->tail_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.db_addr = __atomic_load_n(&cq_entry->db_addr, __ATOMIC_ACQUIRE);
+    cq_ctx.db_sw_addr = __atomic_load_n(&cq_entry->db_sw_addr, __ATOMIC_ACQUIRE);
+
+    RdmaWqCtx wq_ctx{};
+    wq_ctx.wqn = __atomic_load_n(&wq_entry->wqn, __ATOMIC_ACQUIRE);
+    wq_ctx.depth = __atomic_load_n(&wq_entry->depth, __ATOMIC_ACQUIRE);
+    wq_ctx.head_addr = __atomic_load_n(&wq_entry->head_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.tail_addr = __atomic_load_n(&wq_entry->tail_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.db_addr = __atomic_load_n(&wq_entry->db_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.db_sw_addr = __atomic_load_n(&wq_entry->db_sw_addr, __ATOMIC_ACQUIRE);
+    wq_ctx.mtu_shift = __atomic_load_n(&wq_entry->mtu_shift, __ATOMIC_ACQUIRE);
+    wq_ctx.db_cos = __atomic_load_n(&wq_entry->db_cos, __ATOMIC_ACQUIRE);
+    const uint32_t cqe_size = cq_ctx.cqe_size == 0 ? kCqeBytes : cq_ctx.cqe_size;
+    const uint32_t cq_ring = cq_ctx.depth;
+    if (cqe_size < sizeof(Hns1825Cqe) || cqe_size > kCqeBytes || cq_ctx.buf_addr == 0 || cq_ctx.tail_addr == 0 ||
+        cq_ctx.db_sw_addr == 0 || !is_power_of_two(cq_ring)) {
+        LOG_ERROR(
+            "RDMA completion invalid: cq context handle=0x%llx workspace=0x%llx dest_rank=%u target_head=%u "
+            "cqe_size=%u depth=%u cq_ring=%u cq_buf=0x%llx cq_tail=0x%llx cq_db_sw=0x%llx sq_tail=0x%llx",
+            static_cast<unsigned long long>(event_handle), static_cast<unsigned long long>(workspace_addr), dest_rank,
+            target_head, cqe_size, cq_ctx.depth, cq_ring, static_cast<unsigned long long>(cq_ctx.buf_addr),
+            static_cast<unsigned long long>(cq_ctx.tail_addr), static_cast<unsigned long long>(cq_ctx.db_sw_addr),
+            static_cast<unsigned long long>(wq_ctx.tail_addr)
+        );
+        return {CompletionPollState::FAILED, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+
+    uint32_t cur_tail = load_device_u32(cq_ctx.tail_addr);
+    if (has_reached(cur_tail, target_head)) {
+        return {CompletionPollState::READY, SIMPLER_ERROR_NONE};
+    }
+
+    uint32_t next_tail = cur_tail;
+    while (!has_reached(next_tail, target_head)) {
+        const uint64_t cqe_addr =
+            cq_ctx.buf_addr + static_cast<uint64_t>(cqe_size) * static_cast<uint64_t>(next_tail & (cq_ring - 1));
+        auto *cqe = reinterpret_cast<volatile Hns1825Cqe *>(static_cast<uintptr_t>(cqe_addr));
+        invalidate_object(cqe, sizeof(*cqe));
+        const uint32_t owner_id_qpn = __atomic_load_n(&cqe->owner_id_qpn, __ATOMIC_ACQUIRE);
+        const uint32_t op_sr_wqebb = __atomic_load_n(&cqe->op_sr_wqebb, __ATOMIC_ACQUIRE);
+        constexpr uint32_t kOwnerShift = 31;
+        constexpr uint32_t kCqeOpcodeShift = 27;
+        constexpr uint32_t kCqeOpcodeMask = 0x1f;
+        constexpr uint32_t kCqeOptypeError = 0x1e;
+        constexpr uint32_t kCqeOptypeInvalid = 0x1f;
+        const uint32_t cqe_type = (op_sr_wqebb >> kCqeOpcodeShift) & kCqeOpcodeMask;
+        const bool owner = (owner_id_qpn & (1u << kOwnerShift)) != 0;
+        if (cqe_type == kCqeOptypeInvalid || !is_hns1825_cqe_owner_ready(owner, next_tail, cq_ring)) {
+            break;
+        }
+
+        if (cqe_type == kCqeOptypeError) {
+            const uint8_t syndrome = __atomic_load_n(&cqe->syndrome, __ATOMIC_ACQUIRE);
+            const uint32_t byte_cnt = __atomic_load_n(&cqe->byte_cnt, __ATOMIC_ACQUIRE);
+            const uint32_t imm_data = __atomic_load_n(&cqe->imm_data, __ATOMIC_ACQUIRE);
+            const uint32_t wqe_num = __atomic_load_n(&cqe->wqe_num, __ATOMIC_ACQUIRE);
+            const uint32_t vlan_queue_index = __atomic_load_n(&cqe->vlan_queue_index, __ATOMIC_ACQUIRE);
+            LOG_ERROR(
+                "RDMA completion invalid: CQE error handle=0x%llx workspace=0x%llx dest_rank=%u target_head=%u "
+                "cur_tail=%u next_tail=%u cqe_addr=0x%llx owner_id_qpn=0x%x op_sr_wqebb=0x%x "
+                "byte_cnt=0x%x imm_data=0x%x wqe_num=0x%x vlan_queue_index=0x%x syndrome=0x%x",
+                static_cast<unsigned long long>(event_handle), static_cast<unsigned long long>(workspace_addr),
+                dest_rank, target_head, cur_tail, next_tail, static_cast<unsigned long long>(cqe_addr), owner_id_qpn,
+                op_sr_wqebb, byte_cnt, imm_data, wqe_num, vlan_queue_index, static_cast<unsigned>(syndrome)
+            );
+            ++next_tail;
+            update_tail_info(cq_ctx, wq_ctx, next_tail);
+            return {CompletionPollState::FAILED, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID};
+        }
+        next_tail++;
+    }
+
+    if (next_tail != cur_tail) {
+        update_tail_info(cq_ctx, wq_ctx, next_tail);
+    }
+    if (!has_reached(next_tail, target_head)) {
+        // Diagnostic: AICore posts WQEs and rings the SQ hardware doorbell via
+        // st_dev, but the NIC is observed never consuming (head>tail, CQ empty).
+        // Re-issue the hardware doorbell from AICPU once per handle to test
+        // whether the AICore doorbell write is the gap. Logged once per handle.
+        static thread_local uint64_t last_ringed_handle = 0;
+        if (last_ringed_handle != event_handle) {
+            last_ringed_handle = event_handle;
+            const uint32_t sq_head = load_device_u32_or_zero(wq_ctx.head_addr);
+            if (sq_head != 0) {
+                ring_sq_doorbell_from_aicpu(wq_ctx, sq_head);
+            }
+        }
+    }
+    return {
+        has_reached(next_tail, target_head) ? CompletionPollState::READY : CompletionPollState::PENDING,
+        SIMPLER_ERROR_NONE
+    };
+}
+
+inline void
+log_rdma_event_handle_snapshot(uint64_t event_handle, uint64_t workspace_addr, int32_t entry_idx, int32_t cond_idx) {
+    uint32_t dest_rank = 0;
+    uint32_t target_head = 0;
+    decode_rdma_event_handle(event_handle, dest_rank, target_head);
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] handle=0x%llx workspace=0x%llx dest_rank=%u target_head=%u", entry_idx,
+        cond_idx, static_cast<unsigned long long>(event_handle), static_cast<unsigned long long>(workspace_addr),
+        dest_rank, target_head
+    );
+
+    if (event_handle == 0 || workspace_addr == 0 || is_rdma_error_handle(event_handle)) {
+        return;
+    }
+
+    auto *info = reinterpret_cast<volatile RdmaInfo *>(static_cast<uintptr_t>(workspace_addr));
+    invalidate_object(info, sizeof(*info));
+    const uint32_t magic = __atomic_load_n(&info->magic, __ATOMIC_ACQUIRE);
+    const uint32_t version = __atomic_load_n(&info->version, __ATOMIC_ACQUIRE);
+    const uint32_t backend = __atomic_load_n(&info->backend, __ATOMIC_ACQUIRE);
+    const uint32_t qp_num = __atomic_load_n(&info->qp_num, __ATOMIC_ACQUIRE);
+    const uint32_t rank_count = __atomic_load_n(&info->rank_count, __ATOMIC_ACQUIRE);
+    const uint64_t sq_ptr = __atomic_load_n(&info->sq_ptr, __ATOMIC_ACQUIRE);
+    const uint64_t rq_ptr = __atomic_load_n(&info->rq_ptr, __ATOMIC_ACQUIRE);
+    const uint64_t scq_ptr = __atomic_load_n(&info->scq_ptr, __ATOMIC_ACQUIRE);
+    const uint64_t rcq_ptr = __atomic_load_n(&info->rcq_ptr, __ATOMIC_ACQUIRE);
+    const uint64_t mem_ptr = __atomic_load_n(&info->mem_ptr, __ATOMIC_ACQUIRE);
+    LOG_INFO(
+        "[ASYNC_WAIT RDMA entry=%d cond=%d] info magic=0x%x version=%u backend=%u qp_num=%u rank_count=%u "
+        "sq=0x%llx rq=0x%llx scq=0x%llx rcq=0x%llx mem=0x%llx",
+        entry_idx, cond_idx, magic, version, backend, qp_num, rank_count, static_cast<unsigned long long>(sq_ptr),
+        static_cast<unsigned long long>(rq_ptr), static_cast<unsigned long long>(scq_ptr),
+        static_cast<unsigned long long>(rcq_ptr), static_cast<unsigned long long>(mem_ptr)
+    );
+    if (magic != kRdmaWorkspaceMagic || version != kRdmaWorkspaceVersion || backend != kRdmaBackendHns1825 ||
+        qp_num == 0 || dest_rank >= rank_count || sq_ptr == 0 || scq_ptr == 0) {
+        return;
+    }
+
+    const uint64_t ctx_index = static_cast<uint64_t>(dest_rank) * qp_num;
+    RdmaWqCtx sq_ctx = load_wq_ctx(sq_ptr, ctx_index);
+    log_rdma_wq_snapshot("sq", sq_ctx, entry_idx, cond_idx);
+    if (rq_ptr != 0) {
+        log_rdma_wq_snapshot("rq", load_wq_ctx(rq_ptr, ctx_index), entry_idx, cond_idx);
+    }
+    log_rdma_cq_snapshot("scq", load_cq_ctx(scq_ptr, ctx_index), target_head, entry_idx, cond_idx);
+    if (rcq_ptr != 0) {
+        log_rdma_cq_snapshot("rcq", load_cq_ctx(rcq_ptr, ctx_index), target_head, entry_idx, cond_idx);
+    }
+    if (mem_ptr != 0) {
+        log_rdma_mem_snapshot("mem", load_mem_info(mem_ptr, dest_rank), dest_rank, entry_idx, cond_idx);
+    }
+    if (target_head != 0) {
+        log_rdma_wqe_snapshot("sq", sq_ctx, 0, entry_idx, cond_idx);
+        if (target_head > 1) {
+            log_rdma_wqe_snapshot("sq", sq_ctx, target_head - 1, entry_idx, cond_idx);
+        }
+    }
+}
+
+inline void retire_rdma_event_handle(uint64_t /*event_handle*/, uint64_t /*workspace_addr*/) {}
+
+}  // namespace pto2::rdma_backend

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler.h
@@ -1456,6 +1456,52 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
     return result;
 }
 
+inline void AsyncWaitList::log_diagnostics(AICoreCompletionMailbox *aicore_mailbox) {
+    uint64_t mailbox_head = 0;
+    uint64_t mailbox_tail = 0;
+    if (aicore_mailbox != nullptr) {
+        mailbox_head = aicore_mailbox->head.load(std::memory_order_acquire);
+        mailbox_tail = aicore_mailbox->tail.load(std::memory_order_acquire);
+    }
+    LOG_INFO(
+        "[ASYNC_WAIT] mailbox_head=%llu mailbox_tail=%llu mailbox_pending=%llu mpsc_skipped=%llu",
+        static_cast<unsigned long long>(mailbox_head), static_cast<unsigned long long>(mailbox_tail),
+        static_cast<unsigned long long>(mailbox_head - mailbox_tail),
+        static_cast<unsigned long long>(mpsc_skipped_count.load(std::memory_order_relaxed))
+    );
+
+    if (!try_lock()) {
+        LOG_INFO("[ASYNC_WAIT] wait-list busy; skipping locked entry dump");
+        return;
+    }
+    LOG_INFO("[ASYNC_WAIT] wait_count=%d", count);
+
+    for (int32_t i = 0; i < count; ++i) {
+        const AsyncWaitEntry &entry = entries[i];
+        LOG_INFO(
+            "[ASYNC_WAIT entry=%d] task_token=%llu slot_state=0x%llx normal_done=%u conditions=%d waiting=%d", i,
+            static_cast<unsigned long long>(entry.task_token.raw),
+            static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(entry.slot_state)),
+            static_cast<unsigned>(entry.normal_done), entry.condition_count, entry.waiting_completion_count
+        );
+        for (int32_t c = 0; c < entry.condition_count; ++c) {
+            const CompletionCondition &cond = entry.conditions[c];
+            LOG_INFO(
+                "[ASYNC_WAIT entry=%d cond=%d] engine=%s type=%d satisfied=%u retired=%u addr=0x%llx cookie=0x%llx "
+                "expected=%u",
+                i, c, async_engine_name(cond.engine), cond.completion_type, static_cast<unsigned>(cond.satisfied),
+                static_cast<unsigned>(cond.retired), static_cast<unsigned long long>(cond.addr),
+                static_cast<unsigned long long>(cond.backend_cookie), cond.expected_value
+            );
+            if (cond.completion_type == COMPLETION_TYPE_RDMA_EVENT_HANDLE) {
+                pto2::rdma_backend::log_rdma_event_handle_snapshot(cond.addr, cond.backend_cookie, i, c);
+            }
+        }
+    }
+
+    unlock();
+}
+
 // =============================================================================
 // Scheduler Profiling Data
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -362,6 +362,10 @@ void SchedulerContext::log_shutdown_stall_snapshot(
     for (int32_t t = 0; t < thread_count; t++) {
         log_stall_diagnostics(t, total_tasks_, trigger_idle_iterations, trigger_last_progress_count);
     }
+    if (sched_ != nullptr) {
+        AICoreCompletionMailbox *mailbox = rt_ != nullptr ? rt_->aicore_mailbox : nullptr;
+        sched_->async_wait_list.log_diagnostics(mailbox);
+    }
 }
 
 SchedulerContext::StallClassification SchedulerContext::classify_stall_reason() const {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -98,6 +98,10 @@ void SchedulerContext::complete_slot_task(
 
     if (slot_state.payload != nullptr) {
         volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        cache_invalidate_range(
+            reinterpret_cast<const void *>(const_cast<DeferredCompletionSlab *>(deferred_slab)),
+            offsetof(DeferredCompletionSlab, entries)
+        );
         int32_t slab_err = deferred_slab->error_code;
         if (slab_err != SIMPLER_ERROR_NONE) {
             int32_t expected = SIMPLER_ERROR_NONE;
@@ -119,6 +123,10 @@ void SchedulerContext::complete_slot_task(
         }
 
         if (cond_count > 0) {
+            cache_invalidate_range(
+                reinterpret_cast<const void *>(const_cast<DeferredCompletionEntry *>(deferred_slab->entries)),
+                cond_count * sizeof(DeferredCompletionEntry)
+            );
             slot_state.mark_any_subtask_deferred();
 
             const TaskId token = slot_state.task->task_id;

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -1124,6 +1124,7 @@ add_a5_orchestrator_runtime_test(test_a5_orchestrator_fanin a5/test_orchestrator
 add_a5_orchestrator_runtime_test(test_a5_wiring a5/test_wiring.cpp)
 add_a5_orchestrator_runtime_test(test_a5_args_dump a5/test_args_dump.cpp)
 add_a5_runtime_test(test_a5_aicore_completion_mailbox a5/test_aicore_completion_mailbox.cpp)
+add_a5_runtime_test(test_a5_rdma_completion_scheduler a5/test_rdma_completion_scheduler.cpp)
 
 # Host logger silent/off behavior — no runtime deps, just compile the same
 # self-contained host logger sources used by production consumers.

--- a/tests/ut/cpp/a5/test_rdma_completion_scheduler.cpp
+++ b/tests/ut/cpp/a5/test_rdma_completion_scheduler.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "backend/rdma/rdma_completion_scheduler.h"
+
+namespace {
+
+using pto2::rdma_backend::encode_rdma_event_handle;
+using pto2::rdma_backend::Hns1825Cqe;
+using pto2::rdma_backend::is_hns1825_cqe_owner_ready;
+using pto2::rdma_backend::is_rdma_error_handle;
+using pto2::rdma_backend::kCqeBytes;
+using pto2::rdma_backend::poll_rdma_event_handle;
+using pto2::rdma_backend::RdmaCqCtx;
+using pto2::rdma_backend::RdmaWqCtx;
+
+constexpr uint32_t kTestCqDepth = 1024;
+
+struct alignas(kCqeBytes) TestRdmaCqe : Hns1825Cqe {};
+
+struct TestRdmaWorkspace {
+    pto2::rdma_backend::RdmaInfo info;
+    RdmaWqCtx sq[2];
+    RdmaCqCtx scq[2];
+    uint32_t sq_tail[2];
+    uint32_t cq_tail[2];
+    uint32_t cq_sw_doorbell[2];
+    TestRdmaCqe scq_entries[2][kTestCqDepth];
+};
+
+inline bool test_cqe_ready_owner(uint32_t cqe_seq) { return (cqe_seq & kTestCqDepth) != 0; }
+
+inline void encode_test_cqe(TestRdmaCqe &cqe, uint32_t cqe_seq, bool error) {
+    constexpr uint32_t kOwnerShift = 31;
+    constexpr uint32_t kCqeOpcodeShift = 27;
+    constexpr uint32_t kCqeOptypeSend = 0;
+    constexpr uint32_t kCqeOptypeError = 0x1e;
+    const uint32_t owner = test_cqe_ready_owner(cqe_seq) ? 1u : 0u;
+    cqe.owner_id_qpn = owner << kOwnerShift;
+    cqe.op_sr_wqebb = (error ? kCqeOptypeError : kCqeOptypeSend) << kCqeOpcodeShift;
+    cqe.syndrome = error ? 9 : 0;
+}
+
+inline void encode_test_pending_cqe(TestRdmaCqe &cqe, uint32_t cqe_seq) {
+    constexpr uint32_t kOwnerShift = 31;
+    constexpr uint32_t kCqeOpcodeShift = 27;
+    constexpr uint32_t kCqeOptypeSend = 0;
+    const uint32_t owner = test_cqe_ready_owner(cqe_seq) ? 0u : 1u;
+    cqe.owner_id_qpn = owner << kOwnerShift;
+    cqe.op_sr_wqebb = kCqeOptypeSend << kCqeOpcodeShift;
+}
+
+inline void encode_test_invalid_cqe(TestRdmaCqe &cqe, uint32_t cqe_seq) {
+    constexpr uint32_t kOwnerShift = 31;
+    constexpr uint32_t kCqeOpcodeShift = 27;
+    constexpr uint32_t kCqeOptypeInvalid = 0x1f;
+    const uint32_t owner = test_cqe_ready_owner(cqe_seq) ? 1u : 0u;
+    cqe.owner_id_qpn = owner << kOwnerShift;
+    cqe.op_sr_wqebb = kCqeOptypeInvalid << kCqeOpcodeShift;
+}
+
+struct SchedulerWorkspaceFixture {
+    TestRdmaWorkspace ws{};
+
+    SchedulerWorkspaceFixture() {
+        std::memset(&ws, 0, sizeof(ws));
+        ws.info.magic = pto2::rdma_backend::kRdmaWorkspaceMagic;
+        ws.info.version = pto2::rdma_backend::kRdmaWorkspaceVersion;
+        ws.info.backend = pto2::rdma_backend::kRdmaBackendHns1825;
+        ws.info.qp_num = 1;
+        ws.info.rank_count = 2;
+        ws.info.sq_ptr = reinterpret_cast<uint64_t>(&ws.sq[0]);
+        ws.info.scq_ptr = reinterpret_cast<uint64_t>(&ws.scq[0]);
+        for (uint32_t rank = 0; rank < ws.info.rank_count; ++rank) {
+            RdmaWqCtx &sq = ws.sq[rank];
+            sq.wqe_size = kCqeBytes;
+            sq.depth = kTestCqDepth;
+            sq.tail_addr = reinterpret_cast<uint64_t>(&ws.sq_tail[rank]);
+
+            RdmaCqCtx &cq = ws.scq[rank];
+            cq.buf_addr = reinterpret_cast<uint64_t>(&ws.scq_entries[rank][0]);
+            cq.cqe_size = kCqeBytes;
+            cq.depth = kTestCqDepth;
+            cq.tail_addr = reinterpret_cast<uint64_t>(&ws.cq_tail[rank]);
+            cq.db_sw_addr = reinterpret_cast<uint64_t>(&ws.cq_sw_doorbell[rank]);
+        }
+    }
+
+    uint64_t addr() { return reinterpret_cast<uint64_t>(&ws); }
+};
+
+}  // namespace
+
+TEST(A5RdmaCompletionScheduler, ErrorHandleIsDetected) {
+    EXPECT_TRUE(is_rdma_error_handle(encode_rdma_event_handle(0xffffffffu, 7)));
+    EXPECT_FALSE(is_rdma_error_handle(encode_rdma_event_handle(1, 7)));
+}
+
+TEST(A5RdmaCompletionScheduler, ZeroHandleIsReady) {
+    auto result = poll_rdma_event_handle(0, 0);
+    EXPECT_EQ(result.state, CompletionPollState::READY);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_NONE);
+}
+
+TEST(A5RdmaCompletionScheduler, ErrorHandleFails) {
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(0xffffffffu, 9), 0);
+    EXPECT_EQ(result.state, CompletionPollState::FAILED);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+}
+
+TEST(A5RdmaCompletionScheduler, NullWorkspaceFails) {
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 1), 0);
+    EXPECT_EQ(result.state, CompletionPollState::FAILED);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+}
+
+TEST(A5RdmaCompletionScheduler, OwnerReadyMatchesHns1825Backend) {
+    EXPECT_TRUE(is_hns1825_cqe_owner_ready(false, 0, kTestCqDepth));
+    EXPECT_FALSE(is_hns1825_cqe_owner_ready(true, 0, kTestCqDepth));
+    EXPECT_TRUE(is_hns1825_cqe_owner_ready(true, kTestCqDepth, kTestCqDepth));
+    EXPECT_FALSE(is_hns1825_cqe_owner_ready(false, kTestCqDepth, kTestCqDepth));
+}
+
+TEST(A5RdmaCompletionScheduler, InvalidWorkspaceMagicFails) {
+    SchedulerWorkspaceFixture fixture;
+    fixture.ws.info.magic = 0;
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::FAILED);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+}
+
+TEST(A5RdmaCompletionScheduler, InvalidRankFails) {
+    SchedulerWorkspaceFixture fixture;
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(3, 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::FAILED);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+}
+
+TEST(A5RdmaCompletionScheduler, TailAlreadyAtTargetIsReady) {
+    SchedulerWorkspaceFixture fixture;
+    fixture.ws.cq_tail[1] = 7;
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 7), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::READY);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_NONE);
+    EXPECT_EQ(fixture.ws.cq_sw_doorbell[1], 0u);
+    EXPECT_EQ(fixture.ws.sq_tail[1], 0u);
+}
+
+TEST(A5RdmaCompletionScheduler, OwnerNotReadyReturnsPending) {
+    SchedulerWorkspaceFixture fixture;
+    encode_test_pending_cqe(fixture.ws.scq_entries[1][0], 0);
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::PENDING);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_NONE);
+    EXPECT_EQ(fixture.ws.cq_tail[1], 0u);
+    EXPECT_EQ(fixture.ws.cq_sw_doorbell[1], 0u);
+    EXPECT_EQ(fixture.ws.sq_tail[1], 0u);
+}
+
+TEST(A5RdmaCompletionScheduler, InvalidOpcodeReturnsPending) {
+    SchedulerWorkspaceFixture fixture;
+    encode_test_invalid_cqe(fixture.ws.scq_entries[1][0], 0);
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::PENDING);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_NONE);
+    EXPECT_EQ(fixture.ws.cq_tail[1], 0u);
+    EXPECT_EQ(fixture.ws.cq_sw_doorbell[1], 0u);
+    EXPECT_EQ(fixture.ws.sq_tail[1], 0u);
+}
+
+TEST(A5RdmaCompletionScheduler, ReadyCqeAdvancesCqDoorbellAndSqTail) {
+    SchedulerWorkspaceFixture fixture;
+    encode_test_cqe(fixture.ws.scq_entries[1][0], 0, false);
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::READY);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_NONE);
+    EXPECT_EQ(fixture.ws.cq_tail[1], 1u);
+    EXPECT_EQ(fixture.ws.cq_sw_doorbell[1], __builtin_bswap32(1u));
+    EXPECT_EQ(fixture.ws.sq_tail[1], 0u);
+}
+
+TEST(A5RdmaCompletionScheduler, ReadyCqeAfterWrapAdvancesCqDoorbellAndSqTail) {
+    SchedulerWorkspaceFixture fixture;
+    fixture.ws.cq_tail[1] = kTestCqDepth;
+    fixture.ws.sq_tail[1] = kTestCqDepth;
+    encode_test_cqe(fixture.ws.scq_entries[1][0], kTestCqDepth, false);
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, kTestCqDepth + 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::READY);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_NONE);
+    EXPECT_EQ(fixture.ws.cq_tail[1], kTestCqDepth + 1);
+    EXPECT_EQ(fixture.ws.cq_sw_doorbell[1], __builtin_bswap32(kTestCqDepth + 1));
+    EXPECT_EQ(fixture.ws.sq_tail[1], kTestCqDepth);
+}
+
+TEST(A5RdmaCompletionScheduler, CqeErrorFailsAfterRetiringCqe) {
+    SchedulerWorkspaceFixture fixture;
+    encode_test_cqe(fixture.ws.scq_entries[1][0], 0, true);
+
+    auto result = poll_rdma_event_handle(encode_rdma_event_handle(1, 1), fixture.addr());
+    EXPECT_EQ(result.state, CompletionPollState::FAILED);
+    EXPECT_EQ(result.error_code, SIMPLER_ERROR_ASYNC_COMPLETION_INVALID);
+    EXPECT_EQ(fixture.ws.cq_tail[1], 1u);
+    EXPECT_EQ(fixture.ws.cq_sw_doorbell[1], __builtin_bswap32(1u));
+    EXPECT_EQ(fixture.ws.sq_tail[1], 0u);
+}
+
+static_assert(sizeof(TestRdmaCqe) == kCqeBytes);

--- a/tests/ut/py/test_rdma_backend_source.py
+++ b/tests/ut/py/test_rdma_backend_source.py
@@ -1,0 +1,239 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+RDMA_BACKEND_KERNEL = (
+    REPO_ROOT / "src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/rdma_completion_kernel.h"
+)
+ASYNC_WAIT = REPO_ROOT / "src/a5/runtime/tensormap_and_ringbuffer/runtime/async_wait.h"
+MAILBOX_TYPES = REPO_ROOT / "src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h"
+HOST_CMAKE = REPO_ROOT / "src/a5/platform/onboard/host/CMakeLists.txt"
+HOST_COMM = REPO_ROOT / "src/a5/platform/onboard/host/comm_hccl.cpp"
+KERNEL_COMPILER = REPO_ROOT / "simpler_setup/kernel_compiler.py"
+RDMA_SCHEDULER = REPO_ROOT / "src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/rdma_completion_scheduler.h"
+SCHEDULER_COMPLETION = REPO_ROOT / "src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp"
+RDMA_DEFERRED_DEMO = (
+    REPO_ROOT
+    / "examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/test_rdma_deferred_completion_demo.py"
+)
+RDMA_DEFERRED_ORCH = (
+    REPO_ROOT
+    / "examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/orchestration"
+    / "rdma_deferred_completion_orch.cpp"
+)
+
+
+def test_rdma_kernel_backend_exposes_deferred_adapter_contract() -> None:
+    backend = RDMA_BACKEND_KERNEL.read_text(encoding="utf-8")
+
+    assert "enum class RdmaOp" in backend
+    assert "struct RdmaRequestDescriptor" in backend
+    assert "RdmaTget" in backend
+    assert "RdmaTput" in backend
+    assert "DmaEngine::RDMA" in backend
+    assert "TGET_ASYNC<pto::comm::DmaEngine::RDMA>" in backend
+    assert "TPUT_ASYNC<pto::comm::DmaEngine::RDMA>" in backend
+    assert "register_rdma_async_event" in backend
+    assert "COMPLETION_ENGINE_ROCE" in backend
+    assert "COMPLETION_TYPE_RDMA_EVENT_HANDLE" in backend
+    assert "event.handle," in backend
+    assert "COMPLETION_ENGINE_ROCE," in backend
+    assert "COMPLETION_TYPE_RDMA_EVENT_HANDLE," in backend
+    assert "reinterpret_cast<uint64_t>(workspace)" in backend
+
+
+def test_rdma_kernel_backend_uses_peer_mr_base_not_windows_in() -> None:
+    backend = RDMA_BACKEND_KERNEL.read_text(encoding="utf-8")
+
+    assert "peer_mr_base_addr" in backend
+    assert "peer_mr_ptr" in backend
+    assert "PeerMrBaseAddr(workspace, peer)" in backend
+    assert "windowsIn" not in backend
+
+
+def test_rdma_completion_type_is_registered_in_async_wait() -> None:
+    wait_source = ASYNC_WAIT.read_text(encoding="utf-8")
+    type_source = MAILBOX_TYPES.read_text(encoding="utf-8")
+
+    assert "#define COMPLETION_TYPE_RDMA_EVENT_HANDLE 3" in type_source
+    assert "backend/rdma/rdma_completion_scheduler.h" in wait_source
+    assert "rdma_event_handle_poll_op" in wait_source
+    assert "rdma_event_handle_retire_op" in wait_source
+    assert "COMPLETION_TYPE_RDMA_EVENT_HANDLE = 3" in wait_source
+
+
+def test_a5_host_cmake_gates_rdma_workspace_overlay() -> None:
+    cmake = HOST_CMAKE.read_text(encoding="utf-8")
+
+    assert "option(SIMPLER_ENABLE_PTO_RDMA_WORKSPACE" in cmake
+    assert "set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE OFF)" in cmake
+    assert "set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ON)" in cmake
+    assert "Only one PTO async workspace overlay may be enabled" in cmake
+    assert "PTO RDMA workspace overlay requires pto-isa RDMA headers" in cmake
+    assert "PTO_RDMA_SUPPORTED" in cmake
+    assert "PTO_RDMA_BACKEND_HNS_1825_SUPPORTED" in cmake
+
+
+def test_a5_comm_hccl_keeps_urma_and_rdma_workspace_paths_macro_gated() -> None:
+    source = HOST_COMM.read_text(encoding="utf-8")
+
+    assert "#ifdef SIMPLER_ENABLE_PTO_URMA_WORKSPACE" in source
+    assert "#ifdef SIMPLER_ENABLE_PTO_RDMA_WORKSPACE" in source
+    assert '#include "pto/comm/async/rdma/rdma_workspace_manager.hpp"' in source
+    assert "std::unique_ptr<pto::comm::rdma::RdmaWorkspaceManager> rdma_workspace" in source
+
+
+def test_a5_comm_hccl_uses_mr1374_rdma_host_api_shape() -> None:
+    source = HOST_COMM.read_text(encoding="utf-8")
+
+    assert "#define __gm__" in source
+    assert "aclrtGetPhyDevIdByUserDevId" in source
+    assert "PTO_ROCE_PHYIDS" in source
+    assert "PTO_ROCE_ROOTINFO" in source
+    assert 'kDefaultRdmaRootinfoPath = "/etc/hccl_rootinfo.json"' in source
+    assert 'kDefaultVirtualTopologyPath = "/var/run/ascend-topologyd/virtualTopology.xml"' in source
+    assert "rdma_resolve_local_ip_from_virtual_topology(out.phy_id, out.local_ip)" in source
+    assert "rdma_resolve_local_ip_from_env(base_rank, rank_count, out.local_ip)" in source
+    assert "PTO_ROCE_LOCAL_IP" in source
+    assert "PTO_ROCE_IPS" in source
+    assert "rdma_resolve_local_ip_from_hccn_tool(device_id, out.local_ip)" in source
+    assert "rdma_resolve_local_ip_from_rootinfo(out.phy_id, out.local_ip, rootinfo_path)" in source
+    assert 's.find("\\"CLOS\\"", dev_key_pos)' in source
+    assert "hccn_tool -g -dev_info -i %d" in source
+    assert '\\"addr\\"' in source
+    assert "manager->Init(config)" in source
+    assert "WorkspaceInitResult::READY" in source
+    assert "RdmaBackend::HNS_1825" not in source
+
+
+def test_kernel_compiler_forwards_rdma_workspace_macros_to_incore_builds() -> None:
+    source = KERNEL_COMPILER.read_text(encoding="utf-8")
+
+    assert '"SIMPLER_ENABLE_PTO_RDMA_WORKSPACE"' in source
+    assert '"-DPTO_RDMA_SUPPORTED"' in source
+    assert '"-DPTO_RDMA_BACKEND_HNS_1825_SUPPORTED"' in source
+    assert "cmd += self._incore_feature_defines()" in source
+    assert "_pto_isa_include_dirs" in source
+    assert '"pkg_inc"' in source
+
+
+def test_kernel_compiler_adds_ascend_device_headers_for_rdma_backend_headers() -> None:
+    source = KERNEL_COMPILER.read_text(encoding="utf-8")
+
+    assert "get_ascend_incore_include_dirs" in source
+    assert 'root / "asc" / "include" / "interface"' in source
+    assert 'root / "asc" / "include" / "basic_api" / "interface"' in source
+    assert 'root / "ascendc" / "include" / "basic_api" / "interface"' in source
+    assert '"kernel_operator_sys_var_intf.h"' in source
+    assert '"kernel_operator_sys_var_intf_impl.h"' in source
+    assert ".rglob(header)" in source
+    assert "for inc_dir in self.get_ascend_incore_include_dirs():" in source
+
+
+def test_rdma_scheduler_abi_matches_mr1374_workspace_and_hns1825_contexts() -> None:
+    source = RDMA_SCHEDULER.read_text(encoding="utf-8")
+
+    assert "uint32_t rank_count;" in source
+    assert "uint32_t reserved;" in source
+    assert "uint32_t local_token_id" not in source
+    assert "static_assert(sizeof(RdmaWqCtx) == 96" in source
+    assert "static_assert(sizeof(RdmaCqCtx) == 64" in source
+    assert "struct Hns1825Cqe" in source
+    assert "static_assert(sizeof(Hns1825Cqe) == 32" in source
+    assert "struct RdmaMemInfo" in source
+    assert "static_assert(sizeof(RdmaMemInfo) == 24" in source
+    assert "uint32_t cqe_size;" in source
+    assert "1u << cq_ctx.cqe" not in source
+    assert "db_sw_addr" in source
+    assert "is_hns1825_cqe_owner_ready" in source
+    assert "const uint32_t cq_ring = cq_ctx.depth;" in source
+    assert "kHns1825CqeMaxGenNum" not in source
+    assert "owner_id_qpn" in source
+    assert "op_sr_wqebb" in source
+
+
+def test_rdma_scheduler_stall_snapshot_reports_sq_and_cq_progress() -> None:
+    source = RDMA_SCHEDULER.read_text(encoding="utf-8")
+
+    assert "load_device_u32_or_zero" in source
+    assert "load_wq_ctx" in source
+    assert "load_cq_ctx" in source
+    assert "load_mem_info" in source
+    assert "sq=0x%llx rq=0x%llx scq=0x%llx rcq=0x%llx mem=0x%llx" in source
+    assert "%s wqn=%u depth=%u wqe_size=%u head=%u tail=%u db_sw_be=0x%x" in source
+    assert "head_addr=0x%llx " in source
+    assert "tail_addr=0x%llx db_hw=0x%llx db_sw=0x%llx" in source
+    assert "%s cqn=%u depth=%u cqe_size=%u cur_head=%u cur_tail=%u target_head=%u" in source
+    assert "db_sw_be=0x%x cq_buf=0x%llx" in source
+    assert "log_rdma_mem_snapshot" in source
+    assert "log_rdma_wqe_snapshot" in source
+    assert "%s wqe index=%u addr=0x%llx raw64=" in source
+    assert 'log_rdma_wq_snapshot("rq"' in source
+    assert 'log_rdma_cq_snapshot("rcq"' in source
+
+
+def test_rdma_domain_bootstrap_resolves_env_arrays_by_domain_rank() -> None:
+    source = HOST_COMM.read_text(encoding="utf-8")
+
+    assert (
+        "resolve_rdma_bootstrap(h, domain_rank, static_cast<uint32_t>(rank_count), myDevice, rdma_bootstrap)" in source
+    )
+    assert "resolve_rdma_bootstrap(\n            h, static_cast<uint32_t>(h->rank)" not in source
+
+
+def test_rdma_kernel_uses_peer_independent_session_and_explicit_peer_ops() -> None:
+    backend = RDMA_BACKEND_KERNEL.read_text(encoding="utf-8")
+    common = (
+        REPO_ROOT
+        / "examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv"
+        / "rdma_deferred_completion_common.h"
+    ).read_text(encoding="utf-8")
+    consumer = (
+        REPO_ROOT
+        / "examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/kernels/aiv"
+        / "kernel_rdma_deferred_completion_consumer.cpp"
+    ).read_text(encoding="utf-8")
+
+    assert "pto::comm::rdma::kRdmaScratchBytes" in common
+    assert "using RdmaScratchTile = pto::Tile<pto::TileType::Vec, uint8_t, 1, kRdmaScratchBytes>" in common
+    assert (
+        "using RdmaScratchTile = pto::Tile<pto::TileType::Vec, uint8_t, 1, pto::comm::sdma::UB_ALIGN_SIZE>"
+        not in common
+    )
+    assert "desc.scratch, desc.workspace, desc.local_rank, session, desc.sync_id" in backend
+    assert "desc.scratch, desc.workspace, desc.peer_rank, desc.local_rank, session" not in backend
+    assert "TGET_ASYNC<pto::comm::DmaEngine::RDMA>(desc.dst, desc.src, session, desc.peer_rank)" in backend
+    assert "TPUT_ASYNC<pto::comm::DmaEngine::RDMA>(desc.dst, desc.src, session, desc.peer_rank)" in backend
+    assert "comm_ctx->workSpace), comm_ctx->rankId," in consumer
+    assert "readback_session, 2" in consumer
+    assert "TGET_ASYNC<pto::comm::DmaEngine::RDMA>(local_scratch, remote_tput, readback_session, peer)" in consumer
+
+
+def test_a5_scheduler_invalidates_deferred_completion_slab_before_reading_count() -> None:
+    source = SCHEDULER_COMPLETION.read_text(encoding="utf-8")
+    assert "volatile DeferredCompletionSlab *deferred_slab" in source
+    assert "cache_invalidate_range" in source
+    assert "offsetof(DeferredCompletionSlab, entries)" in source
+    assert source.index("cache_invalidate_range") < source.index("deferred_slab->error_code")
+    assert source.index("cache_invalidate_range") < source.index("deferred_slab->count")
+
+
+def test_rdma_deferred_demo_serializes_hns1825_sq_posts() -> None:
+    py_source = RDMA_DEFERRED_DEMO.read_text(encoding="utf-8")
+    orch_source = RDMA_DEFERRED_ORCH.read_text(encoding="utf-8")
+
+    assert py_source.count("[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT") == 1
+    assert py_source.count("[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT") == 1
+    assert "serialize producer posts through marker dependencies" in orch_source
+    assert "tget1_args.add_input(tget0_marker)" in orch_source
+    assert "tput0_args.add_input(tget1_marker)" in orch_source
+    assert "tput1_args.add_input(tput0_marker)" in orch_source

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -616,6 +616,55 @@ class TestRuntimeBuilderGetBinaries:
         assert host_call.kwargs["cmake_defines"]["PTO_ISA_ROOT"] == "/tmp/pto-isa"
 
     @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_a5_rdma_overlay_host_build_forwards_overlay_defines(self, MockCompiler, tmp_path, monkeypatch):
+        """RDMA overlay is forwarded to host CMake and disables the implicit URMA default."""
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        pin = "e" * 40
+        self._make_runtime(tmp_path, "a5")
+        mock_instance = MockCompiler.get_instance.return_value
+        mock_instance.compile.side_effect = lambda target, *a, **kw: (Path(kw["output_dir"]) / f"lib{target}.so")
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", raising=False)
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: pin)
+        monkeypatch.setattr(pto_isa, "ensure_pto_isa_root", lambda verbose=False: "/tmp/pto-isa")
+        monkeypatch.setattr(pto_isa, "write_pto_isa_build_metadata", lambda *args: None)
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_RDMA_WORKSPACE", "ON")
+
+        builder = RuntimeBuilder(platform="a5")
+        builder.get_binaries("test_rt", build=True)
+
+        host_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "host")
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_ENABLE_PTO_RDMA_WORKSPACE"] == "ON"
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_ENABLE_PTO_URMA_WORKSPACE"] == "OFF"
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_PTO_ISA_BUILD_COMMIT"] == pin
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
+    def test_a5_sdma_overlay_host_build_forwards_overlay_defines(self, MockCompiler, tmp_path, monkeypatch):
+        """Explicit SDMA overlay also turns off the implicit URMA default."""
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        pin = "f" * 40
+        self._make_runtime(tmp_path, "a5")
+        mock_instance = MockCompiler.get_instance.return_value
+        mock_instance.compile.side_effect = lambda target, *a, **kw: (Path(kw["output_dir"]) / f"lib{target}.so")
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_URMA_WORKSPACE", raising=False)
+        monkeypatch.delenv("SIMPLER_ENABLE_PTO_RDMA_WORKSPACE", raising=False)
+        monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: pin)
+        monkeypatch.setattr(pto_isa, "ensure_pto_isa_root", lambda verbose=False: "/tmp/pto-isa")
+        monkeypatch.setattr(pto_isa, "write_pto_isa_build_metadata", lambda *args: None)
+        monkeypatch.setenv("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "ON")
+
+        builder = RuntimeBuilder(platform="a5")
+        builder.get_binaries("test_rt", build=True)
+
+        host_call = next(call for call in mock_instance.compile.call_args_list if call.args[0] == "host")
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"] == "ON"
+        assert host_call.kwargs["cmake_defines"]["SIMPLER_ENABLE_PTO_URMA_WORKSPACE"] == "OFF"
+
+    @patch("simpler_setup.runtime_builder.RuntimeCompiler")
     def test_sim_direct_build_does_not_write_pto_isa_metadata(self, MockCompiler, tmp_path, monkeypatch):
         """get_binaries(build=True) only writes PTO-ISA metadata for embedding onboard."""
         from simpler_setup import pto_isa  # noqa: PLC0415


### PR DESCRIPTION
## Summary

  This PR introduces the RDMA (HNS1825 RoCE) asynchronous transfer and deferred completion backend for the A5 `tensormap_and_ringbuffer` runtime.

  With pto-isa adding `TGET_ASYNC` and `TPUT_ASYNC` support under `DmaEngine::RDMA`, this change completes the runtime glue in `simpler`, enabling AICore
  kernels to issue asynchronous RDMA READ/WRITE operations and defer task retirement to the AICPU CQ/SQ poller.

  The feature is gated via the opt-in CMake / environment flag `SIMPLER_ENABLE_PTO_RDMA_WORKSPACE=ON`, ensuring zero regression on the default SDMA and URMA
  backends.

  ---

  ## Key Changes

  ### 1. Backend Kernel Adapter (`src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/rdma/`)
  - **`rdma_completion_kernel.h`**:
    - Implements `RdmaTget` and `RdmaTput` descriptors mapping to `pto::comm::TGET_ASYNC` / `TPUT_ASYNC<DmaEngine::RDMA>`.
    - Calculates remote WQE target addresses using the peer's MR base address (`PeerMrBaseAddr`) plus local window offset, bypassing the need for peer VA
  mapping in device context.
    - Registers completion events with engine `COMPLETION_ENGINE_ROCE` and type `COMPLETION_TYPE_RDMA_EVENT_HANDLE` (3).

  ### 2. AICPU Scheduler Poller (`src/a5/runtime/tensormap_and_ringbuffer/runtime/`)
  - **`rdma_completion_scheduler.h`**:
    - Implements lock-free polling of HNS1825 Send/Receive Completion Queues (`RdmaCqCtx`) and updates Send Queue tail (`RdmaWqCtx`).
    - Includes detailed queue state dump diagnostics (`log_rdma_event_handle_snapshot`) for stall triage.
  - **`async_wait.h` & `aicore_completion_mailbox_types.h`**:
    - Registers `COMPLETION_TYPE_RDMA_EVENT_HANDLE` into the global completion backend table (`completion_backend_ops_for`).
    - Implements `AsyncWaitList::log_diagnostics` hook wired into shutdown stall snapshots.
  - **`scheduler_completion.cpp`**:
    - Invalidates the `DeferredCompletionSlab` cache line prior to reading error codes and condition counts.

  ### 3. Host Communication & Workspace Setup (`src/a5/platform/onboard/host/comm_hccl.cpp`)
  - **Low-segment Memory Allocation**:
    - Implements `aclrt_malloc_low_segment` to ensure symmetric windows fall below the VMM high region (`0x124000000000`), allowing HNS1825 NIC DMA
  reachability.
  - **Bootstrap Resolution**:
    - Automatically resolves RoCE physical IDs and local IPs from `hccl_rootinfo.json`, `virtualTopology.xml`, environment variables
  (`PTO_ROCE_LOCAL_IP`/`PTO_ROCE_IPS`), and `hccn_tool`.
  - **SQ Doorbell Class-of-Service Patch**:
    - Adds `patch_rdma_workspace_db_cos` to automatically patch SQ context `dbCos` in the device workspace from 0 to the NIC-configured value (4).

  ### 4. Build System & Tooling
  - **`src/a5/platform/onboard/host/CMakeLists.txt`**:
    - Adds `SIMPLER_ENABLE_PTO_RDMA_WORKSPACE` overlay option with strict mutual exclusion against `SDMA` and `URMA`.
    - Adds pto-isa `pkg_inc` to host include search paths.
  - **`simpler_setup/runtime_builder.py`**:
    - Forwards `SIMPLER_ENABLE_PTO_RDMA_WORKSPACE` to host CMake builds and automatically disables the default URMA overlay when RDMA is explicit.
  - **`simpler_setup/kernel_compiler.py`**:
    - Forwards `-DPTO_RDMA_SUPPORTED` and `-DPTO_RDMA_BACKEND_HNS_1825_SUPPORTED` to incore compiler invocations.
    - Automatically discovers CANN ascend device include directories needed for backend headers.

  ### 5. Verification & Tests
  - **Hardware Demo**:
    - `examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/`: end-to-end AIV TGET / TPUT / Consumer verification on 2 ranks.
  - **Unit Tests**:
    - `tests/ut/py/test_rdma_backend_source.py`: source contract and interface consistency tests.
    - `tests/ut/cpp/a5/test_rdma_completion_scheduler.cpp`: unit tests for synthetic CQ/SQ polling logic, registered in `tests/ut/cpp/CMakeLists.txt`.
  - **Documentation**:
    - Updated `docs/comm-domain.md` and `docs/developer-guide.md`.

  ---

  ## Hardware Validation

  Tested on real A5 NPU hardware (Device pair 1-2):
  - **Command**:
    ```bash
    SIMPLER_ENABLE_PTO_RDMA_WORKSPACE=ON pytest examples/a5/tensormap_and_ringbuffer/rdma_deferred_completion_demo/ -p a5 -d 1-2
  - Results:
    - 64 elements (256 B): PASSED (Multi-chunk WQE issue & deferred retirement verified)
    - 16384 elements (64 KiB): PASSED (Data integrity and full consumer pipeline verified)
    - All status words return kOk (0).