### PR TITLE
Fix: size the ring task window for host_build_graph PA Case1/Case2

### DIFF
--- a/tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py
+++ b/tests/st/a2a3/host_build_graph/paged_attention/test_paged_attention.py
@@ -78,6 +78,9 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
             "name": "Case1",
             "platforms": ["a2a3"],
             "manual": True,
+            # ~65,792 tasks, all resident at once; the table is sized to the next
+            # power of two above that. The heap takes no knob.
+            "config": {"runtime_env": {"ring_task_window": 131072}},
             "params": {
                 "batch": 256,
                 "num_heads": 16,
@@ -93,6 +96,8 @@ class TestPagedAttentionHostBuildGraph(SceneTestCase):
             "name": "Case2",
             "platforms": ["a2a3"],
             "manual": True,
+            # ~32,832 resident tasks.
+            "config": {"runtime_env": {"ring_task_window": 65536}},
             "params": {
                 "batch": 64,
                 "num_heads": 64,


### PR DESCRIPTION
Both cases are whole-graph-resident and build more tasks than the 16384-task default window, so bind fails with -1000 before any kernel runs. Case1 orchestrates ~65,792 tasks and Case2 ~32,832; each case now requests the next power of two above its own count via CallConfig.runtime_env.ring_task_window.

Only the task window needs a knob -- the graph heap is committed to its measured size after orchestration and takes no configuration.