### PR TITLE
Refactor: hbg gives in-graph tasks their own compact state array

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -16,10 +16,10 @@
  * 1. Maintaining per-resource-shape ready queues
  * 2. Polling-completion dependency resolution: a GLOBAL task is ready when every
  *    producer named in its inline fanin has a COMPLETED task_states byte, an
- *    IN_GRAPH one when every producer in its Graph's fanin wire has reached
- *    task_state == COMPLETED (that table has no flag bytes); a producer publishes
- *    completion + drains its wake list on finish
- * 3. Publishing completion (task_state PENDING -> COMPLETED, task_states byte)
+ *    IN_GRAPH one when every producer in its Graph's fanin wire does — the same
+ *    array shape, held by the GraphExecution instead of the task header; a
+ *    producer publishes completion + drains its wake list on finish
+ * 3. Publishing completion (task_states byte PENDING -> COMPLETED)
  * 4. Two-stage mixed-task completion (subtask done bits -> mixed-task complete)
  *
  * The Scheduler runs on Device AI_CPU. host_build_graph is scheduler-only (the
@@ -659,15 +659,14 @@ struct SchedulerState {
         }
     }
 
-    // Producer completion under polling: publish the task_state completion
-    // mirror + the device-visible task_states byte, then drain the wake list
+    // Producer completion under polling: publish the device-visible task_states
+    // byte, then drain the wake list
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
         const int32_t task_id = slot_state.to_descriptor().task_id.local_id();
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
-        slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
         tasks.store_completed(task_id);
         // COMPLETED >= PUBLISHED, so a tracked producer that never published
         // (DUMMY, predicate-retired) still releases its publish-list waiters
