### PR TITLE
Refactor: give the sim base the same shared-collector bracket as onboard

### DIFF
--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -39,7 +39,6 @@
 #include "common/unified_log.h"
 #include "cpu_sim_context.h"
 #include "host_log.h"
-#include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host/runtime_timeout_config.h"
 #include "runtime.h"
@@ -574,17 +573,13 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 set_scope_stats_enabled_func_(enable_scope_stats_);
                 set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-                auto thread_factory = [this](std::function<void()> fn) {
-                    return create_thread(std::move(fn));
-                };
-                if (enable_chip_swimlane_) {
-                    if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
-                    chip_swimlane_collector_.start(thread_factory);
+                start_shared_collectors_for_run();
+                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                    auto thread_factory = [this](std::function<void()> fn) {
+                        return create_thread(std::move(fn));
+                    };
+                    dep_gen_collector_.start(thread_factory);
                 }
-                if (enable_dump_args_) dump_collector_.start(thread_factory);
-                if (enable_pmu_) pmu_collector_.start(thread_factory);
-                if (enable_dep_gen_ && !dep_gen_host_graph_active()) dep_gen_collector_.start(thread_factory);
-                if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
 
                 if (kernel_args_.device_wall_data_base != 0) {
                     *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
@@ -707,27 +702,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         return runtime_rc;
     }
 
-    // Tear down collectors. stop() joins mgmt then collector in the only safe
-    // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    finish_clock_correlation_session(true);
-    if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.quiesce();
-        chip_swimlane_collector_.read_phase_header_metadata();
-        chip_swimlane_collector_.reconcile_counters();
-        publish_host_phase_records_to_swimlane();
-        chip_swimlane_collector_.export_swimlane_json();
-    }
-
-    if (enable_dump_args_) {
-        dump_collector_.quiesce();
-        dump_collector_.reconcile_counters();
-        dump_collector_.export_dump_files();
-    }
-
-    if (enable_pmu_) {
-        pmu_collector_.quiesce();
-        pmu_collector_.reconcile_counters();
-    }
+    teardown_shared_collectors_after_run(true);
 
     // Device-orch shape: the collector stops, the ring reconciles, and the
     // records replay. The host-orch shape emits at the end of bind instead, where
@@ -742,20 +717,6 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
                 LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
             }
         }
-    }
-
-    // Per-event view of the prepare path. Keyed on output_prefix_ rather than a
-    // flag because it is non-empty exactly when this run produces diagnostic
-    // artifacts, and on the store having finished a pass, which is what a
-    // host-orchestrating runtime leaves behind.
-    if (!output_prefix_.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
-    }
-
-    if (enable_scope_stats_) {
-        scope_stats_collector_.quiesce();
-        scope_stats_collector_.reconcile_counters();
-        scope_stats_collector_.write_jsonl(output_prefix_);
     }
 
     print_handshake_results();

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -40,7 +40,6 @@
 #include "common/unified_log.h"
 #include "cpu_sim_context.h"
 #include "host_log.h"
-#include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host/runtime_timeout_config.h"
 #include "runtime.h"
@@ -554,17 +553,13 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 set_scope_stats_enabled_func_(enable_scope_stats_);
                 set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-                auto thread_factory = [this](std::function<void()> fn) {
-                    return create_thread(std::move(fn));
-                };
-                if (enable_chip_swimlane_) {
-                    if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
-                    chip_swimlane_collector_.start(thread_factory);
+                start_shared_collectors_for_run();
+                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                    auto thread_factory = [this](std::function<void()> fn) {
+                        return create_thread(std::move(fn));
+                    };
+                    dep_gen_collector_.start(thread_factory);
                 }
-                if (enable_dump_args_) dump_collector_.start(thread_factory);
-                if (enable_pmu_) pmu_collector_.start(thread_factory);
-                if (enable_dep_gen_ && !dep_gen_host_graph_active()) dep_gen_collector_.start(thread_factory);
-                if (enable_scope_stats_) scope_stats_collector_.start(thread_factory);
 
                 if (kernel_args_.device_wall_data_base != 0) {
                     *reinterpret_cast<uint64_t *>(kernel_args_.device_wall_data_base) = 0;
@@ -688,30 +683,7 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         return runtime_rc;
     }
 
