### PR TITLE
Arm the resident DFX collectors under the execution claim

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -223,11 +223,11 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     // Resolved from this run's own CallConfig rather than read off the runner:
     // apply_call_config() is skipped when this prepare overlaps an in-flight
     // predecessor, so the members still describe that predecessor.
-    const DfxRunConfig dfx = DfxRunConfig::from(config);
-    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
+    const DfxRunConfig &dfx = execution->dfx;
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
         cleanup_execution(*execution, /*retire_aicore=*/false);
@@ -367,8 +367,7 @@ int DeviceRunner::prepare_execution(
 
     if (dfx.chip_swimlane_enabled()) {
         rc = init_chip_swimlane(
-            num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args, dfx.output_prefix,
-            dfx.chip_swimlane_level
+            num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args, dfx.chip_swimlane_level
         );
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
@@ -378,7 +377,7 @@ int DeviceRunner::prepare_execution(
 
     if (dfx.dump_args_enabled()) {
         // Initialize args dump (independent from profiling)
-        rc = init_args_dump(runtime, device_id_, execution->kernel_args, dfx.output_prefix, dfx.dump_args_level);
+        rc = init_args_dump(runtime, device_id_, execution->kernel_args, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
@@ -386,10 +385,7 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.pmu_enabled) {
-        rc = init_pmu(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_,
-            execution->kernel_args
-        );
+        rc = init_pmu(num_aicore, launch_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -460,7 +456,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         cleanup_execution(prepared, /*retire_aicore=*/true);
     });
 
-    int rc = reap_run();
+    int rc = reap_run(prepared.dfx);
     if (rc != 0) {
         // The device/sync error remains authoritative over teardown errors.
         return rc;
@@ -621,14 +617,15 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
             try {
                 activate_launch_shape(runtime);
                 (void)arm_device_wall_buffer(prepared.kernel_args);
-                start_shared_collectors_for_run();
-                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                start_shared_collectors_for_run(prepared.dfx);
+                if (prepared.dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
                     };
+                    dep_gen_collector_.begin_run();
                     dep_gen_collector_.start(thread_factory);
                 }
-                if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
+                if (prepared.dfx.chip_swimlane_enabled() && chip_swimlane_collector_.is_initialized()) {
                     std::vector<CoreType> core_types(num_aicore);
                     for (int i = 0; i < num_aicore; i++)
                         core_types[i] = runtime.get_workers()[i].core_type;
@@ -691,7 +688,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
     return result;
 }
 
-int DeviceRunner::reap_run() {
+int DeviceRunner::reap_run(const DfxRunConfig &dfx) {
     if (!run_streams_.ready()) {
         LOG_ERROR("reap_run: the run stream pair is not ready");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -712,7 +709,7 @@ int DeviceRunner::reap_run() {
         // JSON manifest, i.e. unusable for triage. reconcile/export are not
         // idempotent, so this runs only on the error return; the success path
         // still exports exactly once below.
-        teardown_shared_collectors_after_run(false);
+        teardown_shared_collectors_after_run(dfx, false);
         return rc;
     }
 
@@ -720,16 +717,16 @@ int DeviceRunner::reap_run() {
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    teardown_shared_collectors_after_run(true);
+    teardown_shared_collectors_after_run(dfx, true);
 
     // a2a3-only dep_gen teardown, device-orch shape: the collector stops, the
     // ring reconciles, and the records replay. The host-orch shape emits at the
     // end of bind instead, where its capture window closes — see
     // `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         dep_gen_collector_.quiesce();
         if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(output_prefix_);
+            const std::string deps = make_deps_json_path(dfx.output_prefix);
             const auto &records = dep_gen_collector_.records();
             int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (rc != 0) {
@@ -1141,7 +1138,7 @@ int DeviceRunner::finalize() {
 
 int DeviceRunner::init_chip_swimlane(
     int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
-    const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
+    ChipSwimlaneLevel chip_swimlane_level
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -1164,9 +1161,9 @@ int DeviceRunner::init_chip_swimlane(
         return mem_alloc_.free(dev_ptr);
     };
 
-    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
-    int rc =
-        chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, register_cb, free_cb);
+    int rc = chip_swimlane_collector_.initialize(
+        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level, alloc_cb, register_cb, free_cb
+    );
     if (rc != 0) {
         return rc;
     }
@@ -1179,8 +1176,7 @@ int DeviceRunner::init_chip_swimlane(
 }
 
 int DeviceRunner::init_args_dump(
-    Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
-    DumpArgsLevel dump_args_level
+    Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, DumpArgsLevel dump_args_level
 ) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
@@ -1205,8 +1201,7 @@ int DeviceRunner::init_args_dump(
         return mem_alloc_.free(dev_ptr);
     };
 
-    dump_collector_.begin_run(output_prefix, dump_args_level);
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, register_cb, free_cb);
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, dump_args_level, alloc_cb, register_cb, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -1215,10 +1210,7 @@ int DeviceRunner::init_args_dump(
     return 0;
 }
 
-int DeviceRunner::init_pmu(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
-    KernelArgsHelper &kernel_args
-) {
+int DeviceRunner::init_pmu(int num_cores, int num_threads, int device_id, KernelArgsHelper &kernel_args) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1240,7 +1232,6 @@ int DeviceRunner::init_pmu(
         return mem_alloc_.free(dev_ptr);
     };
 
-    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, register_cb, free_cb, device_id);
     if (rc != 0) {
         return rc;
@@ -1251,7 +1242,6 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
-    dep_gen_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -1283,7 +1273,6 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper 
 }
 
 int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
-    scope_stats_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -257,7 +257,7 @@ private:
     // The kernel submission boundary is separate from the stream wait and
     // post-run teardown: launch_run() submits and drain_execution() reaps.
     LaunchTransactionResult launch_run(PreparedExecution &prepared, LaunchPermit permit);
-    int reap_run();
+    int reap_run(const DfxRunConfig &dfx);
 
     // On an AICore launch/sync error, best-effort drain the device so a later
     // enqueue on the same DeviceRunner can recover in place; if the drain itself
@@ -301,7 +301,7 @@ private:
      */
     int init_chip_swimlane(
         int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
-        const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
+        ChipSwimlaneLevel chip_swimlane_level
     );
 
     /**
@@ -314,10 +314,7 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_args_dump(
-        Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
-        DumpArgsLevel dump_args_level
-    );
+    int init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, DumpArgsLevel dump_args_level);
 
     /**
      * Initialize PMU streaming shared memory.
@@ -328,15 +325,10 @@ private:
      *
      * @param num_cores  Number of AICore instances
      * @param num_threads Number of AICPU scheduling threads
-     * @param csv_path   Output CSV file path
-     * @param event_type PMU event type (written to CSV rows)
      * @param device_id  Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_pmu(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
-        KernelArgsHelper &kernel_args
-    );
+    int init_pmu(int num_cores, int num_threads, int device_id, KernelArgsHelper &kernel_args);
 
     /**
      * Initialize dep_gen capture shared memory.

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -325,15 +325,14 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
-    // Resolved from this run's own CallConfig rather than read off the runner:
-    // apply_call_config() is skipped when this prepare overlaps an in-flight
-    // predecessor, so the members still describe that predecessor.
-    const DfxRunConfig dfx = DfxRunConfig::from(config);
     if (active_run_ != nullptr) {
         LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
+    // This run's own diagnostics configuration, carried on the prepared run so
+    // that arming at launch and teardown at drain read the same value.
+    const DfxRunConfig &dfx = execution->dfx;
     active_run_ = std::make_unique<ActiveRun>();
     active_run_->runtime = &runtime;
     run_completion_.reset(1);
@@ -421,9 +420,7 @@ int DeviceRunner::prepare_execution(
     latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
     if (dfx.chip_swimlane_enabled()) {
-        rc = init_chip_swimlane(
-            num_aicore, runtime.get_aicpu_thread_num(), device_id_, dfx.output_prefix, dfx.chip_swimlane_level
-        );
+        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, dfx.chip_swimlane_level);
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
@@ -439,7 +436,7 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.dump_args_enabled()) {
-        rc = init_args_dump(runtime, device_id_, dfx.output_prefix, dfx.dump_args_level);
+        rc = init_args_dump(runtime, device_id_, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
@@ -447,9 +444,7 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.pmu_enabled) {
-        rc = init_pmu(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_
-        );
+        rc = init_pmu(num_aicore, launch_aicpu_num, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -568,25 +563,26 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 set_platform_regs_func_(kernel_args_.regs);
                 if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
                 set_platform_dump_base_func_(kernel_args_.dump_data_base);
-                set_dump_args_enabled_func_(enable_dump_args_);
+                set_dump_args_enabled_func_(prepared->dfx.dump_args_enabled());
                 set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
                 set_platform_chip_swimlane_aicore_rotation_table_func_(
                     kernel_args_.chip_swimlane_aicore_rotation_table
                 );
-                set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
+                set_chip_swimlane_enabled_func_(prepared->dfx.chip_swimlane_enabled());
                 set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
                 set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);
-                set_pmu_enabled_func_(enable_pmu_);
+                set_pmu_enabled_func_(prepared->dfx.pmu_enabled);
                 set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
-                set_dep_gen_enabled_func_(enable_dep_gen_ && !dep_gen_host_graph_active());
-                set_scope_stats_enabled_func_(enable_scope_stats_);
+                set_dep_gen_enabled_func_(prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active());
+                set_scope_stats_enabled_func_(prepared->dfx.scope_stats_enabled);
                 set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-                start_shared_collectors_for_run();
-                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                start_shared_collectors_for_run(prepared->dfx);
+                if (prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
                     };
+                    dep_gen_collector_.begin_run();
                     dep_gen_collector_.start(thread_factory);
                 }
 
@@ -651,11 +647,12 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
 
 int DeviceRunner::poll_execution(const ActiveExecution &) { return run_completion_.poll(); }
 
-int DeviceRunner::drain_execution(ActiveExecution &) {
-    if (active_run_ == nullptr) {
+int DeviceRunner::drain_execution(ActiveExecution &active) {
+    if (active_run_ == nullptr || active.prepared == nullptr) {
         LOG_ERROR("drain_execution called without a launched simulated run");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    const DfxRunConfig &dfx = active.prepared->dfx;
     auto run_cleanup = RAIIScopeGuard([this]() {
         cleanup_active_run();
     });
@@ -711,15 +708,15 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         return runtime_rc;
     }
 
-    teardown_shared_collectors_after_run(true);
+    teardown_shared_collectors_after_run(dfx, true);
 
     // Device-orch shape: the collector stops, the ring reconciles, and the
     // records replay. The host-orch shape emits at the end of bind instead, where
     // its capture window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         dep_gen_collector_.quiesce();
         if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(output_prefix_);
+            const std::string deps = make_deps_json_path(dfx.output_prefix);
             const auto &records = dep_gen_collector_.records();
             int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (rc != 0) {
@@ -856,8 +853,7 @@ int DeviceRunner::finalize() {
 // =============================================================================
 
 int DeviceRunner::init_chip_swimlane(
-    int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
-    ChipSwimlaneLevel chip_swimlane_level
+    int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -866,8 +862,9 @@ int DeviceRunner::init_chip_swimlane(
         return mem_alloc_.free(dev_ptr);
     };
 
-    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
-    int rc = chip_swimlane_collector_.initialize(num_aicore, aicpu_thread_num, device_id, alloc_cb, nullptr, free_cb);
+    int rc = chip_swimlane_collector_.initialize(
+        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level, alloc_cb, nullptr, free_cb
+    );
     if (rc != 0) {
         return rc;
     }
@@ -879,9 +876,7 @@ int DeviceRunner::init_chip_swimlane(
     return 0;
 }
 
-int DeviceRunner::init_args_dump(
-    Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level
-) {
+int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, DumpArgsLevel dump_args_level) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
@@ -891,8 +886,7 @@ int DeviceRunner::init_args_dump(
         return mem_alloc_.free(dev_ptr);
     };
 
-    dump_collector_.begin_run(output_prefix, dump_args_level);
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb);
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, dump_args_level, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
     }
@@ -901,9 +895,7 @@ int DeviceRunner::init_args_dump(
     return 0;
 }
 
-int DeviceRunner::init_pmu(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
-) {
+int DeviceRunner::init_pmu(int num_cores, int num_threads, int /*device_id*/) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -911,7 +903,6 @@ int DeviceRunner::init_pmu(
         return mem_alloc_.free(dev_ptr);
     };
 
-    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, nullptr, free_cb, -1);
     if (rc != 0) {
         return rc;
@@ -922,7 +913,6 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
-    dep_gen_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
@@ -940,7 +930,6 @@ int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
 }
 
 int DeviceRunner::init_scope_stats(int num_threads) {
-    scope_stats_collector_.begin_run();
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -56,13 +56,9 @@ private:
     void unload_executor_binaries();
     void cleanup_active_run() noexcept;
 
-    int init_chip_swimlane(
-        int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
-        ChipSwimlaneLevel chip_swimlane_level
-    );
-    int
-    init_args_dump(Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level);
-    int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level);
+    int init_args_dump(Runtime &runtime, int device_id, DumpArgsLevel dump_args_level);
+    int init_pmu(int num_cores, int num_threads, int device_id);
     int init_dep_gen(int num_threads, int device_id);
     int init_scope_stats(int num_threads);
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -263,11 +263,11 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
     // Resolved from this run's own CallConfig rather than read off the runner:
     // apply_call_config() is skipped when this prepare overlaps an in-flight
     // predecessor, so the members still describe that predecessor.
-    const DfxRunConfig dfx = DfxRunConfig::from(config);
-    auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
+    DfxRunConfig &dfx = execution->dfx;
     execution->resources_owned = true;
     auto prepare_rollback = RAIIScopeGuard([this, &execution]() {
         cleanup_execution(*execution, /*launched=*/false);
@@ -422,8 +422,7 @@ int DeviceRunner::prepare_execution(
 
     if (dfx.chip_swimlane_enabled()) {
         rc = init_chip_swimlane(
-            num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args, dfx.output_prefix,
-            dfx.chip_swimlane_level
+            num_aicore, runtime.get_aicpu_thread_num(), device_id_, execution->kernel_args, dfx.chip_swimlane_level
         );
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
@@ -432,7 +431,7 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.dump_args_enabled()) {
-        rc = init_args_dump(runtime, device_id_, execution->kernel_args, dfx.output_prefix, dfx.dump_args_level);
+        rc = init_args_dump(runtime, device_id_, execution->kernel_args, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
@@ -440,17 +439,14 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.pmu_enabled) {
-        rc = init_pmu(
-            num_aicore, active_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_,
-            execution->kernel_args
-        );
+        rc = init_pmu(num_aicore, active_aicpu_num, device_id_, execution->kernel_args);
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             execution->kernel_args.args.pmu_data_base = 0;
-            // Written to the runner, not to `dfx`: the launch arming and the
-            // teardown both read this member, and neither can see a local. It is
-            // therefore the one DFX value this prepare still writes runner-wide.
-            enable_pmu_ = false;
+            // Recorded on this run's own configuration, which its launch arming
+            // and its teardown both read. a2a3 fails the whole run on the same
+            // error instead of degrading it.
+            dfx.pmu_enabled = false;
         }
     }
 
@@ -511,14 +507,15 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
             try {
                 activate_launch_shape(runtime);
                 (void)arm_device_wall_buffer(prepared->kernel_args);
-                start_shared_collectors_for_run();
-                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                start_shared_collectors_for_run(prepared->dfx);
+                if (prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
                     };
+                    dep_gen_collector_.begin_run();
                     dep_gen_collector_.start(thread_factory);
                 }
-                if (enable_chip_swimlane_ && chip_swimlane_collector_.is_initialized()) {
+                if (prepared->dfx.chip_swimlane_enabled() && chip_swimlane_collector_.is_initialized()) {
                     std::vector<CoreType> core_types(num_aicore);
                     for (int i = 0; i < num_aicore; i++)
                         core_types[i] = runtime.get_workers()[i].core_type;
@@ -643,27 +640,27 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         recover_device_or_mark_unusable(rc);
         // Emergency shutdown may already have flushed diagnostics. Export the
         // manifest on the error path exactly once.
-        if (enable_chip_swimlane_ && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
+        if (prepared.dfx.chip_swimlane_enabled() && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
             LOG_WARN("Runtime chip-swimlane extension publication failed");
         }
-        teardown_shared_collectors_after_run(false);
+        teardown_shared_collectors_after_run(prepared.dfx, false);
         return rc;
     }
 
     read_device_wall_ns();
-    if (enable_chip_swimlane_ && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
+    if (prepared.dfx.chip_swimlane_enabled() && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
         LOG_WARN("Runtime chip-swimlane extension publication failed");
     }
-    teardown_shared_collectors_after_run(true);
+    teardown_shared_collectors_after_run(prepared.dfx, true);
 
     // a5-specific dep_gen teardown, device-orch shape: the collector stops, the
     // ring reconciles, and the records replay. The host-orch shape emits at the
     // end of bind instead, where its capture window closes — see
     // `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (prepared.dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         dep_gen_collector_.quiesce();
         if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(output_prefix_);
+            const std::string deps = make_deps_json_path(prepared.dfx.output_prefix);
             const auto &records = dep_gen_collector_.records();
             int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (replay_rc != 0) {
@@ -1037,7 +1034,7 @@ void DeviceRunner::finalize_collectors(bool abandon_device_resources) {
 
 int DeviceRunner::init_chip_swimlane(
     int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
-    const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
+    ChipSwimlaneLevel chip_swimlane_level
 ) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
@@ -1045,9 +1042,8 @@ int DeviceRunner::init_chip_swimlane(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
     int rc = chip_swimlane_collector_.initialize(
-        num_aicore, aicpu_thread_num, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb
+        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level, alloc_cb, /*register_cb=*/nullptr, free_cb
     );
     if (rc == 0) {
         kernel_args.args.chip_swimlane_data_base =
@@ -1059,8 +1055,7 @@ int DeviceRunner::init_chip_swimlane(
 }
 
 int DeviceRunner::init_args_dump(
-    Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
-    DumpArgsLevel dump_args_level
+    Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, DumpArgsLevel dump_args_level
 ) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
@@ -1070,8 +1065,9 @@ int DeviceRunner::init_args_dump(
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    dump_collector_.begin_run(output_prefix, dump_args_level);
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, /*register_cb=*/nullptr, free_cb);
+    int rc = dump_collector_.initialize(
+        num_dump_threads, device_id, dump_args_level, alloc_cb, /*register_cb=*/nullptr, free_cb
+    );
     if (rc != 0) {
         return rc;
     }
@@ -1080,17 +1076,13 @@ int DeviceRunner::init_args_dump(
     return 0;
 }
 
-int DeviceRunner::init_pmu(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
-    KernelArgsHelper &kernel_args
-) {
+int DeviceRunner::init_pmu(int num_cores, int num_threads, int device_id, KernelArgsHelper &kernel_args) {
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);
     };
     auto free_cb = [this](void *dev_ptr) -> int {
         return mem_alloc_.free(dev_ptr);
     };
-    pmu_collector_.begin_run(csv_path, event_type);
     int rc = pmu_collector_.init(num_cores, num_threads, alloc_cb, /*register_cb=*/nullptr, free_cb, device_id);
     if (rc == 0) {
         kernel_args.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
@@ -1101,7 +1093,6 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
-    scope_stats_collector_.begin_run();
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device (see
     // ProfilerBase::alloc_paired_buffer). No halHostRegister on a5.
@@ -1121,7 +1112,6 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id, KernelArgsHel
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args) {
-    dep_gen_collector_.begin_run();
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device. No
     // halHostRegister on a5 (matches PMU / chip swimlane / dump collectors).

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -255,7 +255,7 @@ private:
      */
     int init_chip_swimlane(
         int num_aicore, int aicpu_thread_num, int device_id, KernelArgsHelper &kernel_args,
-        const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level
+        ChipSwimlaneLevel chip_swimlane_level
     );
 
     /**
@@ -266,10 +266,7 @@ private:
      * @param device_id Device ID for allocations
      * @return 0 on success, error code on failure
      */
-    int init_args_dump(
-        Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, const std::string &output_prefix,
-        DumpArgsLevel dump_args_level
-    );
+    int init_args_dump(Runtime &runtime, int device_id, KernelArgsHelper &kernel_args, DumpArgsLevel dump_args_level);
 
     /**
      * Initialize PMU profiling device buffers.
@@ -297,10 +294,7 @@ private:
     bool aicpu_topology_cached_{false};
     pto::a5::AicpuTopology aicpu_topology_{};
 
-    int init_pmu(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id,
-        KernelArgsHelper &kernel_args
-    );
+    int init_pmu(int num_cores, int num_threads, int device_id, KernelArgsHelper &kernel_args);
     int init_scope_stats(int num_threads, int device_id, KernelArgsHelper &kernel_args);
 
     /**

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -330,15 +330,14 @@ int DeviceRunner::prepare_execution(
     std::unique_ptr<PreparedExecution> *prepared
 ) {
     if (prepared == nullptr || *prepared != nullptr) return PTO_RUNTIME_ERR_INTERNAL;
-    // Resolved from this run's own CallConfig rather than read off the runner:
-    // apply_call_config() is skipped when this prepare overlaps an in-flight
-    // predecessor, so the members still describe that predecessor.
-    const DfxRunConfig dfx = DfxRunConfig::from(config);
     if (active_run_ != nullptr) {
         LOG_ERROR("prepare_execution called while another simulated run still owns execution state");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto execution = std::make_unique<PreparedExecution>(identity, runtime, config, pipeline_slot);
+    // This run's own diagnostics configuration, carried on the prepared run so
+    // that arming at launch and teardown at drain read the same value.
+    DfxRunConfig &dfx = execution->dfx;
     active_run_ = std::make_unique<ActiveRun>();
     active_run_->runtime = &runtime;
     run_completion_.reset(1);
@@ -424,9 +423,7 @@ int DeviceRunner::prepare_execution(
     latch_collector_shape(num_aicore, runtime.get_aicpu_thread_num(), launch_aicpu_num);
 
     if (dfx.chip_swimlane_enabled()) {
-        rc = init_chip_swimlane(
-            num_aicore, runtime.get_aicpu_thread_num(), device_id_, dfx.output_prefix, dfx.chip_swimlane_level
-        );
+        rc = init_chip_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_, dfx.chip_swimlane_level);
         if (rc != 0) {
             LOG_ERROR("init_chip_swimlane failed: %d", rc);
             return rc;
@@ -441,7 +438,7 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.dump_args_enabled()) {
-        rc = init_args_dump(runtime, device_id_, dfx.output_prefix, dfx.dump_args_level);
+        rc = init_args_dump(runtime, device_id_, dfx.dump_args_level);
         if (rc != 0) {
             LOG_ERROR("init_args_dump failed: %d", rc);
             return rc;
@@ -449,16 +446,14 @@ int DeviceRunner::prepare_execution(
     }
 
     if (dfx.pmu_enabled) {
-        rc = init_pmu(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type, device_id_
-        );
+        rc = init_pmu(num_aicore, launch_aicpu_num, device_id_);
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.pmu_data_base = 0;
-            // Written to the runner, not to `dfx`: the launch arming and the
-            // teardown both read this member, and neither can see a local. It is
-            // therefore the one DFX value this prepare still writes runner-wide.
-            enable_pmu_ = false;
+            // Recorded on this run's own configuration, which its launch arming
+            // and its teardown both read. a2a3 fails the whole run on the same
+            // error instead of degrading it.
+            dfx.pmu_enabled = false;
         }
     }
 
@@ -552,24 +547,25 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 set_platform_regs_func_(kernel_args_.regs);
                 if (set_orch_device_id_func_ != nullptr) set_orch_device_id_func_(device_id_);
                 set_platform_dump_base_func_(kernel_args_.dump_data_base);
-                set_dump_args_enabled_func_(enable_dump_args_);
+                set_dump_args_enabled_func_(prepared->dfx.dump_args_enabled());
                 set_platform_chip_swimlane_base_func_(kernel_args_.chip_swimlane_data_base);
                 set_platform_chip_swimlane_aicore_rotation_table_func_(
                     kernel_args_.chip_swimlane_aicore_rotation_table
                 );
-                set_chip_swimlane_enabled_func_(enable_chip_swimlane_);
+                set_chip_swimlane_enabled_func_(prepared->dfx.chip_swimlane_enabled());
                 set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
-                set_pmu_enabled_func_(enable_pmu_);
+                set_pmu_enabled_func_(prepared->dfx.pmu_enabled);
                 set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
-                set_dep_gen_enabled_func_(enable_dep_gen_ && !dep_gen_host_graph_active());
-                set_scope_stats_enabled_func_(enable_scope_stats_);
+                set_dep_gen_enabled_func_(prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active());
+                set_scope_stats_enabled_func_(prepared->dfx.scope_stats_enabled);
                 set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-                start_shared_collectors_for_run();
-                if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+                start_shared_collectors_for_run(prepared->dfx);
+                if (prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
                     };
+                    dep_gen_collector_.begin_run();
                     dep_gen_collector_.start(thread_factory);
                 }
 
@@ -635,11 +631,12 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
 
 int DeviceRunner::poll_execution(const ActiveExecution &) { return run_completion_.poll(); }
 
-int DeviceRunner::drain_execution(ActiveExecution &) {
-    if (active_run_ == nullptr) {
+int DeviceRunner::drain_execution(ActiveExecution &active) {
+    if (active_run_ == nullptr || active.prepared == nullptr) {
         LOG_ERROR("drain_execution called without a launched simulated run");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    const DfxRunConfig &dfx = active.prepared->dfx;
     auto run_cleanup = RAIIScopeGuard([this]() {
         cleanup_active_run();
     });
@@ -695,15 +692,15 @@ int DeviceRunner::drain_execution(ActiveExecution &) {
         return runtime_rc;
     }
 
-    teardown_shared_collectors_after_run(true);
+    teardown_shared_collectors_after_run(dfx, true);
 
     // Device-orch shape: the collector stops, the ring reconciles, and the
     // records replay. The host-orch shape emits at the end of bind instead, where
     // its capture window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (enable_dep_gen_ && !dep_gen_host_graph_active()) {
+    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
         dep_gen_collector_.quiesce();
         if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(output_prefix_);
+            const std::string deps = make_deps_json_path(dfx.output_prefix);
             const auto &records = dep_gen_collector_.records();
             int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (replay_rc != 0) {
@@ -858,12 +855,11 @@ void DeviceRunner::finalize_collectors() {
 }
 
 int DeviceRunner::init_chip_swimlane(
-    int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
-    ChipSwimlaneLevel chip_swimlane_level
+    int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level
 ) {
-    chip_swimlane_collector_.begin_run(output_prefix, chip_swimlane_level);
     int rc = chip_swimlane_collector_.initialize(
-        num_aicore, aicpu_thread_num, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb
+        num_aicore, aicpu_thread_num, device_id, chip_swimlane_level, prof_alloc_cb, /*register_cb=*/nullptr,
+        prof_free_cb
     );
     if (rc == 0) {
         kernel_args_.chip_swimlane_data_base =
@@ -874,14 +870,12 @@ int DeviceRunner::init_chip_swimlane(
     return rc;
 }
 
-int DeviceRunner::init_args_dump(
-    Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level
-) {
+int DeviceRunner::init_args_dump(Runtime &runtime, int device_id, DumpArgsLevel dump_args_level) {
     int num_dump_threads = runtime.get_aicpu_thread_num();
 
-    dump_collector_.begin_run(output_prefix, dump_args_level);
-    int rc =
-        dump_collector_.initialize(num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb);
+    int rc = dump_collector_.initialize(
+        num_dump_threads, device_id, dump_args_level, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb
+    );
     if (rc != 0) {
         return rc;
     }
@@ -890,10 +884,7 @@ int DeviceRunner::init_args_dump(
     return 0;
 }
 
-int DeviceRunner::init_pmu(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
-) {
-    pmu_collector_.begin_run(csv_path, event_type);
+int DeviceRunner::init_pmu(int num_cores, int num_threads, int /*device_id*/) {
     int rc = pmu_collector_.init(
         num_cores, num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*device_id=*/-1
     );
@@ -906,7 +897,6 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_scope_stats(int num_threads) {
-    scope_stats_collector_.begin_run();
     // a5 sim: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer; sim's profiling_copy_* are plain memcpys, so the dev/host
     // shadow path collapses to one allocation pair without address-space tricks.
@@ -922,7 +912,6 @@ int DeviceRunner::init_scope_stats(int num_threads) {
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
-    dep_gen_collector_.begin_run();
     // a5 sim: register_cb=nullptr; sim's profiling_copy_* are plain memcpys, so
     // the dev/host shadow path collapses to one allocation pair.
     int rc =

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -57,13 +57,9 @@ private:
     void unload_executor_binaries();
     void cleanup_active_run() noexcept;
 
-    int init_chip_swimlane(
-        int num_aicore, int aicpu_thread_num, int device_id, const std::string &output_prefix,
-        ChipSwimlaneLevel chip_swimlane_level
-    );
-    int
-    init_args_dump(Runtime &runtime, int device_id, const std::string &output_prefix, DumpArgsLevel dump_args_level);
-    int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+    int init_chip_swimlane(int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level);
+    int init_args_dump(Runtime &runtime, int device_id, DumpArgsLevel dump_args_level);
+    int init_pmu(int num_cores, int num_threads, int device_id);
     int init_scope_stats(int num_threads);
     int init_dep_gen(int num_threads, int device_id);
 

--- a/src/common/platform/include/host/args_dump_collector.h
+++ b/src/common/platform/include/host/args_dump_collector.h
@@ -227,12 +227,12 @@ public:
     // Allocates the device-side resources: header, per-thread DumpBufferStates,
     // DumpMetaBuffers and payload arenas.
     //
-    // The per-run configuration (output prefix, level) is NOT taken here — it
-    // is bound separately via begin_run(), which the caller must run before this
-    // on the first run.
+    // The level is taken here because it is written into DumpDataHeader with the
+    // rest of the layout. The prefix is bound by begin_run(), which runs once per
+    // run and may run either side of this.
     int initialize(
-        int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
-        const DumpFreeCallback &free_cb
+        int num_dump_threads, int device_id, DumpArgsLevel dump_args_level, const DumpAllocCallback &alloc_cb,
+        DumpRegisterCallback register_cb, const DumpFreeCallback &free_cb
     );
 
     // Start a run's collection window: bind its artifact configuration, drop the

--- a/src/common/platform/include/host/chip_swimlane_collector.h
+++ b/src/common/platform/include/host/chip_swimlane_collector.h
@@ -390,12 +390,14 @@ public:
     // that outlives a run holds pools shaped for those two counts, and the
     // caller rebuilds it when a later run changes them.
     //
-    // Per-run configuration (artifact prefix, level) is bound separately by
-    // begin_run(), which must run before this on the first run: the level
-    // selects the orch phase pool here.
+    // The level is taken here because it selects the orch phase pool, and the
+    // pools are built once for every run this collector serves. The rest of a
+    // run's configuration is bound by begin_run(), which runs once per run and
+    // may run either side of this.
     int initialize(
-        int num_aicore, int aicpu_thread_num, int device_id, const ChipSwimlaneAllocCallback &alloc_cb,
-        ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
+        int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level,
+        const ChipSwimlaneAllocCallback &alloc_cb, ChipSwimlaneRegisterCallback register_cb,
+        const ChipSwimlaneFreeCallback &free_cb
     );
 
     /**
@@ -411,8 +413,8 @@ public:
      * stays on whichever level the first run asked for.
      *
      * Before the first initialize() there is no region and no shard storage yet;
-     * reset_collector_shards() is then a no-op over empty extents, and
-     * initialize() picks the level up from the member this sets.
+     * reset_collector_shards() is then a no-op over empty extents and
+     * publish_run_config() has no header to write.
      */
     void begin_run(const std::string &output_prefix, ChipSwimlaneLevel chip_swimlane_level) {
         output_prefix_ = output_prefix;

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -894,7 +894,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         // The host phase records describe the bind path this variable exists to
         // measure, so they are written here as well as in the device-run
         // teardown. Skipping the device must not skip the artifact.
-        state->runner->write_host_phase_records_artifact();
+        state->runner->write_host_phase_records_artifact(state->config.output_prefix);
         state->completion_rc = 0;
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return 0;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1275,13 +1275,9 @@ extern "C" __attribute__((weak)) int prewarm_config_impl(
 
 void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_chip_swimlane_enabled(config.enable_chip_swimlane);
-    set_dump_args_enabled(config.enable_dump_args);
-    set_pmu_enabled(config.enable_pmu);
     // Virtual: a2a3 and a5 wire through to their enable_dep_gen_; an arch
     // without dep_gen falls through to the base no-op.
     set_dep_gen_enabled(config.enable_dep_gen != 0);
-    set_scope_stats_enabled(config.enable_scope_stats != 0);
-    capture_clock_anchors_ = config.capture_clock_anchors != 0;
     set_output_prefix(config.output_prefix);
 }
 
@@ -1885,49 +1881,56 @@ int DeviceRunnerBase::init_runtime_args_with_metadata(Runtime &runtime, KernelAr
     return 0;
 }
 
-void DeviceRunnerBase::start_shared_collectors_for_run() {
-    // Start collector mgmt + poll threads now, just before kernels launch.
-    // Starting earlier wastes CPU on empty queues and risks tripping
-    // ProfilerBase's poll-loop idle-timeout if device-side init is slow.
+void DeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx) {
+    // Open each enabled collector's window and start its mgmt + poll threads
+    // now, just before kernels launch. Both halves belong here: begin_run()
+    // drops the previous run's records and republishes the device level, which
+    // is only safe while this run holds the execution claim, and starting
+    // earlier wastes CPU on empty queues and risks tripping ProfilerBase's
+    // poll-loop idle-timeout if device-side init is slow.
     auto thread_factory = [this](std::function<void()> fn) {
         return create_thread(std::move(fn));
     };
-    if (enable_chip_swimlane_) {
-        if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
+    if (dfx.chip_swimlane_enabled()) {
+        chip_swimlane_collector_.begin_run(dfx.output_prefix, dfx.chip_swimlane_level);
+        if (dfx.capture_clock_anchors) begin_clock_correlation_session_if_needed();
         chip_swimlane_collector_.start(thread_factory);
     }
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
+        dump_collector_.begin_run(dfx.output_prefix, dfx.dump_args_level);
         dump_collector_.start(thread_factory);
     }
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
+        pmu_collector_.begin_run(make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type);
         pmu_collector_.start(thread_factory);
     }
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
+        scope_stats_collector_.begin_run();
         scope_stats_collector_.start(thread_factory);
     }
 }
 
-void DeviceRunnerBase::write_host_phase_records_artifact() {
+void DeviceRunnerBase::write_host_phase_records_artifact(const std::string &output_prefix) {
     // Per-event view of the prepare path. Every phase it records is produced on
     // the host during bind, and the store is finished before launch, so this
     // touches no device state and is callable from any point after bind --
-    // including a path that never launches. Keyed on output_prefix_ because it is
-    // non-empty exactly when this run produces diagnostic artifacts, and on the
-    // store having finished a pass, which is what a host-orchestrating runtime
-    // leaves behind. The store writes a pass at most once, so every path that can
-    // end a run calls this unconditionally.
-    if (!output_prefix_.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
+    // including a path that never launches. Keyed on the run's output_prefix
+    // because it is non-empty exactly when this run produces diagnostic
+    // artifacts, and on the store having finished a pass, which is what a
+    // host-orchestrating runtime leaves behind. The store writes a pass at most
+    // once, so every path that can end a run calls this unconditionally.
+    if (!output_prefix.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix));
     }
 }
 
-void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execution_complete) {
+void DeviceRunnerBase::teardown_shared_collectors_after_run(const DfxRunConfig &dfx, bool device_execution_complete) {
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    // Diagnostic exports use the per-task `output_prefix_` directory the user
-    // set on CallConfig (CallConfig::validate() enforces non-empty upstream).
+    // Diagnostic exports use the per-task output prefix the user set on
+    // CallConfig (CallConfig::validate() enforces non-empty upstream).
     finish_clock_correlation_session(device_execution_complete, !can_accept_run());
-    if (enable_chip_swimlane_) {
+    if (dfx.chip_swimlane_enabled()) {
         chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
@@ -1935,23 +1938,23 @@ void DeviceRunnerBase::teardown_shared_collectors_after_run(bool device_executio
         chip_swimlane_collector_.export_swimlane_json();
     }
 
-    write_host_phase_records_artifact();
+    write_host_phase_records_artifact(dfx.output_prefix);
 
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
         dump_collector_.quiesce();
         dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         pmu_collector_.quiesce();
         pmu_collector_.reconcile_counters();
     }
 
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         scope_stats_collector_.quiesce();
         scope_stats_collector_.reconcile_counters();
-        scope_stats_collector_.write_jsonl(output_prefix_);
+        scope_stats_collector_.write_jsonl(dfx.output_prefix);
     }
 }
 

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -64,6 +64,7 @@
 #include "device_runner_helpers.h"
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
+#include "host/dfx_run_config.h"
 #include "host/host_phase_records.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
@@ -558,6 +559,7 @@ public:
             identity(identity_in),
             runtime(&runtime_in),
             config(config_in),
+            dfx(DfxRunConfig::from(config_in)),
             pipeline_slot(pipeline_slot_in) {}
         PreparedExecution(const PreparedExecution &) = delete;
         PreparedExecution &operator=(const PreparedExecution &) = delete;
@@ -565,6 +567,7 @@ public:
             identity(other.identity),
             runtime(std::exchange(other.runtime, nullptr)),
             config(other.config),
+            dfx(std::move(other.dfx)),
             pipeline_slot(other.pipeline_slot),
             num_aicore(other.num_aicore),
             launch_aicpu_num(other.launch_aicpu_num),
@@ -576,6 +579,18 @@ public:
         NativeRunIdentity identity{};
         Runtime *runtime{nullptr};
         CallConfig config{};
+        /**
+         * This run's diagnostics configuration, resolved from its own config.
+         *
+         * Every phase of the run reads its DFX configuration from here rather
+         * than from the runner's members: prepare because it can overlap a
+         * predecessor whose configuration is still the one bound on the runner,
+         * and launch/drain so that one run answers for its whole lifetime from a
+         * single value. A run that degrades a channel (a5 disables PMU when its
+         * init fails) writes that here, where it reaches this run's arming and
+         * teardown and no other run's.
+         */
+        DfxRunConfig dfx{};
         uint32_t pipeline_slot{PTO_PIPELINE_MAX_DEPTH};
         int num_aicore{0};
         int launch_aicpu_num{0};
@@ -722,16 +737,14 @@ public:
 
     /**
      * Enablement setters for the four shared diagnostics sub-features.
-     * Applied from the per-run CallConfig by `apply_call_config()` before prepare;
-     * downstream execution paths read the corresponding `enable_*_`
-     * members directly.
+     * Applied from the per-run CallConfig by `apply_call_config()` before
+     * prepare. Execution paths do not read these: a run's own diagnostics
+     * configuration reaches them on its `PreparedExecution::dfx`, and the runner
+     * keeps only what a device-context query answers from.
      *
      * `set_dep_gen_enabled` is a2a3-only and lives on the subclass.
      */
-    void set_chip_swimlane_enabled(int level) {
-        chip_swimlane_level_ = static_cast<ChipSwimlaneLevel>(level);
-        enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
-    }
+    void set_chip_swimlane_enabled(int level) { chip_swimlane_level_ = static_cast<ChipSwimlaneLevel>(level); }
     uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
     bool
     publish_chip_swimlane_extension(ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size) {
@@ -755,23 +768,14 @@ public:
      * can still produce the artifact. The store writes a pass at most once, so
      * every path that can end a run may call this unconditionally.
      */
-    void write_host_phase_records_artifact();
+    void write_host_phase_records_artifact(const std::string &output_prefix);
     void finish_clock_correlation_session(bool capture_device_complete, bool abandon_device_resources) noexcept;
-    void set_dump_args_enabled(int level) {
-        dump_args_level_ = static_cast<DumpArgsLevel>(level);
-        enable_dump_args_ = (dump_args_level_ != DumpArgsLevel::OFF);
-    }
-    void set_pmu_enabled(int enable_pmu) {
-        enable_pmu_ = (enable_pmu > 0);
-        pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
-    }
-    void set_scope_stats_enabled(bool enable) { enable_scope_stats_ = enable; }
 
     /**
-     * Latch this run's per-run diagnostic config onto the runner's `enable_*_`
-     * members before prepare uses them. The c_api applies it only when no active
-     * run can observe the runner-global collector configuration. Defined in the
-     * .cpp so this header does not need the full CallConfig definition.
+     * Latch the part of this run's config a device-context query answers from.
+     * The c_api applies it only when no active run can observe the runner-global
+     * state. Defined in the .cpp so this header does not need the full CallConfig
+     * definition.
      */
     void apply_call_config(const CallConfig &config);
 
@@ -958,24 +962,31 @@ protected:
     int init_runtime_args_with_metadata(Runtime &runtime, KernelArgsHelper &kernel_args);
 
     /**
-     * Start collector mgmt + poll threads for the four shared
-     * diagnostics collectors (`chip_swimlane_collector_`, `dump_collector_`,
-     * `pmu_collector_`, `scope_stats_collector_`) that are enabled.
-     * Each `start()` is gated on the corresponding `enable_*_` flag;
-     * disabled collectors are not started.
+     * Open this run's collection window on the four shared diagnostics
+     * collectors (`chip_swimlane_collector_`, `dump_collector_`,
+     * `pmu_collector_`, `scope_stats_collector_`) that it enables, and start
+     * their mgmt + poll threads. Each block is gated on `dfx`, this run's own
+     * configuration, not on the runner's members.
+     *
+     * The collectors are resident and serve every run, so opening the window is
+     * destructive: it drops the previous run's records and counters and
+     * republishes the level the device reads. That is why it happens here, at
+     * launch, rather than during preparation — this is the first point the run
+     * holds the execution claim, so it is the first point at which no other run
+     * is executing against those collectors.
      *
      * Each spawned thread is bound to `device_id_` via `create_thread`.
      *
      * Subclasses with arch-specific collectors (`dep_gen_collector_`) call
-     * this helper and then start their own. The sim base carries the same
-     * split.
+     * this helper and then open and start their own. The sim base carries the
+     * same split.
      */
-    void start_shared_collectors_for_run();
+    void start_shared_collectors_for_run(const DfxRunConfig &dfx);
 
     /**
      * Tear down the four shared diagnostics collectors after the launched
-     * kernels have synced. Each block is gated on the corresponding
-     * `enable_*_` flag and does: stop() → reconcile_counters() →
+     * kernels have synced. Each block is gated on `dfx`, this run's own
+     * configuration, and does: stop() → reconcile_counters() →
      * export step (`chip_swimlane` writes swimlane JSON via
      * `read_phase_header_metadata` + `export_swimlane_json`; `dump`
      * writes dump files; `pmu` has no export step beyond reconcile;
@@ -985,7 +996,7 @@ protected:
      * `dep_gen_replay_emit_deps_json` export) inline their own teardown after
      * calling this helper. The sim base carries the same split.
      */
-    void teardown_shared_collectors_after_run(bool device_execution_complete);
+    void teardown_shared_collectors_after_run(const DfxRunConfig &dfx, bool device_execution_complete);
 
     /**
      * The core and AICPU-thread counts a resident collector's pools were built
@@ -1350,14 +1361,6 @@ protected:
     ScopeStatsCollector scope_stats_collector_;
 
     // Enablement for the four shared diagnostics sub-features.
-    // Written from CallConfig before enqueue and read by execution helpers.
-    bool enable_chip_swimlane_{false};
-    bool enable_dump_args_{false};
-    DumpArgsLevel dump_args_level_{DumpArgsLevel::OFF};  // resolved from set_dump_args_enabled()
-    bool enable_pmu_{false};
-    bool enable_scope_stats_{false};
     ChipSwimlaneLevel chip_swimlane_level_{ChipSwimlaneLevel::DISABLED};  // resolved from set_chip_swimlane_enabled()
-    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};         // resolved from set_pmu_enabled()
-    bool capture_clock_anchors_{false};                                   // from CallConfig::capture_clock_anchors
     std::string output_prefix_{};                                         // diagnostic artifact root directory
 };

--- a/src/common/platform/shared/host/args_dump_collector.cpp
+++ b/src/common/platform/shared/host/args_dump_collector.cpp
@@ -138,8 +138,8 @@ void ArgsDumpCollector::merge_collector_shards() {
 }
 
 int ArgsDumpCollector::initialize(
-    int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
-    const DumpFreeCallback &free_cb
+    int num_dump_threads, int device_id, DumpArgsLevel dump_args_level, const DumpAllocCallback &alloc_cb,
+    DumpRegisterCallback register_cb, const DumpFreeCallback &free_cb
 ) {
     if (shm_host_ != nullptr) {
         // Already holding this run's device resources. They are not per-run:
@@ -147,6 +147,7 @@ int ArgsDumpCollector::initialize(
         // compile time, so there is nothing here left to re-apply.
         return 0;
     }
+    dump_args_level_ = dump_args_level;
     if (num_dump_threads <= 0 || num_dump_threads > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR(
             "ArgsDumpCollector::initialize: invalid num_dump_threads=%d (valid range: 1-%d)", num_dump_threads,
@@ -288,8 +289,8 @@ void ArgsDumpCollector::start_writer_thread_once() {
     if (writer_started_) return;
     writer_started_ = true;
 
-    // `output_prefix_` is captured at initialize() time and is the per-task
-    // uniqueness boundary; the dump dir name is fixed (`<prefix>/args_dump`).
+    // `output_prefix_` is bound by begin_run() and is the per-task uniqueness
+    // boundary; the dump dir name is fixed (`<prefix>/args_dump`).
     std::string run_dir_name = "args_dump";
     run_dir_ = std::filesystem::path(output_prefix_) / run_dir_name;
     std::filesystem::create_directories(run_dir_);

--- a/src/common/platform/shared/host/chip_swimlane_collector.cpp
+++ b/src/common/platform/shared/host/chip_swimlane_collector.cpp
@@ -109,8 +109,9 @@ bool ChipSwimlaneCollector::set_json_extension(ChipSwimlaneExtensionSection sect
 }
 
 int ChipSwimlaneCollector::initialize(
-    int num_aicore, int aicpu_thread_num, int device_id, const ChipSwimlaneAllocCallback &alloc_cb,
-    ChipSwimlaneRegisterCallback register_cb, const ChipSwimlaneFreeCallback &free_cb
+    int num_aicore, int aicpu_thread_num, int device_id, ChipSwimlaneLevel chip_swimlane_level,
+    const ChipSwimlaneAllocCallback &alloc_cb, ChipSwimlaneRegisterCallback register_cb,
+    const ChipSwimlaneFreeCallback &free_cb
 ) {
     if (shm_host_ != nullptr) {
         // Already holding this run's device resources. They are not per-run:
@@ -118,6 +119,7 @@ int ChipSwimlaneCollector::initialize(
         // compile time, so there is nothing here left to re-apply.
         return 0;
     }
+    chip_swimlane_level_ = chip_swimlane_level;
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
         return PTO_RUNTIME_ERR_INTERNAL;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -757,12 +757,8 @@ extern "C" __attribute__((weak)) int prewarm_config_impl(
 
 void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_chip_swimlane_enabled(config.enable_chip_swimlane);
-    set_dump_args_enabled(config.enable_dump_args);
-    set_pmu_enabled(config.enable_pmu);
     // a2a3 and a5 override set_dep_gen_enabled; an arch without dep_gen no-ops.
     set_dep_gen_enabled(config.enable_dep_gen != 0);
-    set_scope_stats_enabled(config.enable_scope_stats != 0);
-    capture_clock_anchors_ = config.capture_clock_anchors != 0;
     set_output_prefix(config.output_prefix);
 }
 
@@ -824,45 +820,53 @@ void SimDeviceRunnerBase::publish_host_phase_records_to_swimlane() {
     );
 }
 
-void SimDeviceRunnerBase::start_shared_collectors_for_run() {
+void SimDeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx) {
+    // Opening a resident collector's window drops the previous run's records and
+    // republishes the device level, so it belongs with the start, at launch.
     auto thread_factory = [this](std::function<void()> fn) {
         return create_thread(std::move(fn));
     };
-    if (enable_chip_swimlane_) {
-        if (capture_clock_anchors_) begin_clock_correlation_session_if_needed();
+    if (dfx.chip_swimlane_enabled()) {
+        chip_swimlane_collector_.begin_run(dfx.output_prefix, dfx.chip_swimlane_level);
+        if (dfx.capture_clock_anchors) begin_clock_correlation_session_if_needed();
         chip_swimlane_collector_.start(thread_factory);
     }
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
+        dump_collector_.begin_run(dfx.output_prefix, dfx.dump_args_level);
         dump_collector_.start(thread_factory);
     }
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
+        pmu_collector_.begin_run(make_pmu_csv_path(dfx.output_prefix), dfx.pmu_event_type);
         pmu_collector_.start(thread_factory);
     }
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
+        scope_stats_collector_.begin_run();
         scope_stats_collector_.start(thread_factory);
     }
 }
 
-void SimDeviceRunnerBase::write_host_phase_records_artifact() {
+void SimDeviceRunnerBase::write_host_phase_records_artifact(const std::string &output_prefix) {
     // Every phase this records is produced on the host during bind and the store
     // is finished before launch, so it touches no device state and is callable
-    // from any point after bind — including a path that never launched.
-    // `output_prefix_` is non-empty exactly when this run produces diagnostic
-    // artifacts, and the store writes a pass at most once.
-    if (!output_prefix_.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix_));
+    // from any point after bind — including a path that never launched. The run's
+    // output prefix is non-empty exactly when it produces diagnostic artifacts,
+    // and the store writes a pass at most once.
+    if (!output_prefix.empty() && host_phase_records_.finished()) {
+        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix));
     }
 }
 
-void SimDeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execution_complete) {
+void SimDeviceRunnerBase::teardown_shared_collectors_after_run(
+    const DfxRunConfig &dfx, bool device_execution_complete
+) {
     // The order is fixed by three couplings, not by preference: the clock
     // correlation session closes before the swimlane export reads it, the host
     // phase records reach the collector before that same export serializes them,
     // and each collector drains before it reconciles before it exports.
-    // Diagnostic exports use the per-task `output_prefix_` directory the user set
-    // on CallConfig (CallConfig::validate() enforces non-empty upstream).
+    // Diagnostic exports use the per-task output prefix the user set on
+    // CallConfig (CallConfig::validate() enforces non-empty upstream).
     finish_clock_correlation_session(device_execution_complete);
-    if (enable_chip_swimlane_) {
+    if (dfx.chip_swimlane_enabled()) {
         chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
@@ -871,23 +875,23 @@ void SimDeviceRunnerBase::teardown_shared_collectors_after_run(bool device_execu
         chip_swimlane_collector_.export_swimlane_json();
     }
 
-    write_host_phase_records_artifact();
+    write_host_phase_records_artifact(dfx.output_prefix);
 
-    if (enable_dump_args_) {
+    if (dfx.dump_args_enabled()) {
         dump_collector_.quiesce();
         dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
-    if (enable_pmu_) {
+    if (dfx.pmu_enabled) {
         pmu_collector_.quiesce();
         pmu_collector_.reconcile_counters();
     }
 
-    if (enable_scope_stats_) {
+    if (dfx.scope_stats_enabled) {
         scope_stats_collector_.quiesce();
         scope_stats_collector_.reconcile_counters();
-        scope_stats_collector_.write_jsonl(output_prefix_);
+        scope_stats_collector_.write_jsonl(dfx.output_prefix);
     }
 }
 

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -57,6 +57,7 @@
 #include "platform_comm/comm.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
+#include "host/dfx_run_config.h"
 #include "host/host_phase_records.h"
 #include "host/args_dump_collector.h"
 #include "host/pmu_collector.h"
@@ -104,6 +105,7 @@ public:
             identity(identity_in),
             runtime(&runtime_in),
             config(config_in),
+            dfx(DfxRunConfig::from(config_in)),
             pipeline_slot(pipeline_slot_in) {}
         virtual ~PreparedExecution() = default;
         PreparedExecution(const PreparedExecution &) = delete;
@@ -112,6 +114,7 @@ public:
             identity(other.identity),
             runtime(std::exchange(other.runtime, nullptr)),
             config(other.config),
+            dfx(std::move(other.dfx)),
             pipeline_slot(other.pipeline_slot),
             num_aicore(other.num_aicore),
             launch_aicpu_num(other.launch_aicpu_num) {}
@@ -120,6 +123,17 @@ public:
         NativeRunIdentity identity{};
         Runtime *runtime{nullptr};
         CallConfig config{};
+        /**
+         * This run's diagnostics configuration, resolved from its own config.
+         *
+         * Every phase of the run reads its DFX configuration from here rather
+         * than from the runner's members, so that one run answers for its whole
+         * lifetime from a single value. A simulated device context takes the
+         * execution claim in simpler_prepare_run and therefore never prepares a
+         * successor against a live predecessor, so unlike onboard this carries
+         * no correctness weight here — it keeps the two runner shapes the same.
+         */
+        DfxRunConfig dfx{};
         uint32_t pipeline_slot{PTO_PIPELINE_MAX_DEPTH};
         int num_aicore{0};
         int launch_aicpu_num{0};
@@ -276,10 +290,7 @@ public:
     uint64_t last_task_slot_dispatch_ns(int slot) const { return task_slot_dispatch_ns_[slot]; }
     uint64_t last_task_slot_finish_ns(int slot) const { return task_slot_finish_ns_[slot]; }
 
-    void set_chip_swimlane_enabled(int level) {
-        chip_swimlane_level_ = static_cast<ChipSwimlaneLevel>(level);
-        enable_chip_swimlane_ = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
-    }
+    void set_chip_swimlane_enabled(int level) { chip_swimlane_level_ = static_cast<ChipSwimlaneLevel>(level); }
     uint32_t chip_swimlane_level() const { return static_cast<uint32_t>(chip_swimlane_level_); }
     bool
     publish_chip_swimlane_extension(ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size) {
@@ -301,37 +312,32 @@ public:
      */
     virtual void publish_chip_swimlane_runtime_extensions() {}
     /**
-     * Start collector mgmt + poll threads for the four shared diagnostics
-     * collectors that are enabled. Mirrors the onboard base. Subclasses with
-     * arch-specific collectors (`dep_gen_collector_`) call this and then start
-     * their own.
+     * Open this run's collection window on the four shared diagnostics
+     * collectors it enables, and start their mgmt + poll threads. Each block is
+     * gated on `dfx`, this run's own configuration, not on the runner's members.
+     * Mirrors the onboard base, where opening the window at launch is what keeps
+     * a resident collector's per-run state off a live predecessor. Subclasses
+     * with arch-specific collectors (`dep_gen_collector_`) call this and then
+     * open and start their own.
      */
-    void start_shared_collectors_for_run();
+    void start_shared_collectors_for_run(const DfxRunConfig &dfx);
     /** Write this pass's per-event host phase records, if it collected any. */
-    void write_host_phase_records_artifact();
+    void write_host_phase_records_artifact(const std::string &output_prefix);
     /**
      * Tear down the four shared diagnostics collectors after the launched
      * kernels have synced, in the one order their couplings allow: the clock
      * correlation session closes before the swimlane export reads it, and each
-     * collector drains before it reconciles before it exports.
+     * collector drains before it reconciles before it exports. Each block is
+     * gated on `dfx`, this run's own configuration.
      *
      * Subclasses with arch-specific collectors (`dep_gen_collector_` + its
      * `dep_gen_replay_emit_deps_json` export) inline their own teardown after
      * calling this helper, as on onboard.
      */
-    void teardown_shared_collectors_after_run(bool device_execution_complete);
+    void teardown_shared_collectors_after_run(const DfxRunConfig &dfx, bool device_execution_complete);
     /** Start the level-4 Host/Device clock correlation once per run. */
     void begin_clock_correlation_session_if_needed() noexcept;
     void finish_clock_correlation_session(bool capture_device_complete) noexcept;
-    void set_dump_args_enabled(int level) {
-        dump_args_level_ = static_cast<DumpArgsLevel>(level);
-        enable_dump_args_ = (dump_args_level_ != DumpArgsLevel::OFF);
-    }
-    void set_pmu_enabled(int enable_pmu) {
-        enable_pmu_ = (enable_pmu > 0);
-        pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
-    }
-    void set_scope_stats_enabled(bool enable) { enable_scope_stats_ = enable; }
     // Diagnostic artifact root directory (CallConfig::validate() enforces non-empty
     // upstream when any diagnostic is enabled).
     void set_output_prefix(const char *prefix) { output_prefix_ = (prefix != nullptr) ? prefix : ""; }
@@ -601,15 +607,10 @@ protected:
 
     CollectorShape collector_shape_{};
 
-    // Enablement flags. Written before enqueue and read by execution helpers.
-    bool enable_chip_swimlane_{false};
-    bool enable_dump_args_{false};
-    DumpArgsLevel dump_args_level_{DumpArgsLevel::OFF};  // resolved from set_dump_args_enabled()
-    bool enable_pmu_{false};
-    bool enable_scope_stats_{false};
+    // Enablement flags. A run's own diagnostics configuration travels on its
+    // PreparedExecution::dfx; the runner keeps only what a device-context query
+    // answers from, plus the artifact root the host-phase pool arms against.
     ChipSwimlaneLevel chip_swimlane_level_{ChipSwimlaneLevel::DISABLED};  // resolved from set_chip_swimlane_enabled()
-    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};         // resolved from set_pmu_enabled()
-    bool capture_clock_anchors_{false};                                   // from CallConfig::capture_clock_anchors
     std::string output_prefix_{};                                         // diagnostic artifact root directory
 };
 

--- a/tests/ut/cpp/common/test_args_dump_collector.cpp
+++ b/tests/ut/cpp/common/test_args_dump_collector.cpp
@@ -49,7 +49,7 @@ TEST(ArgsDumpCollectorTest, MergesConcurrentShardRecordsIntoManifest) {
     constexpr int kShardCount = DumpModule::kMaxCollectorThreads;
     ArgsDumpCollector collector;
     collector.begin_run(test_dir.string(), DumpArgsLevel::HYBRID);
-    ASSERT_EQ(collector.initialize(kShardCount, 0, test_alloc, nullptr, test_free), 0);
+    ASSERT_EQ(collector.initialize(kShardCount, 0, DumpArgsLevel::HYBRID, test_alloc, nullptr, test_free), 0);
 
     std::vector<DumpMetaBuffer> buffers(kShardCount);
     std::atomic<int> ready_workers{0};
@@ -110,7 +110,7 @@ TEST(ArgsDumpCollectorTest, ArenaAckAdvancesOnlyForThreadsWhosePayloadsLanded) {
     constexpr uint64_t kPayloadSize = sizeof(uint64_t);
     TestArgsDumpCollector collector;
     collector.begin_run(test_dir.string(), DumpArgsLevel::FULL);
-    ASSERT_EQ(collector.initialize(kArenaCount, 0, test_alloc, nullptr, test_free), 0);
+    ASSERT_EQ(collector.initialize(kArenaCount, 0, DumpArgsLevel::FULL, test_alloc, nullptr, test_free), 0);
 
     auto *device_base = collector.get_dump_shm_device_ptr();
     ASSERT_NE(device_base, nullptr);
@@ -172,7 +172,7 @@ TEST(ArgsDumpCollectorTest, ArenaAckDoesNotOffsetPayloadsAcrossThreads) {
 
     TestArgsDumpCollector collector;
     collector.begin_run(test_dir.string(), DumpArgsLevel::FULL);
-    ASSERT_EQ(collector.initialize(2, 0, test_alloc, nullptr, test_free), 0);
+    ASSERT_EQ(collector.initialize(2, 0, DumpArgsLevel::FULL, test_alloc, nullptr, test_free), 0);
 
     auto *device_base = collector.get_dump_shm_device_ptr();
     ASSERT_NE(device_base, nullptr);


### PR DESCRIPTION
## Summary

The DFX collectors are resident objects that serve every run, so opening a run's collection window is destructive: `begin_run()` drops the previous run's records and counters and republishes the level the device reads. That ran during `prepare_execution`, which on onboard can run for a **successor while a predecessor is still executing**.

This moves it to launch, where the run holds the execution claim and is the only run touching those collectors — and carries the run's own DFX configuration through launch and drain instead of reading the runner's members.

Part of #2078.

## What changed

| | |
| --- | --- |
| `begin_run()` × 5 collectors × 4 runners | → `start_shared_collectors_for_run()` on each base, beside the `start()` it belongs with |
| `initialize()` for chip-swimlane / args-dump | takes the level as an argument, instead of reading what `begin_run()` latched |
| launch / drain / the two bracket helpers | read `PreparedExecution::dfx`, not runner members |
| 6 runner members | dead as a result, removed with their setters |
| a5's PMU degradation | `dfx.pmu_enabled = false` — a per-run value, no longer a runner-wide write |

`initialize()` could not move with `begin_run()`: chip-swimlane sizes its orch phase pool from the level and args-dump writes it into `DumpDataHeader`, and its device pointers must be in `kernel_args` before that uploads at the end of prepare. Passing the level in removes the ordering constraint between two calls that no longer share state.

`PreparedExecution` already carried the run's `CallConfig` by value, so carrying `DfxRunConfig` needed no new plumbing.

### Why the dead members go in this commit

`enable_chip_swimlane_`, `enable_dump_args_`, `enable_pmu_`, `enable_scope_stats_`, `pmu_event_type_` and `capture_clock_anchors_` are now write-only — every remaining occurrence is a declaration or a setter assignment, which is what let the compiler confirm the removal. A write-only `enable_pmu_` on the runner is the exact shape of the defect this change is about: it reads as the source of truth and is not one. `chip_swimlane_level_` stays (a device-context query answers from it) and `output_prefix_` stays (`host_phase_pool_arm()` reads it).

## What this does *not* do

**The diagnostics depth-one gate stays.** What remains behind it is pool construction, not per-run arming: a prepare whose collector shape differs from the resident one calls `finalize_collectors()`, which frees device memory the predecessor is using. That is a much narrower condition than "any diagnostic is on", and turning the gate into it is the next change on this line.

**Sim takes the same shape but not the same fix.** It acquires the execution claim at the top of `simpler_prepare_run`, so it never prepares a successor against a live predecessor. Keeping the two runner shapes identical is the point — see #2162.

## Testing

Verified **per DFX channel** in the shapes `_st-sim-{a2a3,a5}.yml` uses. A bare sweep enables no channel and so cannot fail on a collector defect.

- **12 channel runs, 23 cases, green** on both sim platforms
- **Negative control fires on the relocated code**: with `begin_run()` omitted from `start_shared_collectors_for_run()`, all 5 a5sim swimlane cases fail
- Full sim sweeps green: **33** (a2a3sim) and **29** (a5sim) cases
- pyut **2216 passed / 7 skipped**
- cpput **135/135** from a cleared build dir — which is what caught the three test call sites of the changed `initialize()`
- a2a3 **onboard** smokes green under `task-submit` across PMU, chip_swimlane + dep_gen, hbg dep_gen and args_dump: **11 cases**

Related: #2078, #2162