### PR TITLE
Refactor: resolve prepare-phase DFX config from the run's own CallConfig

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -44,6 +44,7 @@
 #include "call_config.h"
 #include "chip_callable_layout.h"
 #include "utils/elf_build_id.h"
+#include "host/dfx_run_config.h"
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
 #include "utils/fatal_shutdown_latch.h"
@@ -222,6 +223,10 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    // Resolved from this run's own CallConfig rather than read off the runner:
+    // apply_call_config() is skipped when this prepare overlaps an in-flight
+    // predecessor, so the members still describe that predecessor.
+    const DfxRunConfig dfx = DfxRunConfig::from(config);
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
@@ -272,7 +277,7 @@ int DeviceRunner::prepare_execution(
     }
 
     // Get AICore PMU register addresses (distinct MMIO page from AIC_CTRL).
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         rc = init_aicore_register_addresses(
             &execution->kernel_args.args.pmu_reg_addrs, static_cast<uint64_t>(device_id_), mem_alloc_,
             AicoreRegKind::Pmu
@@ -285,15 +290,15 @@ int DeviceRunner::prepare_execution(
 
     // Build the profiling-flag bitfield (a2a3 carries an extra dep_gen bit).
     uint32_t enable_profiling_flag = SIMPLER_DFX_FLAG_NONE;
-    if (enable_dump_args_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
-    if (enable_chip_swimlane_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
-    if (enable_pmu_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
+    if (dfx.dump_args_enabled()) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
+    if (dfx.chip_swimlane_enabled()) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
+    if (dfx.pmu_enabled) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
     // The device flag drives the AICPU writer only; a host-orch runtime has no
     // device-side dep_gen to switch on.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DEP_GEN);
     }
-    if (enable_scope_stats_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
+    if (dfx.scope_stats_enabled) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     execution->kernel_args.args.enable_profiling_flag = enable_profiling_flag;
 
     resolve_task_binary_addrs(runtime);
@@ -360,26 +365,29 @@ int DeviceRunner::prepare_execution(
     }
     latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
-    if (enable_chip_swimlane_) {
-        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args);
+    if (dfx.chip_swimlane_enabled()) {
+        rc = init_chip_swimlane(
+            num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args, dfx.output_prefix,
+            dfx.chip_swimlane_level
+        );
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
         }
     }
 
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
         // Initialize args dump (independent from profiling)
-        rc = init_args_dump(runtime, device_id_, execution->kernel_args);
+        rc = init_args_dump(runtime, device_id_, execution->kernel_args, dfx.output_prefix, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
         }
     }
 
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         rc = init_pmu(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_,
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_,
             execution->kernel_args
         );
         if (rc != 0) {
@@ -391,7 +399,7 @@ int DeviceRunner::prepare_execution(
     // A host-orch runtime already holds the graph in host memory; standing up
     // the device ring and its collector would allocate shared memory and a
     // drain thread for a stream that never produces a record.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         rc = init_dep_gen(launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
@@ -399,7 +407,7 @@ int DeviceRunner::prepare_execution(
         }
     }
 
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         rc = init_scope_stats(launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_scope_stats failed: %d", rc);
@@ -1132,7 +1140,8 @@ int DeviceRunner::finalize() {
 // `launch_aicpu_kernel` and `launch_aicore_kernel` live on `DeviceRunnerBase`.
 
 int DeviceRunner::init_chip_swimlane(
-    int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args
+    int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
+    const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -1155,7 +1164,7 @@ int DeviceRunner::init_chip_swimlane(
         return mem_alloc_.free(dev_ptr);
     };
 
-    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
     int rc =
         chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
@@ -1169,7 +1178,10 @@ int DeviceRunner::init_chip_swimlane(
     return 0;
 }
 
-int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args) {
+int DeviceRunner::init_args_dump(
+    Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
+    DumpArgsLevel dump_args_level
+) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
@@ -1193,7 +1205,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
         return mem_alloc_.free(dev_ptr);
     };
 
-    dump_collector_.begin_run(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix, dump_args_level);
     int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
         return rc;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -299,7 +299,10 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args);
+    int init_chip_swimlane(
+        int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
+        const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
+    );
 
     /**
      * Initialize args dump shared memory and collector.
@@ -311,7 +314,10 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args);
+    int init_args_dump(
+        Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
+        DumpArgsLevel dump_args_level
+    );
 
     /**
      * Initialize PMU streaming shared memory.

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -39,6 +39,7 @@
 #include "common/unified_log.h"
 #include "cpu_sim_context.h"
 #include "host_log.h"
+#include "host/dfx_run_config.h"
 #include "host/raii_scope_guard.h"
 #include "host/runtime_timeout_config.h"
 #include "runtime.h"
@@ -324,6 +325,10 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    // Resolved from this run's own CallConfig rather than read off the runner:
+    // apply_call_config() is skipped when this prepare overlaps an in-flight
+    // predecessor, so the members still describe that predecessor.
+    const DfxRunConfig dfx = DfxRunConfig::from(config);
     if (active_run_ != nullptr) {
         LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -370,21 +375,21 @@ int DeviceRunner::prepare_execution(
 
     int num_aicore = block_dim * cores_per_blockdim_;
     uint32_t enable_profiling_flag = SIMPLER_DFX_FLAG_NONE;
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
     }
-    if (enable_chip_swimlane_) {
+    if (dfx.chip_swimlane_enabled()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
     }
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
     }
     // The device flag drives the AICPU writer only; a host-orch runtime has no
     // device-side dep_gen to switch on.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DEP_GEN);
     }
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     }
     kernel_args_.enable_profiling_flag = enable_profiling_flag;
@@ -415,8 +420,10 @@ int DeviceRunner::prepare_execution(
     }
     latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
-    if (enable_chip_swimlane_) {
-        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
+    if (dfx.chip_swimlane_enabled()) {
+        rc = init_chip_swimlane(
+            num_aicore, runtime.get_aicpu_thread_num(), device_id_, dfx.output_prefix, dfx.chip_swimlane_level
+        );
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
@@ -431,16 +438,18 @@ int DeviceRunner::prepare_execution(
         chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
 
-    if (enable_dump_args_) {
-        rc = init_args_dump(runtime, device_id_);
+    if (dfx.dump_args_enabled()) {
+        rc = init_args_dump(runtime, device_id_, dfx.output_prefix, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
         }
     }
 
-    if (enable_pmu_) {
-        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
+    if (dfx.pmu_enabled) {
+        rc = init_pmu(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_
+        );
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -450,7 +459,7 @@ int DeviceRunner::prepare_execution(
     // A host-orch runtime already holds the graph in host memory; standing up
     // the device ring and its collector would allocate shared memory and a
     // drain thread for a stream that never produces a record.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         rc = init_dep_gen(launch_aicpu_num, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
@@ -458,7 +467,7 @@ int DeviceRunner::prepare_execution(
         }
     }
 
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         rc = init_scope_stats(launch_aicpu_num);
         if (rc != 0) {
             LOG_ERROR("init_scope_stats failed: %d", rc);
@@ -846,7 +855,10 @@ int DeviceRunner::finalize() {
 // Performance Profiling Implementation
 // =============================================================================
 
-int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id) {
+int DeviceRunner::init_chip_swimlane(
+    int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
+    ChipSwimlaneLevel chip_swimlane_level
+) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -854,7 +866,7 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
         return mem_alloc_.free(dev_ptr);
     };
 
-    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
     int rc = chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
@@ -867,7 +879,9 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
     return 0;
 }
 
-int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
+int DeviceRunner::init_args_dump(
+    Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level
+) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
@@ -877,7 +891,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    dump_collector_.begin_run(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix, dump_args_level);
     int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -56,8 +56,12 @@ private:
     void unload_executor_binaries();
     void cleanup_active_run() noexcept;
 
-    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
-    int init_args_dump(Runtime &runtime, int device_id);
+    int init_chip_swimlane(
+        int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
+        ChipSwimlaneLevel chip_swimlane_level
+    );
+    int
+    init_args_dump(Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level);
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
     int init_dep_gen(int num_threads, int device_id);
     int init_scope_stats(int num_threads);

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -41,6 +41,7 @@
 #include "utils/elf_build_id.h"
 #include "utils/fnv1a_64.h"
 #include "host/host_regs.h"  // Register address retrieval
+#include "host/dfx_run_config.h"
 #include "host/raii_scope_guard.h"
 #include "utils/fatal_shutdown_latch.h"
 
@@ -262,6 +263,10 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    // Resolved from this run's own CallConfig rather than read off the runner:
+    // apply_call_config() is skipped when this prepare overlaps an in-flight
+    // predecessor, so the members still describe that predecessor.
+    const DfxRunConfig dfx = DfxRunConfig::from(config);
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
@@ -315,15 +320,15 @@ int DeviceRunner::prepare_execution(
 
     // Build the profiling-flag bitfield.
     uint32_t enable_profiling_flag = SIMPLER_DFX_FLAG_NONE;
-    if (enable_dump_args_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
-    if (enable_chip_swimlane_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
-    if (enable_pmu_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
+    if (dfx.dump_args_enabled()) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
+    if (dfx.chip_swimlane_enabled()) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
+    if (dfx.pmu_enabled) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
     // The device flag drives the AICPU writer only; a host-orch runtime has no
     // device-side dep_gen to switch on.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DEP_GEN);
     }
-    if (enable_scope_stats_) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
+    if (dfx.scope_stats_enabled) SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     execution->kernel_args.args.enable_profiling_flag = enable_profiling_flag;
 
     resolve_task_binary_addrs(runtime);
@@ -415,30 +420,36 @@ int DeviceRunner::prepare_execution(
     }
     latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), active_aicpu_num);
 
-    if (enable_chip_swimlane_) {
-        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args);
+    if (dfx.chip_swimlane_enabled()) {
+        rc = init_chip_swimlane(
+            num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args, dfx.output_prefix,
+            dfx.chip_swimlane_level
+        );
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
         }
     }
 
-    if (enable_dump_args_) {
-        rc = init_args_dump(runtime, device_id_, execution->kernel_args);
+    if (dfx.dump_args_enabled()) {
+        rc = init_args_dump(runtime, device_id_, execution->kernel_args, dfx.output_prefix, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
         }
     }
 
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         rc = init_pmu(
-            num_aicore, active_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_,
+            num_aicore, active_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_,
             execution->kernel_args
         );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             execution->kernel_args.args.pmu_data_base = 0;
+            // Written to the runner, not to `dfx`: the launch arming and the
+            // teardown both read this member, and neither can see a local. It is
+            // therefore the one DFX value this prepare still writes runner-wide.
             enable_pmu_ = false;
         }
     }
@@ -446,7 +457,7 @@ int DeviceRunner::prepare_execution(
     // A host-orch runtime already holds the graph in host memory; standing up
     // the device ring and its collector would allocate shared memory and a
     // drain thread for a stream that never produces a record.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         rc = init_dep_gen(active_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
@@ -454,7 +465,7 @@ int DeviceRunner::prepare_execution(
         }
     }
 
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         rc = init_scope_stats(active_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_scope_stats failed: %d", rc);
@@ -1025,7 +1036,8 @@ void DeviceRunner::finalize_collectors(bool abandon_device_resources) {
 }
 
 int DeviceRunner::init_chip_swimlane(
-    int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args
+    int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
+    const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -1033,7 +1045,7 @@ int DeviceRunner::init_chip_swimlane(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
+    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
     int rc = chip_swimlane_collector_.initialize(
         num_aicore, aicpu_thread_num, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb
     );
@@ -1046,7 +1058,10 @@ int DeviceRunner::init_chip_swimlane(
     return rc;
 }
 
-int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args) {
+int DeviceRunner::init_args_dump(
+    Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
+    DumpArgsLevel dump_args_level
+) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
@@ -1055,7 +1070,7 @@ int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, KernelArgsHelp
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    dump_collector_.begin_run(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix, dump_args_level);
     int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb);
     if (rc != 0) {
         return rc;

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -253,7 +253,10 @@ private:
      * @param device_id Device ID
      * @return 0 on success, error code on failure
      */
-    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args);
+    int init_chip_swimlane(
+        int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
+        const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
+    );
 
     /**
      * Initialize args dump device buffers.
@@ -263,7 +266,10 @@ private:
      * @param device_id Device ID for allocations
      * @return 0 on success, error code on failure
      */
-    int init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args);
+    int init_args_dump(
+        Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
+        DumpArgsLevel dump_args_level
+    );
 
     /**
      * Initialize PMU profiling device buffers.

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -40,6 +40,7 @@
 #include "common/unified_log.h"
 #include "cpu_sim_context.h"
 #include "host_log.h"
+#include "host/dfx_run_config.h"
 #include "host/raii_scope_guard.h"
 #include "host/runtime_timeout_config.h"
 #include "runtime.h"
@@ -329,6 +330,10 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    // Resolved from this run's own CallConfig rather than read off the runner:
+    // apply_call_config() is skipped when this prepare overlaps an in-flight
+    // predecessor, so the members still describe that predecessor.
+    const DfxRunConfig dfx = DfxRunConfig::from(config);
     if (active_run_ != nullptr) {
         LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -372,21 +377,21 @@ int DeviceRunner::prepare_execution(
 
     int num_aicore = block_dim * cores_per_blockdim_;
     uint32_t enable_profiling_flag = SIMPLER_DFX_FLAG_NONE;
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DUMP_ARGS);
     }
-    if (enable_chip_swimlane_) {
+    if (dfx.chip_swimlane_enabled()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_CHIP_SWIMLANE);
     }
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_PMU);
     }
     // The device flag drives the AICPU writer only; a host-orch runtime has no
     // device-side dep_gen to switch on.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_DEP_GEN);
     }
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         SIMPLER_SET_DFX_FLAG(enable_profiling_flag, SIMPLER_DFX_FLAG_SCOPE_STATS);
     }
 
@@ -418,8 +423,10 @@ int DeviceRunner::prepare_execution(
     }
     latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
-    if (enable_chip_swimlane_) {
-        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
+    if (dfx.chip_swimlane_enabled()) {
+        rc = init_chip_swimlane(
+            num_aicore, runtime.get_aicpu_thread_num(), device_id_, dfx.output_prefix, dfx.chip_swimlane_level
+        );
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
@@ -433,19 +440,24 @@ int DeviceRunner::prepare_execution(
         chip_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
 
-    if (enable_dump_args_) {
-        rc = init_args_dump(runtime, device_id_);
+    if (dfx.dump_args_enabled()) {
+        rc = init_args_dump(runtime, device_id_, dfx.output_prefix, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
         }
     }
 
-    if (enable_pmu_) {
-        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
+    if (dfx.pmu_enabled) {
+        rc = init_pmu(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_
+        );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.pmu_data_base = 0;
+            // Written to the runner, not to `dfx`: the launch arming and the
+            // teardown both read this member, and neither can see a local. It is
+            // therefore the one DFX value this prepare still writes runner-wide.
             enable_pmu_ = false;
         }
     }
@@ -453,7 +465,7 @@ int DeviceRunner::prepare_execution(
     // A host-orch runtime already holds the graph in host memory; standing up
     // the device ring and its collector would allocate shared memory and a
     // drain thread for a stream that never produces a record.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         rc = init_dep_gen(launch_aicpu_num, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
@@ -461,7 +473,7 @@ int DeviceRunner::prepare_execution(
         }
     }
 
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         rc = init_scope_stats(launch_aicpu_num);
         if (rc != 0) {
             LOG_ERROR("init_scope_stats failed: %d", rc);
@@ -845,8 +857,11 @@ void DeviceRunner::finalize_collectors() {
     }
 }
 
-int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id) {
-    chip_swimlane_collector_.begin_run(output_prefix_, chip_swimlane_level_);
+int DeviceRunner::init_chip_swimlane(
+    int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
+    ChipSwimlaneLevel chip_swimlane_level
+) {
+    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
     int rc = chip_swimlane_collector_.initialize(
         num_aicore, aicpu_thread_num, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb
     );
@@ -859,10 +874,12 @@ int DeviceRunner::init_chip_swimlane(int num_aicore, int aicpu_thread_num, int d
     return rc;
 }
 
-int DeviceRunner::init_args_dump(Runtime &runtime, int device_id) {
+int DeviceRunner::init_args_dump(
+    Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level
+) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
-    dump_collector_.begin_run(output_prefix_, dump_args_level_);
+    dump_collector_.begin_run(output_prefix, dump_args_level);
     int rc =
         dump_collector_.initialize(num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb);
     if (rc != 0) {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -57,8 +57,12 @@ private:
     void unload_executor_binaries();
     void cleanup_active_run() noexcept;
 
-    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
-    int init_args_dump(Runtime &runtime, int device_id);
+    int init_chip_swimlane(
+        int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
+        ChipSwimlaneLevel chip_swimlane_level
+    );
+    int
+    init_args_dump(Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level);
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
     int init_scope_stats(int num_threads);
     int init_dep_gen(int num_threads, int device_id);

--- a/src/common/platform/include/host/dfx_run_config.h
+++ b/src/common/platform/include/host/dfx_run_config.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <string>
+
+#include "call_config.h"
+#include "common/args_dump.h"
+#include "common/chip_swimlane_profiling.h"
+#include "host/pmu_collector.h"
+
+/**
+ * One run's diagnostics configuration, resolved from its own CallConfig.
+ *
+ * The runner also holds these values as members, bound by apply_call_config().
+ * Those members are correct for anything that reads them while their run holds
+ * the execution claim — arming at launch, teardown at reap. They are not correct
+ * for `prepare_execution`, which can run for a successor while a predecessor is
+ * still in flight: apply_call_config() is skipped for that overlap, so the
+ * members still describe the predecessor.
+ *
+ * A prepare-phase reader therefore resolves the values here, from the CallConfig
+ * it was handed, rather than reading the members. The derivations are the same
+ * ones the setters apply, kept in one place so the two cannot disagree.
+ */
+struct DfxRunConfig {
+    ChipSwimlaneLevel chip_swimlane_level{ChipSwimlaneLevel::DISABLED};
+    DumpArgsLevel dump_args_level{DumpArgsLevel::OFF};
+    PmuEventType pmu_event_type{};
+    bool pmu_enabled{false};
+    bool dep_gen_enabled{false};
+    bool scope_stats_enabled{false};
+    bool capture_clock_anchors{false};
+    std::string output_prefix;
+
+    bool chip_swimlane_enabled() const { return chip_swimlane_level != ChipSwimlaneLevel::DISABLED; }
+    bool dump_args_enabled() const { return dump_args_level != DumpArgsLevel::OFF; }
+
+    static DfxRunConfig from(const CallConfig &config) {
+        DfxRunConfig resolved;
+        resolved.chip_swimlane_level = static_cast<ChipSwimlaneLevel>(config.enable_chip_swimlane);
+        resolved.dump_args_level = static_cast<DumpArgsLevel>(config.enable_dump_args);
+        resolved.pmu_enabled = config.enable_pmu > 0;
+        resolved.pmu_event_type = resolve_pmu_event_type(config.enable_pmu);
+        resolved.dep_gen_enabled = config.enable_dep_gen != 0;
+        resolved.scope_stats_enabled = config.enable_scope_stats != 0;
+        resolved.capture_clock_anchors = config.capture_clock_anchors != 0;
+        resolved.output_prefix = config.output_prefix;
+        return resolved;
+    }
+};


### PR DESCRIPTION
## Summary

`prepare_execution` read the five diagnostics enables, the swimlane and dump levels, the PMU
event type and `output_prefix` **off the runner**. Those members are bound by
`apply_call_config()`, which `simpler_prepare_run` skips when the prepare overlaps an in-flight
predecessor — the code says so at the binding site:

```cpp
// Diagnostic binding reads runner-global collector configuration. It
// is depth-one, while concurrent HBG preparation must leave the active
// run's configuration untouched until launch.
if (!overlaps_active_run) runner->apply_call_config(state->config);
```

So on an overlapping prepare the members still describe the **predecessor**, and the successor
would arm its collectors — and build the device-side `enable_profiling_flag` — from the wrong
run's configuration. That is one of the two reasons `diagnostics_any()` currently forces
pipeline depth back to 1.

`prepare_execution` already receives the run's own `CallConfig`. This resolves the values from
it instead, through a `DfxRunConfig` that applies the same derivations the setters do so the
two cannot disagree about what a level or an event type means.

## What this does and does not settle

The arming block turned out to hold two kinds of content, and only one is destructive to a
predecessor:

| | Examples | Destructive? |
| --- | --- | --- |
| **Reads a per-run input** | the five enables → `enable_profiling_flag`; `output_prefix` → `make_pmu_csv_path`; the level → `initialize()`'s pool sizing | No — it only reads. It was wrong only because the *value* came from a member a successor had overwritten. **Fixed here.** |
| **Writes the resident collector** | `begin_run()`'s reset, `finalize_collectors()`, `latch_collector_shape()` | Yes. **Not addressed here** — that needs to move under the execution claim. |

Splitting it this way also avoids a problem the "move the whole arming to launch" shape would
have hit: `prepare_execution` ends with `init_device_kernel_args()`, which uploads `kernel_args`
to the device. The device pointers and the profiling flag the `init_*` publish must be in it
before that upload, so they cannot simply move to launch. Sourcing them correctly keeps them
where they are.

**No behavior change.** The gate makes `overlaps_active_run` false whenever any channel is on,
so the resolved values are today identical to the members.

## One write stays

Both a5 runners degrade on PMU init failure with `enable_pmu_ = false`. That has to reach the
launch arming and the teardown, and neither can see a local, so it stays — now commented as the
one DFX value this prepare still writes runner-wide.

Noticed while reading, not changed here: a2a3 **fails the whole run** on the same error where a5
degrades. An undocumented arch divergence; worth its own issue rather than a drive-by.

## Testing

**Per DFX channel, in the shapes `_st-sim-{a2a3,a5}.yml` uses.** A bare `pytest tests/st` enables
no channel, and every artifact assertion in these tests sits behind
`if not request.config.getoption("--enable-<channel>"): return` — so a bare sweep cannot fail on
a collector defect.

12 channel runs, 23 cases, green on both sim platforms.

- [x] **Negative control fires — on a consumer of the changed value.** With `DfxRunConfig::from()`
      resolving an empty `output_prefix`, the PMU channel fails with
      `pmu.csv missing under outputs/TestPmu_default_...`. It does **not** fire on scope_stats,
      whose artifact path comes from the runner member at teardown rather than from this
      resolution — worth stating, since picking that channel first would have produced a false
      all-clear.
- [x] Full sim sweeps (`examples tests/st`) green on a2a3sim and a5sim
- [x] cpput 135/135 from a clean build dir
- [x] pyut 2224 passed / 18 skipped
- [x] onboard a2a3 under `task-submit --device auto`: PMU 1 passed, dep_gen + chip_swimlane 6 passed
- [x] `clang-format --dry-run --Werror` clean on all nine files

One pyut run reddened on `test_failed_startup_reaps_children_no_leak` and then passed both in
isolation (0.20 s) and on a full re-run. It is a `_hard_timeout(_TEST_WALL_BUDGET_S)` wall-clock
budget over a fork-and-reap, and this change is C++-only in a path pyut's worker startup neither
compiles nor loads.

## Notes

Part of #2078's remaining line. The other half of what the depth-1 gate protects — the arming
sequence writing resident collector state during prepare — is the next change; the gate cannot
come off until both land.

Related: #2078