-    // Tear down collectors. stop() joins mgmt then collector in the only safe
-    // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    finish_clock_correlation_session(true);
-    if (enable_chip_swimlane_) {
-        chip_swimlane_collector_.quiesce();
-        chip_swimlane_collector_.read_phase_header_metadata();
-        chip_swimlane_collector_.reconcile_counters();
-        publish_host_phase_records_to_swimlane();
-        if (!publish_runtime_chip_swimlane_extensions(active_run_->runtime)) {
-            LOG_WARN("Runtime chip-swimlane extension publication failed");
-        }
-        chip_swimlane_collector_.export_swimlane_json();
-    }
-
-    if (enable_dump_args_) {
-        dump_collector_.quiesce();
-        dump_collector_.reconcile_counters();
-        dump_collector_.export_dump_files();
-    }
-
-    if (enable_pmu_) {
-        pmu_collector_.quiesce();
-        pmu_collector_.reconcile_counters();
-    }
+    teardown_shared_collectors_after_run(true);
 
     // Device-orch shape: the collector stops, the ring reconciles, and the
     // records replay. The host-orch shape emits at the end of bind instead, where
@@ -726,20 +698,6 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
                 LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
             }
         }
-    }
-
-    // Per-event view of the prepare path. Keyed on output_prefix_ rather than a
-    // flag because it is non-empty exactly when this run produces diagnostic
-    // artifacts, and on the store having finished a pass, which is what a
-    // host-orchestrating runtime leaves behind.
-    if (!output_prefix_.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
-    }
-
-    if (enable_scope_stats_) {
-        scope_stats_collector_.quiesce();
-        scope_stats_collector_.reconcile_counters();
-        scope_stats_collector_.write_jsonl(output_prefix_);
     }
 
     print_handshake_results();