@@ -1156,8 +1155,7 @@ struct SchedulerState {
         const int32_t count = execution.fanin_offsets[task_index + 1] - begin;
         const int32_t start = consumer.wake_scan_cursor < count ? consumer.wake_scan_cursor : count - 1;
         for (int32_t row = start; row >= 0; --row) {
-            const ChipTaskSlotState &producer = execution.task_at(execution.fanin_indices[begin + row]).slot;
-            if (producer.task_state.load(std::memory_order_acquire) != CHIP_TASK_COMPLETED) {
+            if (!execution.is_completed(execution.fanin_indices[begin + row])) {
                 consumer.wake_scan_cursor = static_cast<uint16_t>(row);
                 return row;
             }
@@ -1355,7 +1353,7 @@ struct SchedulerState {
         // Publish completion before closing the wake list. A consumer that
         // loses registration to the sentinel acquires this state when it
         // rescans the Orch-built fanin wire, so no wakeup can be lost.
-        slot_state.mark_completed();
+        execution->store_completed(task_index);
         outcome.fanout_edges = drain_graph_wake_list(*execution, slot_state);
 
         const bool graph_completed = graph_execution_complete_in_graph_task(*execution);
@@ -1410,8 +1408,8 @@ struct SchedulerState {
         int thread_idx
 #endif
     ) {
-        // Polling completion: publish the task_state completion mirror + the
-        // device-visible task_states byte and drain the wake list (route or
+        // Polling completion: publish the device-visible task_states
+        // byte and drain the wake list (route or
         // re-register each waiter). Replaces the
         // fanout-list walk + fanin_refcount decrements of the wiring model.
         on_mixed_task_complete(slot_state);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -219,7 +219,7 @@ void SchedulerContext::log_stall_diagnostics(
         // below it was claimed by the host orchestrator, and no slot above it was.
         for (int32_t si = 0; si < task_count; si++) {
             ChipTaskSlotState &slot_state = tasks.get_slot_state_by_task_id(si);
-            ChipTaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+            const bool completed = tasks.is_completed(si, std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
             // fanin ids vs the task_states array (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
@@ -235,10 +235,10 @@ void SchedulerContext::log_stall_diagnostics(
             int32_t kid_aiv0 = slot_state.to_descriptor().kernel_id[1];
             int32_t kid_aiv1 = slot_state.to_descriptor().kernel_id[2];
             int64_t task_id = static_cast<int64_t>(slot_state.to_descriptor().task_id.raw);
-            if (st >= CHIP_TASK_COMPLETED) continue;
-            // The slot mirror has no intermediate ready/running value — it
-            // stays PENDING until the worker stores COMPLETED (PUBLISHED
-            // lives in the task_states array, not here). Classify
+            if (completed) continue;
+            // The state byte has no intermediate ready/running value — a task
+            // stays PENDING until it publishes PUBLISHED or COMPLETED, neither
+            // of which distinguishes queued from running. Classify
             // by the ground truth instead: a slot is RUNNING iff some
             // core has it as running_slot_state. A task occupies at most
             // 3 cores (one cluster), all under the same owner thread by

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -975,25 +975,29 @@ bool create_scheduler_state(
     uint64_t aic_worker_demand = 0;
     uint64_t aiv_worker_demand = 0;
     int64_t legacy_shape_task_id = -1;
+    // The progress byte is PENDING or COMPLETED throughout this walk, never
+    // PUBLISHED: that value is stored only by the device dispatch path, which
+    // has not run yet, and orch::prepare_task resets every claimed slot this
+    // bind. So `is_completed` and its negation partition the tasks here, and a
+    // future host-side publication would silently change what these tests mean.
     for (int64_t task_id = 0; task_id < total_tasks; ++task_id) {
         ChipTaskSlotState &slot = host_sm_handle.header->tasks.get_slot_state_by_task_id(task_id);
         SchedulerTaskShape shape{};
         SchedulerGraphResult status = scheduler_classify_task_shape(host_graph, task_id, &shape);
         bool inline_dispatch_task = false;
         if (status != SchedulerGraphResult::OK) {
-            bool inline_completed_task = status == SchedulerGraphResult::UNSUPPORTED_SHAPE &&
-                                         slot.active_mask.raw() == 0 && slot.logical_block_num == 1 &&
-                                         slot.total_required_subtasks == 0 &&
-                                         slot.task_state.load(std::memory_order_acquire) == CHIP_TASK_COMPLETED &&
-                                         slot.task_attrs.allow_early_resolve() &&
-                                         !slot.task_attrs.requires_sync_start() && !slot.task_attrs.has_predicate();
+            bool inline_completed_task =
+                status == SchedulerGraphResult::UNSUPPORTED_SHAPE && slot.active_mask.raw() == 0 &&
+                slot.logical_block_num == 1 && slot.total_required_subtasks == 0 &&
+                host_sm_handle.header->tasks.is_completed(task_id) && slot.task_attrs.allow_early_resolve() &&
+                !slot.task_attrs.requires_sync_start() && !slot.task_attrs.has_predicate();
             if (inline_completed_task) {
                 inline_completed_task_ids.push_back(task_id);
                 continue;
             }
             inline_dispatch_task = status == SchedulerGraphResult::UNSUPPORTED_SHAPE && slot.active_mask.raw() == 0 &&
                                    slot.logical_block_num == 1 && slot.total_required_subtasks == 0 &&
-                                   slot.task_state.load(std::memory_order_acquire) == CHIP_TASK_PENDING &&
+                                   !host_sm_handle.header->tasks.is_completed(task_id) &&
                                    !slot.task_attrs.requires_sync_start() && !slot.task_attrs.has_predicate();
             if (!inline_dispatch_task) {
                 LOG_ERROR(
@@ -1030,7 +1034,7 @@ bool create_scheduler_state(
         const uint32_t expected_subtasks = logical_block_num * active_subtasks;
         if ((!inline_dispatch_task && (slot.active_mask.raw() != classified_active_mask ||
                                        static_cast<uint32_t>(slot.total_required_subtasks) != expected_subtasks)) ||
-            expected_subtasks > UINT16_MAX || slot.task_state.load(std::memory_order_acquire) != CHIP_TASK_PENDING ||
+            expected_subtasks > UINT16_MAX || host_sm_handle.header->tasks.is_completed(task_id) ||
             (slot.task_attrs.has_predicate() && (active_subtasks != 1 || logical_block_num != 1))) {
             LOG_ERROR(
                 "A5 HBG AICore scheduler: task id=%" PRId64

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -16,10 +16,10 @@
  * 1. Maintaining per-resource-shape ready queues
  * 2. Polling-completion dependency resolution: a GLOBAL task is ready when every
  *    producer named in its inline fanin has a COMPLETED task_states byte, an
- *    IN_GRAPH one when every producer in its Graph's fanin wire has reached
- *    task_state == COMPLETED (that table has no flag bytes); a producer publishes
- *    completion + drains its wake list on finish
- * 3. Publishing completion (task_state PENDING -> COMPLETED, task_states byte)
+ *    IN_GRAPH one when every producer in its Graph's fanin wire does — the same
+ *    array shape, held by the GraphExecution instead of the task header; a
+ *    producer publishes completion + drains its wake list on finish
+ * 3. Publishing completion (task_states byte PENDING -> COMPLETED)
  * 4. Two-stage mixed-task completion (subtask done bits -> mixed-task complete)
  *
  * The Scheduler runs on Device AI_CPU. host_build_graph is scheduler-only (the
@@ -670,15 +670,14 @@ struct SchedulerState {
         }
     }
 
-    // Producer completion under polling: publish the task_state completion
-    // mirror + the device-visible task_states byte, then drain the wake list
+    // Producer completion under polling: publish the device-visible task_states
+    // byte, then drain the wake list
     // (route/re-register each waiter). Whole-graph-resident hbg
     // has no device slot reclaim, so nothing advances a reclaim cursor here.
     void on_mixed_task_complete(ChipTaskSlotState &slot_state) {
         const int32_t task_id = slot_state.to_descriptor().task_id.local_id();
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
 
-        slot_state.mark_completed();  // completion mirror (task_state = COMPLETED)
         tasks.store_completed(task_id);
         // COMPLETED >= PUBLISHED, so a tracked producer that never published
         // (DUMMY, predicate-retired) still releases its publish-list waiters
@@ -1167,8 +1166,7 @@ struct SchedulerState {
         const int32_t count = execution.fanin_offsets[task_index + 1] - begin;
         const int32_t start = consumer.wake_scan_cursor < count ? consumer.wake_scan_cursor : count - 1;
         for (int32_t row = start; row >= 0; --row) {
-            const ChipTaskSlotState &producer = execution.task_at(execution.fanin_indices[begin + row]).slot;
-            if (producer.task_state.load(std::memory_order_acquire) != CHIP_TASK_COMPLETED) {
+            if (!execution.is_completed(execution.fanin_indices[begin + row])) {
                 consumer.wake_scan_cursor = static_cast<uint16_t>(row);
                 return row;
             }
@@ -1366,7 +1364,7 @@ struct SchedulerState {
         // Publish completion before closing the wake list. A consumer that
         // loses registration to the sentinel acquires this state when it
         // rescans the Orch-built fanin wire, so no wakeup can be lost.
-        slot_state.mark_completed();
+        execution->store_completed(task_index);
         outcome.fanout_edges = drain_graph_wake_list(*execution, slot_state);
 
         const bool graph_completed = graph_execution_complete_in_graph_task(*execution);
@@ -1421,8 +1419,8 @@ struct SchedulerState {
         int thread_idx
 #endif
     ) {
-        // Polling completion: publish the task_state completion mirror + the
-        // device-visible task_states byte and drain the wake list (route or
+        // Polling completion: publish the device-visible task_states
+        // byte and drain the wake list (route or
         // re-register each waiter). Replaces the
         // fanout-list walk + fanin_refcount decrements of the wiring model.
         on_mixed_task_complete(slot_state);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -219,7 +219,7 @@ void SchedulerContext::log_stall_diagnostics(
         // below it was claimed by the host orchestrator, and no slot above it was.
         for (int32_t si = 0; si < task_count; si++) {
             ChipTaskSlotState &slot_state = tasks.get_slot_state_by_task_id(si);
-            ChipTaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+            const bool completed = tasks.is_completed(si, std::memory_order_relaxed);
             // Polling: no fanin_refcount. Recompute met/total from the inline
             // fanin ids vs the task_states array (rc = satisfied producers,
             // fi = raw producer count) so the stall dump still shows readiness.
@@ -235,10 +235,10 @@ void SchedulerContext::log_stall_diagnostics(
             int32_t kid_aiv0 = slot_state.to_descriptor().kernel_id[1];
             int32_t kid_aiv1 = slot_state.to_descriptor().kernel_id[2];
             int64_t task_id = static_cast<int64_t>(slot_state.to_descriptor().task_id.raw);
-            if (st >= CHIP_TASK_COMPLETED) continue;
-            // The slot mirror has no intermediate ready/running value — it
-            // stays PENDING until the worker stores COMPLETED (PUBLISHED
-            // lives in the task_states array, not here). Classify
+            if (completed) continue;
+            // The state byte has no intermediate ready/running value — a task
+            // stays PENDING until it publishes PUBLISHED or COMPLETED, neither
+            // of which distinguishes queued from running. Classify
             // by the ground truth instead: a slot is RUNNING iff some
             // core has it as running_slot_state. A task occupies at most
             // 3 cores (one cluster), all under the same owner thread by

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -37,6 +37,7 @@ GraphExecution *acquire_execution_storage(
     execution->task_storage = reinterpret_cast<ChipTaskStorage *>(base + layout.tasks_offset);
     execution->task_tensor_pool = reinterpret_cast<simpler::hbg::Tensor *>(base + layout.tensors_offset);
     execution->task_scalar_pool = reinterpret_cast<uint64_t *>(base + layout.scalars_offset);
+    execution->task_states = reinterpret_cast<std::atomic<ChipTaskState> *>(base + layout.states_offset);
     return execution;
 }
 
@@ -412,7 +413,10 @@ GraphMaterializeResult graph_execution_materialize_slice(
         task.packed_buffer_end = reinterpret_cast<void *>(outer_base + task_offset + output_bytes);
 
         slot.reset_for_reuse();
-        slot.task_state.store(CHIP_TASK_PENDING, std::memory_order_relaxed);
+        // The readiness a consumer polls, cleared before this task becomes
+        // visible to one: materialization publishes tasks incrementally, so a
+        // peer may scan this index as soon as published_tasks passes it.
+        execution.reset_task_state(i);
         slot.active_mask = ActiveMask(source.active_mask);
         slot.task_attrs = TaskAttrs(source.task_attrs);
         slot.total_required_subtasks = source.total_required_subtasks;

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -380,8 +380,10 @@ directly, so boundary metadata does not need to expand to full `ChipTensor`
 records on either side of H2D.
 
 In-graph tasks consume no task-table slots. Their descriptor, payload, slot
-state, and argument pools live in the tail of the outer `GRAPH` task's own heap block,
-past `required_heap`: `[GraphExecution][ChipTaskStorage...][tensor pool][scalar pool]`. One
+state, argument pools, and completion states live in the tail of the outer `GRAPH` task's
+own heap block, past `required_heap`:
+`[GraphExecution][ChipTaskStorage...][tensor pool][scalar pool][task_states]`. The state
+array is last because a byte needs no alignment, so appending it moves no other region. One
 `TaskAllocator::alloc` covers both the packed outputs and this execution storage,
 so they are reclaimed together without a separate device allocation or release path.
 
@@ -448,8 +450,9 @@ dependency wiring remains an Orchestrator responsibility:
   operand order, so the tail is exactly the deepest producer only on an
   early-dispatch candidate's row, which recording sorts by producer index;
   elsewhere the direction is a heuristic;
-- an in-graph task's release/acquire `task_state` is its Graph-local completion truth, so
-  such tasks need neither a shared-memory `task_states` byte nor a task-table slot;
+- an in-graph task's completion truth is its execution's own `task_states` byte,
+  the same shape the task header gives a GLOBAL task, so such tasks need neither
+  a task-table slot nor a byte in the shared-memory array;
 - producer completion closes and drains only its current wake-list rather than
   traversing the saved fanout CSR;
 - a woken consumer with a single producer enters its shape queue directly; any

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -389,6 +389,19 @@ struct GraphExecution {
     ChipTaskSlotState *outer_slot{nullptr};
     ChipTaskStorage *tasks{nullptr};
     ChipTaskStorage *task_storage{nullptr};
+    // Polling-progress state, one ChipTaskState byte per in-graph task, in the
+    // storage tail. Carries the same PENDING -> PUBLISHED -> COMPLETED meaning
+    // as the shared-memory task_states array a GLOBAL task uses, against
+    // in-graph local ids instead of task-table slots, so both cohorts answer
+    // readiness the same way.
+    //
+    // A byte array of its own rather than a field of ChipTaskStorage, for the
+    // reason the top-level array gives: a fanin scan reads many producers'
+    // states at once, which a couple of cache lines answer here and would take
+    // one line per producer inside the ChipTaskStorage stride. It is also
+    // read-mostly — each byte is written once per execution at completion —
+    // so concurrent scanners share those lines rather than contend for them.
+    std::atomic<ChipTaskState> *task_states{nullptr};
     // This execution's task argument pools, in the storage tail past task_storage.
     // Every task payload's tensor and scalar deltas point here; its pool position is
     // the Definition's tensor_offset / scalar_offset.
@@ -403,6 +416,21 @@ struct GraphExecution {
     int32_t boundary_scalar_count{0};
 
     ChipTaskStorage &task_at(int32_t index) const { return task_storage[index]; }
+
+    // Readiness accessors, named and ordered as SharedMemoryTaskHeader's so a
+    // reader of one cohort reads the other the same way. The byte only ever
+    // advances, so an index a scan has already cleared stays cleared.
+    bool is_completed(int32_t index, std::memory_order order = std::memory_order_acquire) const {
+        return task_states[index].load(order) >= CHIP_TASK_COMPLETED;
+    }
+
+    void store_completed(int32_t index, std::memory_order order = std::memory_order_release) const {
+        task_states[index].store(CHIP_TASK_COMPLETED, order);
+    }
+
+    void reset_task_state(int32_t index) const {
+        task_states[index].store(CHIP_TASK_PENDING, std::memory_order_relaxed);
+    }
 };
 
 static_assert(std::is_trivially_destructible_v<ChipTaskStorage>);
@@ -444,6 +472,7 @@ struct GraphExecutionStorageLayout {
     size_t tasks_offset;
     size_t tensors_offset;
     size_t scalars_offset;
+    size_t states_offset;
     size_t total_bytes;
 };
 
@@ -458,7 +487,12 @@ inline bool graph_execution_storage_layout(
     out->tasks_offset = (sizeof(GraphExecution) + ALIGNMENT - 1) & ~(ALIGNMENT - 1);
     out->tensors_offset = out->tasks_offset + static_cast<size_t>(task_count) * sizeof(ChipTaskStorage);
     out->scalars_offset = out->tensors_offset + static_cast<size_t>(tensor_arg_count) * sizeof(simpler::hbg::Tensor);
-    out->total_bytes = out->scalars_offset + static_cast<size_t>(scalar_arg_count) * sizeof(uint64_t);
+    // The state array is last because it is the one region with no alignment of
+    // its own: a byte needs none, so appending it disturbs no other section's
+    // offset. Every other region is entered through a typed pointer whose
+    // alignment the base already guarantees.
+    out->states_offset = out->scalars_offset + static_cast<size_t>(scalar_arg_count) * sizeof(uint64_t);
+    out->total_bytes = out->states_offset + static_cast<size_t>(task_count) * sizeof(std::atomic<ChipTaskState>);
     return true;
 }
 

--- a/src/common/host_build_graph/host/orchestrator.cpp
+++ b/src/common/host_build_graph/host/orchestrator.cpp
@@ -1519,10 +1519,8 @@ static bool prepare_task(
     // Fields already zeroed by the reset_for_reuse() above:
     //   wake_list_head=nullptr, next_in_wake_list=nullptr,
     //   any_subtask_deferred=false, completed_subtasks=0, next_block_idx=0
-    // task_state is set to PENDING here as the orchestrator populates the slot
     // (host_build_graph does not recycle slots at runtime, so there is no
     // post-CONSUMED reset path).
-    out->slot_state->task_state.store(CHIP_TASK_PENDING, std::memory_order_relaxed);
     out->slot_state->total_required_subtasks = static_cast<int16_t>(total_required_subtasks);
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
@@ -2098,7 +2096,6 @@ bool graph_submit_outer(
     );
     orch->tensor_pool_cursor += tensor_slots;
     orch->scalar_pool_cursor += scalar_span;
-    slot.task_state.store(CHIP_TASK_PENDING, std::memory_order_relaxed);
     slot.active_mask = ActiveMask{};
     slot.task_attrs = TaskAttrs{};
     slot.total_required_subtasks = 0;
@@ -3042,9 +3039,8 @@ TaskOutputTensors OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
         // subtasks to retire. Running the full on_task_complete path
         // would only pay unnecessary fanout_lock / traversal overhead here.
         // The generic slot initialization done in prepare_task() is still
-        // required — a consumer reads this slot's task_attrs and completion
-        // mirror, both set below — but worker dispatch fields are never
-        // observed for hidden alloc tasks.
+        // required — a consumer reads this slot's task_attrs, set below — but
+        // worker dispatch fields are never observed for hidden alloc tasks.
         //
         // Flag the creator so it does NOT suppress its consumers' early-dispatch.
         // Under the direct-only model an unflagged producer disqualifies its
@@ -3053,12 +3049,11 @@ TaskOutputTensors OrchestratorState::alloc_tensors(const CoreTaskArgs &args) {
         // codegen task there is no Arg-driven hint to honor here, so mark it
         // unconditionally.
         prepared.slot_state->task_attrs.set_early_resolve(true);
-        prepared.slot_state->mark_completed();  // GLOBAL task, so task_state is only the completion mirror
         // Polling: pre-set the device-visible task_states byte in the H2D
-        // image. Consumers poll task_states (not the slot's task_state), so a
-        // hidden-alloc producer completed here on the host must publish its byte
-        // too — otherwise every consumer register_wakes on a producer that never
-        // runs on device and the run hangs.
+        // image. That byte is the only completion a consumer polls, so a
+        // hidden-alloc producer completed here on the host must publish it —
+        // otherwise every consumer register_wakes on a producer that never runs
+        // on device and the run hangs.
         SharedMemoryTaskHeader &done_tasks = orch->sm_header->tasks;
         int32_t done_local = prepared.task_id.local_id();
         done_tasks.store_completed(done_local);

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -253,7 +253,7 @@ struct TaskPayload;        // Forward declaration (defined below)
  *
  * Stored in the TaskDescriptor table in shared memory.
  * Contains static identification and buffer pointers only.
- * Dynamic scheduling state (fanin/fanout/task_state) is in ChipTaskSlotState.
+ * Dynamic scheduling state (fanin/fanout/wake list) is in ChipTaskSlotState.
  *
  * Fields set by Orchestrator at submission, read by Scheduler for dispatch.
  */
@@ -577,21 +577,11 @@ static_assert(sizeof(simpler::hbg::Tensor) == 128, "simpler::hbg::Tensor must be
  * is published by marking this task complete + draining its wake list. There is
  * no fanout adjacency, refcount, or per-task lock here.
  *
- * Which field carries that completion state depends on which task table the slot
- * belongs to, and both are load-bearing:
- *
- *   - A GLOBAL task holds a slot in the SM task table, so its readiness truth is
- *     `task_states[local_id]` — a byte-per-slot array, which is what lets a
- *     fanin scan read many producers out of one cache line. `task_state` is then
- *     a mirror, read only by the cold-path stall dump.
- *   - An IN_GRAPH task lives in its Graph's own storage and has no slot in that
- *     table, hence no byte there. `task_state` IS its readiness truth, read on
- *     the device by graph_first_unmet_producer; only the outer Graph shell (a
- *     GLOBAL task) gets its byte advanced when the body finishes.
- *
- * So a completion publishes both for a GLOBAL task and `task_state` alone for an
- * IN_GRAPH one. `task_state` itself only ever holds PENDING or COMPLETED; the
- * PUBLISHED middle value exists in the task_states array alone.
+ * Completion state is not here. It lives in a byte-per-task array — the shared
+ * memory task header's for a GLOBAL task, the GraphExecution's for an IN_GRAPH
+ * one — because a fanin scan reads many producers' states at once, which a
+ * cache line of that array answers and would take one line per producer inside
+ * this struct's stride.
  */
 struct alignas(64) ChipTaskSlotState {
     // --- Wake list: last-fanin notification (intrusive, lock-free) ---
@@ -660,14 +650,6 @@ struct alignas(64) ChipTaskSlotState {
     // what makes this wider than its early-dispatch twin below.
     uint16_t wake_scan_cursor{0xFFFF};
 
-    // Completion state, PENDING or COMPLETED only (never PUBLISHED). PENDING at
-    // submit; COMPLETED at whichever completion path owns this slot. For an
-    // IN_GRAPH task this is the readiness truth the device itself polls
-    // (graph_first_unmet_producer); for a GLOBAL task it mirrors
-    // task_states[slot], which is what the device reads instead. Also read by
-    // the cold-path stall dump.
-    std::atomic<ChipTaskState> task_state;
-
     // --- Set per-submit (depend on task inputs) ---
     ActiveMask active_mask;  // Bitmask of active subtask slots (set once)
     // Single per-task attributes byte (early-dispatch hint, sync_start,
@@ -705,7 +687,7 @@ struct alignas(64) ChipTaskSlotState {
 
     // Keeps the record at one cache line. Members run widest-first up to the
     // byte block above, so their sizes sum to exactly the bytes this leaves.
-    uint8_t reserved[3];
+    uint8_t reserved[4];
 
     int32_t claim_block_range(int32_t block_limit, int32_t max_count, int32_t &start) {
         int16_t current = next_block_idx.load(std::memory_order_relaxed);
@@ -724,12 +706,6 @@ struct alignas(64) ChipTaskSlotState {
         return 0;
     }
 
-    // Publishes completion. For an IN_GRAPH task this store is the whole
-    // publication — that task has no task_states byte. For a GLOBAL task it
-    // accompanies the task_states[slot] store that on_mixed_task_complete
-    // makes, and is the copy the cold-path stall dump reads.
-    void mark_completed() { task_state.store(CHIP_TASK_COMPLETED, std::memory_order_release); }
-
     void mark_any_subtask_deferred() { any_subtask_deferred.store(true, std::memory_order_release); }
 
     bool has_any_subtask_deferred() const { return any_subtask_deferred.load(std::memory_order_acquire); }
@@ -738,8 +714,8 @@ struct alignas(64) ChipTaskSlotState {
      * Reset dynamic scheduling fields to their pristine values. Called once per
      * slot as the orchestrator claims it in prepare_task, and again as an
      * in-graph task's storage is materialized — whole-graph-resident hbg has no
-     * execution-time slot recycle. Skips task_state (the orchestrator sets PENDING
-     * when it populates the slot).
+     * execution-time slot recycle. The task's completion state is not here; its
+     * owning array is cleared alongside this call.
      * wake_list_head starts nullptr (open for registration), NOT SENTINEL.
      */
     void reset_for_reuse() {
@@ -780,7 +756,7 @@ static_assert(sizeof(ChipTaskSlotState) == 64);
 static_assert(
     offsetof(ChipTaskSlotState, ed_publish_list_head) == 16, "the ED publish pair sits right after its wake-list twin"
 );
-static_assert(offsetof(ChipTaskSlotState, reserved) == 61, "ChipTaskSlotState grew interior padding");
+static_assert(offsetof(ChipTaskSlotState, reserved) == 60, "ChipTaskSlotState grew interior padding");
 
 // =============================================================================
 // Per-Task Storage

--- a/src/common/host_build_graph/shared_memory.h
+++ b/src/common/host_build_graph/shared_memory.h
@@ -72,17 +72,17 @@ struct alignas(64) SharedMemoryTaskHeader {
     // (is_completed) and the ED publish scan (is_published). Reset per-slot in
     // orch::prepare_task as each slot is claimed. Indexed by local task id, like
     // the storage array — so it covers GLOBAL tasks only. An IN_GRAPH task holds
-    // no slot here and publishes completion through its own
-    // ChipTaskSlotState::task_state instead; the Graph's outer shell is the GLOBAL
-    // task that carries the byte for the whole body.
+    // no slot here and publishes completion through its GraphExecution's array
+    // of the same shape; the Graph's outer shell is the GLOBAL task that carries
+    // the byte for the whole body.
     //
     // A byte array of its own rather than a field of ChipTaskStorage: a fanin scan
     // reads many producers' states at once, which one cache line answers here and
     // would take one line per producer inside the storage stride.
     //
     // A hidden-alloc task is the one byte the host presets to COMPLETED: it
-    // completes during orchestration, and a consumer polls this array rather than
-    // task_state.
+    // completes during orchestration rather than on device, and a consumer polls
+    // this array to see it.
     //
     // Reads are only meaningful under the init-on-write discipline above, and
     // the ordered comparisons make that stricter than a bit test would: an

--- a/tests/ut/cpp/a2a3/test_graph_activation.cpp
+++ b/tests/ut/cpp/a2a3/test_graph_activation.cpp
@@ -15,8 +15,8 @@
  * whole GRAPH task is materialized, so a producer can complete while a later
  * consumer is still being registered. Scene tests hit that interleaving only
  * probabilistically; these host-side tests force it, exercising the exact path
- * (graph_first_unmet_producer re-reading task_state) that keeps the consumer from
- * being lost on a producer's already-drained wake list.
+ * (graph_first_unmet_producer re-reading the execution's task_states) that keeps the
+ * consumer from being lost on a producer's already-drained wake list.
  */
 
 #include <gtest/gtest.h>
@@ -59,9 +59,11 @@ protected:
     // One in-graph task whose slot is a routable single-block KERNEL/AIC
     // task in the given completion state, with its payload wired the way
     // materialization leaves it for the wake/route path.
-    static void init_in_graph_task(ChipTaskStorage &task, int32_t task_index, ChipTaskState state) {
+    static void init_in_graph_task(
+        ChipTaskStorage &task, std::atomic<ChipTaskState> *states, int32_t task_index, ChipTaskState state
+    ) {
         memset(&task, 0, sizeof(ChipTaskStorage));
-        task.slot.task_state.store(state);
+        states[task_index].store(state);
         task.slot.in_graph_local_id = task_index;
         task.slot.active_mask = ActiveMask(SUBTASK_MASK_AIC);
         task.slot.task_kind = TaskKind::KERNEL;
@@ -71,18 +73,20 @@ protected:
 };
 
 // A consumer registered after its only producer has completed and drained (head
-// == SENTINEL) reaches graph_first_unmet_producer, which reads task_state and
+// == SENTINEL) reaches graph_first_unmet_producer, which reads the state array and
 // routes it — it is never lost on the closed wake list.
 TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegister) {
     auto tasks = std::make_unique<ChipTaskStorage[]>(2);
-    init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);    // producer, already completed
-    init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);      // consumer of task 0
-    tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
+    auto states = std::make_unique<std::atomic<ChipTaskState>[]>(2);
+    init_in_graph_task(tasks[0], states.get(), 0, CHIP_TASK_COMPLETED);  // producer, already completed
+    init_in_graph_task(tasks[1], states.get(), 1, CHIP_TASK_PENDING);    // consumer of task 0
+    tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);              // its wake list already drained
 
     std::vector<int32_t> fanin_offsets{0, 0, 1};  // task 0 is a root; task 1 <- {0}
     std::vector<uint16_t> fanin_indices{0};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();
+    exec.task_states = states.get();
     exec.fanin_offsets = fanin_offsets.data();
     exec.fanin_indices = fanin_indices.data();
 
@@ -99,15 +103,17 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
 // routes exactly once that producer completes and drains its wake list.
 TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPending) {
     auto tasks = std::make_unique<ChipTaskStorage[]>(4);
-    init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);  // root, completed
-    init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);    // root, pending
-    init_in_graph_task(tasks[2], 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
-    init_in_graph_task(tasks[3], 3, CHIP_TASK_PENDING);    // consumer of task 1 (pending)
+    auto states = std::make_unique<std::atomic<ChipTaskState>[]>(4);
+    init_in_graph_task(tasks[0], states.get(), 0, CHIP_TASK_COMPLETED);  // root, completed
+    init_in_graph_task(tasks[1], states.get(), 1, CHIP_TASK_PENDING);    // root, pending
+    init_in_graph_task(tasks[2], states.get(), 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
+    init_in_graph_task(tasks[3], states.get(), 3, CHIP_TASK_PENDING);    // consumer of task 1 (pending)
 
     std::vector<int32_t> fanin_offsets{0, 0, 0, 1, 2};  // task 2 <- {0}, task 3 <- {1}
     std::vector<uint16_t> fanin_indices{0, 1};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();
+    exec.task_states = states.get();
     exec.fanin_offsets = fanin_offsets.data();
     exec.fanin_indices = fanin_indices.data();
 
@@ -119,7 +125,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
         << "only the consumer whose producers are all COMPLETED routes at publish time";
     EXPECT_EQ(out[0], &tasks[2].slot);
 
-    tasks[1].slot.task_state.store(CHIP_TASK_COMPLETED);
+    states[1].store(CHIP_TASK_COMPLETED);
     sched.drain_graph_wake_list(exec, tasks[1].slot);
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, ResourceShape::AIC, out, 4), 1)
         << "the wake-chained consumer must route once its pending producer completes";
@@ -134,6 +140,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
     GraphDefinition definition{};
     auto complete_in_state = [&](GraphExecutionState state) {
         auto task = std::make_unique<ChipTaskStorage[]>(1);
+        auto states = std::make_unique<std::atomic<ChipTaskState>[]>(1);
         memset(task.get(), 0, sizeof(ChipTaskStorage));
         task[0].slot.in_graph_local_id = 0;
         task[0].slot.total_required_subtasks = 1;
@@ -141,6 +148,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
         GraphExecution exec{};
         exec.definition = &definition;
         exec.tasks = exec.task_storage = task.get();
+        exec.task_states = states.get();
         exec.task_count = 1;
         exec.remaining_tasks.store(1);
         exec.outer_slot = nullptr;
@@ -186,5 +194,5 @@ TEST_F(GraphActivationTest, CompleteTaskTakesTheOrdinaryPathForTheOuterGraphTask
 
     EXPECT_EQ(outcome.error_code, SIMPLER_ERROR_NONE);
     EXPECT_EQ(outcome.stream_tasks_completed, 1) << "the outer Graph task is one completed task of the run";
-    EXPECT_EQ(slot.task_state.load(std::memory_order_relaxed), CHIP_TASK_COMPLETED);
+    EXPECT_TRUE(sm_handle->header->tasks.is_completed(slot.to_descriptor().task_id.local_id()));
 }

--- a/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a2a3/test_hbg_submit_poison.cpp
@@ -142,13 +142,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local_id(), local);
-        // task_state is written at submit (reset_for_reuse skips it): PENDING for a
-        // dispatchable task, COMPLETED for a pre-completed hidden-alloc. Either way a
-        // real enum, never poison.
-        const ChipTaskState state = st.task_state.load(std::memory_order_relaxed);
-        EXPECT_TRUE(state == CHIP_TASK_PENDING || state == CHIP_TASK_COMPLETED);
-        // The progress byte is written to a real state (pending vs pre-completed),
-        // not a poison byte (0xAA).
+        // The progress byte is written to a real state at submit — PENDING for a
+        // dispatchable task, COMPLETED for a pre-completed hidden-alloc — never a
+        // poison byte (0xAA).
         const ChipTaskState sm_state = tasks.task_states[local].load(std::memory_order_relaxed);
         EXPECT_TRUE(sm_state == CHIP_TASK_PENDING || sm_state == CHIP_TASK_COMPLETED);
         // Payload counts are real, not the poison bit pattern.
@@ -159,7 +155,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         // predicate.op is a dispatch-time field, read only for tasks the device
         // actually dispatches. submit_task_common writes it (NONE when unset); a
         // pre-completed hidden-alloc is never dispatched, so it does not.
-        if (state == CHIP_TASK_PENDING) {
+        if (sm_state == CHIP_TASK_PENDING) {
             EXPECT_LE(static_cast<uint8_t>(pl.predicate.op), static_cast<uint8_t>(PredicateOp::LE));
         }
     }

--- a/tests/ut/cpp/a5/test_graph_activation.cpp
+++ b/tests/ut/cpp/a5/test_graph_activation.cpp
@@ -15,8 +15,8 @@
  * whole GRAPH task is materialized, so a producer can complete while a later
  * consumer is still being registered. Scene tests hit that interleaving only
  * probabilistically; these host-side tests force it, exercising the exact path
- * (graph_first_unmet_producer re-reading task_state) that keeps the consumer from
- * being lost on a producer's already-drained wake list.
+ * (graph_first_unmet_producer re-reading the execution's task_states) that keeps the
+ * consumer from being lost on a producer's already-drained wake list.
  */
 
 #include <gtest/gtest.h>
@@ -59,9 +59,11 @@ protected:
     // One in-graph task whose slot is a routable single-block KERNEL/AIC
     // task in the given completion state, with its payload wired the way
     // materialization leaves it for the wake/route path.
-    static void init_in_graph_task(ChipTaskStorage &task, int32_t task_index, ChipTaskState state) {
+    static void init_in_graph_task(
+        ChipTaskStorage &task, std::atomic<ChipTaskState> *states, int32_t task_index, ChipTaskState state
+    ) {
         memset(&task, 0, sizeof(ChipTaskStorage));
-        task.slot.task_state.store(state);
+        states[task_index].store(state);
         task.slot.in_graph_local_id = task_index;
         task.slot.active_mask = ActiveMask(SUBTASK_MASK_AIC);
         task.slot.task_kind = TaskKind::KERNEL;
@@ -71,18 +73,20 @@ protected:
 };
 
 // A consumer registered after its only producer has completed and drained (head
-// == SENTINEL) reaches graph_first_unmet_producer, which reads task_state and
+// == SENTINEL) reaches graph_first_unmet_producer, which reads the state array and
 // routes it — it is never lost on the closed wake list.
 TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegister) {
     auto tasks = std::make_unique<ChipTaskStorage[]>(2);
-    init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);    // producer, already completed
-    init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);      // consumer of task 0
-    tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);  // its wake list already drained
+    auto states = std::make_unique<std::atomic<ChipTaskState>[]>(2);
+    init_in_graph_task(tasks[0], states.get(), 0, CHIP_TASK_COMPLETED);  // producer, already completed
+    init_in_graph_task(tasks[1], states.get(), 1, CHIP_TASK_PENDING);    // consumer of task 0
+    tasks[0].slot.wake_list_head.store(WAKE_LIST_SENTINEL);              // its wake list already drained
 
     std::vector<int32_t> fanin_offsets{0, 0, 1};  // task 0 is a root; task 1 <- {0}
     std::vector<uint16_t> fanin_indices{0};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();
+    exec.task_states = states.get();
     exec.fanin_offsets = fanin_offsets.data();
     exec.fanin_indices = fanin_indices.data();
 
@@ -99,15 +103,17 @@ TEST_F(GraphActivationTest, WakeRoutesConsumerWhenProducerCompletedBeforeRegiste
 // routes exactly once that producer completes and drains its wake list.
 TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPending) {
     auto tasks = std::make_unique<ChipTaskStorage[]>(4);
-    init_in_graph_task(tasks[0], 0, CHIP_TASK_COMPLETED);  // root, completed
-    init_in_graph_task(tasks[1], 1, CHIP_TASK_PENDING);    // root, pending
-    init_in_graph_task(tasks[2], 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
-    init_in_graph_task(tasks[3], 3, CHIP_TASK_PENDING);    // consumer of task 1 (pending)
+    auto states = std::make_unique<std::atomic<ChipTaskState>[]>(4);
+    init_in_graph_task(tasks[0], states.get(), 0, CHIP_TASK_COMPLETED);  // root, completed
+    init_in_graph_task(tasks[1], states.get(), 1, CHIP_TASK_PENDING);    // root, pending
+    init_in_graph_task(tasks[2], states.get(), 2, CHIP_TASK_PENDING);    // consumer of task 0 (completed)
+    init_in_graph_task(tasks[3], states.get(), 3, CHIP_TASK_PENDING);    // consumer of task 1 (pending)
 
     std::vector<int32_t> fanin_offsets{0, 0, 0, 1, 2};  // task 2 <- {0}, task 3 <- {1}
     std::vector<uint16_t> fanin_indices{0, 1};
     GraphExecution exec{};
     exec.tasks = exec.task_storage = tasks.get();
+    exec.task_states = states.get();
     exec.fanin_offsets = fanin_offsets.data();
     exec.fanin_indices = fanin_indices.data();
 
@@ -119,7 +125,7 @@ TEST_F(GraphActivationTest, IncrementalPublishRoutesCompletedDepsAndWakeChainsPe
         << "only the consumer whose producers are all COMPLETED routes at publish time";
     EXPECT_EQ(out[0], &tasks[2].slot);
 
-    tasks[1].slot.task_state.store(CHIP_TASK_COMPLETED);
+    states[1].store(CHIP_TASK_COMPLETED);
     sched.drain_graph_wake_list(exec, tasks[1].slot);
     ASSERT_EQ(sched.get_ready_tasks_batch(sched.ready_queues, ResourceShape::AIC, out, 4), 1)
         << "the wake-chained consumer must route once its pending producer completes";
@@ -134,6 +140,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
     GraphDefinition definition{};
     auto complete_in_state = [&](GraphExecutionState state) {
         auto task = std::make_unique<ChipTaskStorage[]>(1);
+        auto states = std::make_unique<std::atomic<ChipTaskState>[]>(1);
         memset(task.get(), 0, sizeof(ChipTaskStorage));
         task[0].slot.in_graph_local_id = 0;
         task[0].slot.total_required_subtasks = 1;
@@ -141,6 +148,7 @@ TEST_F(GraphActivationTest, CompleteTaskAcceptsCompletionBeforeActive) {
         GraphExecution exec{};
         exec.definition = &definition;
         exec.tasks = exec.task_storage = task.get();
+        exec.task_states = states.get();
         exec.task_count = 1;
         exec.remaining_tasks.store(1);
         exec.outer_slot = nullptr;
@@ -186,5 +194,5 @@ TEST_F(GraphActivationTest, CompleteTaskTakesTheOrdinaryPathForTheOuterGraphTask
 
     EXPECT_EQ(outcome.error_code, SIMPLER_ERROR_NONE);
     EXPECT_EQ(outcome.stream_tasks_completed, 1) << "the outer Graph task is one completed task of the run";
-    EXPECT_EQ(slot.task_state.load(std::memory_order_relaxed), CHIP_TASK_COMPLETED);
+    EXPECT_TRUE(sm_handle->header->tasks.is_completed(slot.to_descriptor().task_id.local_id()));
 }

--- a/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
+++ b/tests/ut/cpp/a5/test_hbg_submit_poison.cpp
@@ -141,13 +141,9 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
 
         // Descriptor: the task id is written to this exact local id.
         EXPECT_EQ(desc.task_id.local_id(), local);
-        // task_state is written at submit (reset_for_reuse skips it): PENDING for a
-        // dispatchable task, COMPLETED for a pre-completed hidden-alloc. Either way a
-        // real enum, never poison.
-        const ChipTaskState state = st.task_state.load(std::memory_order_relaxed);
-        EXPECT_TRUE(state == CHIP_TASK_PENDING || state == CHIP_TASK_COMPLETED);
-        // The progress byte is written to a real state (pending vs pre-completed),
-        // not a poison byte (0xAA).
+        // The progress byte is written to a real state at submit — PENDING for a
+        // dispatchable task, COMPLETED for a pre-completed hidden-alloc — never a
+        // poison byte (0xAA).
         const ChipTaskState sm_state = tasks.task_states[local].load(std::memory_order_relaxed);
         EXPECT_TRUE(sm_state == CHIP_TASK_PENDING || sm_state == CHIP_TASK_COMPLETED);
         // Payload counts are real, not the poison bit pattern.
@@ -158,7 +154,7 @@ TEST_F(HbgSubmitPoisonTest, EveryDeviceReadFieldIsWrittenOverPoison) {
         // predicate.op is a dispatch-time field, read only for tasks the device
         // actually dispatches. submit_task_common writes it (NONE when unset); a
         // pre-completed hidden-alloc is never dispatched, so it does not.
-        if (state == CHIP_TASK_PENDING) {
+        if (sm_state == CHIP_TASK_PENDING) {
             EXPECT_LE(static_cast<uint8_t>(pl.predicate.op), static_cast<uint8_t>(PredicateOp::LE));
         }
     }

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -321,7 +321,10 @@ TEST(GraphExecutionStorage, ComputesAlignedExactSize) {
     EXPECT_EQ(layout.tensors_offset, layout.tasks_offset + TASK_COUNT * sizeof(ChipTaskStorage));
     EXPECT_EQ(layout.tensors_offset % alignof(simpler::hbg::Tensor), 0U);
     EXPECT_EQ(layout.scalars_offset, layout.tensors_offset + TENSOR_ARGS * sizeof(simpler::hbg::Tensor));
-    EXPECT_EQ(layout.total_bytes, layout.scalars_offset + SCALAR_ARGS * sizeof(uint64_t));
+    // The state array is last and byte-aligned, so it starts exactly where the
+    // scalar pool ends and closes the image.
+    EXPECT_EQ(layout.states_offset, layout.scalars_offset + SCALAR_ARGS * sizeof(uint64_t));
+    EXPECT_EQ(layout.total_bytes, layout.states_offset + TASK_COUNT * sizeof(std::atomic<ChipTaskState>));
 }
 
 // The outer Graph payload's tensor region is counted in simpler::hbg::Tensor pool slots but
@@ -711,10 +714,12 @@ TEST(GraphExecutionProgress, InGraphTaskResolutionIsNotAHostCompletion) {
     SchedulerState scheduler{};
     GraphDefinition definition{};
     ChipTaskStorage task{};
+    std::atomic<ChipTaskState> states[1]{};
     GraphExecution execution{};
     execution.definition = &definition;
     execution.tasks = &task;
     execution.task_storage = &task;
+    execution.task_states = states;
     execution.task_count = 1;
     execution.remaining_tasks.store(1, std::memory_order_relaxed);
     graph_execution_set_state(execution, GraphExecutionState::ACTIVE, std::memory_order_relaxed);
@@ -766,7 +771,7 @@ TEST(GraphExecutionMaterialize, DirtyStorageYieldsValidExecution) {
     // values only the device side wrote.
     for (int32_t i = 0; i < execution->task_count; ++i) {
         const ChipTaskStorage &storage = execution->task_at(i);
-        ASSERT_EQ(storage.slot.task_state.load(std::memory_order_relaxed), CHIP_TASK_PENDING);
+        ASSERT_EQ(execution->task_states[i].load(std::memory_order_relaxed), CHIP_TASK_PENDING);
         ASSERT_EQ(storage.slot.task_kind, TaskKind::KERNEL);
         ASSERT_EQ(storage.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
         ASSERT_EQ(storage.payload.published_block_count.load(std::memory_order_relaxed), 0);

--- a/tests/ut/cpp/common/test_hbg_graph_ed_qualification.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_ed_qualification.cpp
@@ -277,6 +277,8 @@ protected:
     // ChipTaskStorage holds atomics, so it is neither copyable nor movable and
     // cannot back a vector; this constructs each element in place.
     std::unique_ptr<ChipTaskStorage[]> storage;
+    // The execution's readiness array, allocated with the storage it indexes.
+    std::unique_ptr<std::atomic<ChipTaskState>[]> states;
     std::vector<int32_t> fanin_offsets;
     std::vector<uint16_t> fanin_indices;
 
@@ -300,6 +302,8 @@ protected:
     // pending AIV leaf, the state materialization leaves it in.
     void build(const std::vector<std::vector<uint16_t>> &rows) {
         storage = std::make_unique<ChipTaskStorage[]>(rows.size());
+        states = std::make_unique<std::atomic<ChipTaskState>[]>(rows.size());
+        execution.task_states = states.get();
         fanin_offsets.assign(1, 0);
         for (size_t i = 0; i < rows.size(); ++i) {
             fanin_indices.insert(fanin_indices.end(), rows[i].begin(), rows[i].end());
@@ -309,7 +313,7 @@ protected:
             s.in_graph_local_id = static_cast<int32_t>(i);
             s.active_mask = ActiveMask(SUBTASK_MASK_AIV0);
             s.graph_context = &execution;
-            s.task_state.store(CHIP_TASK_PENDING, std::memory_order_relaxed);
+            execution.reset_task_state(static_cast<int32_t>(i));
         }
         execution.task_count = static_cast<int32_t>(rows.size());
         execution.task_storage = storage.get();
@@ -340,16 +344,16 @@ TEST_F(HbgGraphWakeScanTest, CursorResumesAndNeverRewalks) {
 
     // The hung-at producer completes: the rescan resumes at the cursor and walks
     // down to the next unmet row entry.
-    slot(2).mark_completed();
+    execution.store_completed(2);
     EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), 1);
     EXPECT_EQ(consumer.wake_scan_cursor, 1);
 
     // An entry above the cursor completing does not move it — nothing re-walks
     // that tail — and clearing the rest yields the ready verdict.
-    slot(0).mark_completed();
+    execution.store_completed(0);
     EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), 1);
     EXPECT_EQ(consumer.wake_scan_cursor, 1);
-    slot(1).mark_completed();
+    execution.store_completed(1);
     EXPECT_EQ(sched.graph_first_unmet_producer(execution, consumer), -1);
 }
 
@@ -374,7 +378,7 @@ TEST_F(HbgGraphWakeScanTest, SingleProducerWaiterIsRoutedByTheDrain) {
     sched.register_graph_wake(execution, &producer, &consumer);
     ASSERT_EQ(producer.wake_list_head.load(std::memory_order_relaxed), &consumer);
 
-    producer.mark_completed();
+    execution.store_completed(0);
     EXPECT_EQ(sched.drain_graph_wake_list(execution, producer), 1u);
     EXPECT_EQ(pop_ready(), &consumer);
     // Decided from the row's length alone, so the never-hung sentinel stands.
@@ -388,7 +392,7 @@ TEST_F(HbgGraphWakeScanTest, MultiProducerWaiterReRegistersUntilItsRowClears) {
     ChipTaskSlotState &consumer = slot(2);
 
     sched.register_graph_wake(execution, &slot(1), &consumer);
-    slot(1).mark_completed();
+    execution.store_completed(1);
     EXPECT_EQ(sched.drain_graph_wake_list(execution, slot(1)), 1u);
 
     // Producer 0 is still pending, so the waiter moved rather than became ready.
@@ -396,7 +400,7 @@ TEST_F(HbgGraphWakeScanTest, MultiProducerWaiterReRegistersUntilItsRowClears) {
     EXPECT_EQ(slot(0).wake_list_head.load(std::memory_order_relaxed), &consumer);
     EXPECT_EQ(consumer.wake_scan_cursor, 0);
 
-    slot(0).mark_completed();
+    execution.store_completed(0);
     EXPECT_EQ(sched.drain_graph_wake_list(execution, slot(0)), 1u);
     EXPECT_EQ(pop_ready(), &consumer);
 }


### PR DESCRIPTION
This is the **last prerequisite** for in-graph early dispatch. It turns on no early dispatch of its own; the next PR wires the publish chain and is where the payoff is measured.

## Summary

An in-graph task's readiness lived in its `ChipTaskSlotState`, so `graph_first_unmet_producer` dereferenced one 64-byte slot per producer, striding 320 bytes between them — and those are the lines the completion path writes, through the wake-list CAS, the per-subtask `completed_subtasks` increment and the per-block `next_block_idx` claim. A scan paid a miss per producer on lines being invalidated by traffic it had no interest in.

A `GraphExecution` now carries a byte-per-task `ChipTaskState` array in its storage tail — the same shape the shared-memory task header already gives GLOBAL tasks, so both cohorts answer readiness the same way. That is what lets the publish chain be parameterized rather than forked when in-graph early dispatch lands: the publish bit finally has somewhere to live for an in-graph task, which was the one hard gap. The region is last in the layout because a byte needs no alignment, so appending it moves no other section.

**`ChipTaskSlotState::task_state` is deleted.** With the in-graph read migrated it had no readers the arrays cannot answer: the cold-path stall dump and the a5 host-side scheduler preflight both walk GLOBAL slots, so they read the task header's array. The field goes, along with `mark_completed` and the PENDING stores that paired with it. One task now has one completion state rather than a state and a mirror of it, and `reserved` absorbs the freed byte so the slot stays a single cache line.

## Testing

- [x] a2a3 `host_build_graph` sim 12 passed / 7 skipped; a5 13 passed
- [x] C++ unit tests 137/137
- [x] Device A/B vs #2144's head, 100 rounds, 8 cases, both arms on one pinned die, run twice on two dies

**No reproducible regression.** Each run had one case above 2%, and both reversed sign on the other die, so neither survives:

| Example / Case | die 5 | die 13 |
| --- | ---: | ---: |
| alternating_matmul_add/Case1 | -1.35% | **+3.69%** |
| benchmark_bgemm/Case0 | -4.15% | -2.39% |
| paged_attention_unroll/Case1 | **+2.60%** | -0.59% |
| paged_attention_unroll/Case2 | -0.77% | -1.20% |
| paged_attention_unroll_manual_scope/Case1 | +0.55% | -0.28% |
| paged_attention_unroll_manual_scope/Case2 | -1.61% | -2.62% |
| batch_paged_attention/Case1 | -2.73% | -0.28% |
| qwen3_14b_decode/GraphExecutionBatch16Seq3500 | +1.54% | +0.47% |

The two dies are not comparable in absolute terms — on identical baseline code die 13 ran 3.5% to 29% slower than die 12 did in #2144's A/B — which is why the per-run outliers are read as die noise rather than as effects.

**One thing worth recording rather than glossing:** qwen is the only case with the same sign in both runs, small and positive. There is a mechanism for it. The scan used to read the producer's slot line, and the caller then CASes `wake_list_head` on that same line; the old scan warmed the line the CAS was about to take. Reading the array instead leaves that CAS cold. Amortization only repays this on wide rows, and qwen's in-graph rows are not wide — instrumenting `graph_fill_definition` over a qwen decode gives **251 of 277 rows at width 1**, with the rest at 6-11 and two outliers (27, 85). So on this workload the change is close to a wash, as the numbers show.

That does not argue against the change: the array is required for in-graph early dispatch regardless, the wide rows are exactly the ones a candidate's sorted row will be, and the redundant second state field is gone. It does argue against selling it as a scheduling win, and it gives the next PR something specific to watch — if the cold CAS shows up once ED is on, prefetching the producer slot at the point the scan decides to hang on it is the obvious lever.