@@ -859,6 +817,13 @@ int DeviceRunner::finalize() {
 // =============================================================================
 // Performance Profiling Implementation
 // =============================================================================
+
+void DeviceRunner::publish_chip_swimlane_runtime_extensions() {
+    if (active_run_ == nullptr) return;
+    if (!publish_runtime_chip_swimlane_extensions(active_run_->runtime)) {
+        LOG_WARN("Runtime chip-swimlane extension publication failed");
+    }
+}
 
 void DeviceRunner::finalize_collectors() {
     clear_collector_shape();

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -67,6 +67,12 @@ private:
     // can re-init collectors on the next enqueue. Matches a2a3 sim.
     void finalize_collectors();
 
+    // a5 publishes runtime-derived swimlane metadata that the other arches do
+    // not have; the base calls this between the host-phase handoff and the
+    // export, the only point where the collector holds this run's records and
+    // has not yet serialized them.
+    void publish_chip_swimlane_runtime_extensions() override;
+
     // a5 sim's dlsym'd function-pointer table. Loaded once via
     // ensure_binaries_loaded(), nulled on unload_executor_binaries().
     int (*aicpu_execute_func_)(Runtime *){nullptr};

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -966,8 +966,9 @@ protected:
      *
      * Each spawned thread is bound to `device_id_` via `create_thread`.
      *
-     * Subclasses with arch-specific collectors (a2a3's
-     * `dep_gen_collector_`) call this helper and then start their own.
+     * Subclasses with arch-specific collectors (`dep_gen_collector_`) call
+     * this helper and then start their own. The sim base carries the same
+     * split.
      */
     void start_shared_collectors_for_run();
 
@@ -980,9 +981,9 @@ protected:
      * writes dump files; `pmu` has no export step beyond reconcile;
      * `scope_stats` writes JSONL).
      *
-     * Subclasses with arch-specific collectors (a2a3's
-     * `dep_gen_collector_` + its `dep_gen_replay_emit_deps_json` export)
-     * inline their own teardown after calling this helper.
+     * Subclasses with arch-specific collectors (`dep_gen_collector_` + its
+     * `dep_gen_replay_emit_deps_json` export) inline their own teardown after
+     * calling this helper. The sim base carries the same split.
      */
     void teardown_shared_collectors_after_run(bool device_execution_complete);
 

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -29,6 +29,7 @@
 #include "chip_callable_layout.h"
 #include "common/host_api.h"
 #include "cpu_sim_context.h"
+#include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "task_args_wire.h"
 #include "utils/elf_build_id.h"
@@ -821,6 +822,73 @@ void SimDeviceRunnerBase::publish_host_phase_records_to_swimlane() {
         host_phase_records_.submitted_tasks(), host_phase_records_.total_records(),
         host_phase_records_.dropped_records()
     );
+}
+
+void SimDeviceRunnerBase::start_shared_collectors_for_run() {
+    auto thread_factory = [this](std::function<void()> fn) {
+        return create_thread(std::move(fn));
+    };
+    if (enable_chip_swimlane_) {
+        if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
+        chip_swimlane_collector_.start(thread_factory);
+    }
+    if (enable_dump_args_) {
+        dump_collector_.start(thread_factory);
+    }
+    if (enable_pmu_) {
+        pmu_collector_.start(thread_factory);
+    }
+    if (enable_scope_stats_) {
+        scope_stats_collector_.start(thread_factory);
+    }
+}
+
+void SimDeviceRunnerBase::write_host_phase_records_artifact() {
+    // Every phase this records is produced on the host during bind and the store
+    // is finished before launch, so it touches no device state and is callable
+    // from any point after bind — including a path that never launched.
+    // `output_prefix_` is non-empty exactly when this run produces diagnostic
+    // artifacts, and the store writes a pass at most once.
+    if (!output_prefix_.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
+    }
+}
+
+void SimDeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execution_complete) {
+    // The order is fixed by three couplings, not by preference: the clock
+    // correlation session closes before the swimlane export reads it, the host
+    // phase records reach the collector before that same export serializes them,
+    // and each collector drains before it reconciles before it exports.
+    // Diagnostic exports use the per-task `output_prefix_` directory the user set
+    // on CallConfig (CallConfig::validate() enforces non-empty upstream).
+    finish_clock_correlation_session(device_execution_complete);
+    if (enable_chip_swimlane_) {
+        chip_swimlane_collector_.quiesce();
+        chip_swimlane_collector_.read_phase_header_metadata();
+        chip_swimlane_collector_.reconcile_counters();
+        publish_host_phase_records_to_swimlane();
+        publish_chip_swimlane_runtime_extensions();
+        chip_swimlane_collector_.export_swimlane_json();
+    }
+
+    write_host_phase_records_artifact();
+
+    if (enable_dump_args_) {
+        dump_collector_.quiesce();
+        dump_collector_.reconcile_counters();
+        dump_collector_.export_dump_files();
+    }
+
+    if (enable_pmu_) {
+        pmu_collector_.quiesce();
+        pmu_collector_.reconcile_counters();
+    }
+
+    if (enable_scope_stats_) {
+        scope_stats_collector_.quiesce();
+        scope_stats_collector_.reconcile_counters();
+        scope_stats_collector_.write_jsonl(output_prefix_);
+    }
 }
 
 void SimDeviceRunnerBase::finish_clock_correlation_session(bool capture_device_complete) noexcept {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -293,6 +293,33 @@ public:
     const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
     /** Hand this pass's records to the swimlane reader, just before its export. */
     void publish_host_phase_records_to_swimlane();
+    /**
+     * Publish arch-specific runtime metadata into the swimlane export, between
+     * the host-phase handoff and the export itself — the only point at which the
+     * collector holds this run's records but has not yet serialized them. a5
+     * overrides it; every other arch has nothing to add.
+     */
+    virtual void publish_chip_swimlane_runtime_extensions() {}
+    /**
+     * Start collector mgmt + poll threads for the four shared diagnostics
+     * collectors that are enabled. Mirrors the onboard base. Subclasses with
+     * arch-specific collectors (`dep_gen_collector_`) call this and then start
+     * their own.
+     */
+    void start_shared_collectors_for_run();
+    /** Write this pass's per-event host phase records, if it collected any. */
+    void write_host_phase_records_artifact();
+    /**
+     * Tear down the four shared diagnostics collectors after the launched
+     * kernels have synced, in the one order their couplings allow: the clock
+     * correlation session closes before the swimlane export reads it, and each
+     * collector drains before it reconciles before it exports.
+     *
+     * Subclasses with arch-specific collectors (`dep_gen_collector_` + its
+     * `dep_gen_replay_emit_deps_json` export) inline their own teardown after
+     * calling this helper, as on onboard.
+     */
+    void teardown_shared_collectors_after_run(bool device_execution_complete);
     /** Start the level-4 Host/Device clock correlation once per run. */
     void begin_clock_correlation_session_if_needed() noexcept;
     void finish_clock_correlation_session(bool capture_device_complete) noexcept;


### PR DESCRIPTION
## Summary

The per-run DFX collector sequence existed in **three copies**: the onboard base owned one for
its four shared collectors, and each sim arch runner inlined its own. Nothing held the three
together, and they had already drifted in two observable ways:

- sim wrote `host_phase_records.jsonl` **after** dep_gen; onboard writes it straight after the
  swimlane export
- a5 sim carried an extra `publish_runtime_chip_swimlane_extensions` step that a2a3 sim does not

This moves the sim copies onto `SimDeviceRunnerBase` as `start_shared_collectors_for_run()` /
`teardown_shared_collectors_after_run()`, matching the onboard base method for method. The
sequence is now stated once per platform instead of once per arch runner.

The arch runners keep exactly what the onboard base already documents as their extension —
starting and tearing down `dep_gen_collector_`, whose `dep_gen_replay_emit_deps_json` resolves
per arch tree. That extension point is deliberately left alone here; collapsing it depends on
#2156.

## The teardown order is a constraint, not a preference

The new comment records which parts are fixed, because that is what makes adopting onboard's
ordering safe rather than arbitrary:

- the clock correlation session closes **before** the swimlane export reads it
- the host phase records reach the collector **before** that same export serializes them
- each collector drains **before** it reconciles **before** it exports

Everything else is free.

## a5's extra step

It becomes `publish_chip_swimlane_runtime_extensions()`, a virtual the base calls at the one
point that step requires — between the host-phase handoff and the export, the only moment the
collector holds this run's records and has not yet serialized them.

Worth stating plainly: its underlying `publish_runtime_chip_swimlane_extensions` is **still the
weak no-op every build links today**. The symbol has two weak definitions (a5 sim, a5 onboard)
and three call sites, and no strong definition anywhere in the tree — the comment above it
describes an extension point that no runtime implements yet. So this piece is a no-op before
and after.

## Why the artifact-ordering change is safe

Both settled differences are writes to distinct paths, and nothing observes their relative
order:

- **No consumer compares one artifact kind's mtime to another's.** The four mtime sorts
  (`critical_path.py:76,85`, `deps_viewer.py:1724,1743`) each rank *one* artifact kind across
  runs; two of them rank `name_map*.json` / `merged_swimlane*.json`, which are Python
  post-processing outputs and not in this sequence at all.
- **The swimlane ↔ deps.json join is post-hoc.** `export_swimlane_json()` is "a pure dump";
  `swimlane_converter.py` performs the join after the process ends.
- **Only one append-mode writer exists** (`host_phase_records.cpp:114`), and it owns its own
  file.
- **Tests use existence, not order** — `_swimlane_validate.py` does
  `if deps_sibling.exists(): ...`, skipping that half when absent.

## Testing

**Verified per channel, in the shapes `_st-sim-{a2a3,a5}.yml` uses.** This matters more than it
sounds: a bare `pytest tests/st --platform a2a3sim` enables no DFX channel, and every artifact
assertion in these tests sits behind `if not request.config.getoption("--enable-<channel>"):
return`. A bare sweep therefore cannot fail on a collector defect — I confirmed that directly
before trusting any of it.

| | a2a3sim | a5sim |
| --- | --- | --- |
| dep_gen (tmr / hbg) | 2 / 3 | 2 / — |
| chip_swimlane (tmr / hbg) | 4 / 1 | 5 / 1 |
| pmu | 1 | 1 |
| args_dump | 1 | — |
| scope_stats | 1 | 1 |

12 channel runs, 23 cases, all green.

- [x] **Negative control fires.** With `scope_stats_collector_.write_jsonl(output_prefix_)`
      removed from the moved code, `TestScopeStats::test_run` fails on
      `scope_stats.jsonl missing under outputs/TestScopeStats_default_...` under
      `--enable-scope-stats` — and **passes** without the flag, which is the trap above.
- [x] Full sim sweeps (`examples tests/st`) green: a2a3sim 42 passed / 8 skipped, a5sim 42 passed
- [x] cpput 135/135 from a clean build dir
- [x] pyut 2206 passed / 18 skipped
- [x] onboard a2a3 dep_gen + scope_stats smoke green under `task-submit --device auto`
- [x] `clang-format --dry-run --Werror` clean on all six files

## Notes

Step toward #2078's remaining work: with the sequence in one place per platform, the later
changes there (moving the destructive arming into the execution claim, and deciding the
failure-path export) edit two sites instead of five. This PR changes no behavior on its own.

Also removes the now-dead `host/host_phase_records_artifact.h` include from both sim arch
runners, which existed only for the code that moved.

Related: #2078, #2156
