### PR TITLE
Fix: normalize onboard CANN worker scheduling policy

### DIFF
--- a/docs/troubleshooting/README.md
+++ b/docs/troubleshooting/README.md
@@ -11,6 +11,7 @@ guide when the failure happens during build, test setup, or simulation.
 | [Device Error Codes](device-error-codes.md) | Runtime and CANN error classification, first-response triage, minimal reproductions, and links to focused diagnostic guides |
 | [Local Runtime Timeouts](local-timeout-defaults.md) | Local and CI timeout defaults, override variables, and the required ordering for onboard watchdogs |
 | [A2/A3 Worker Retirement](a2a3-worker-retirement.md) | Why EXITED is not permission to return, and the group-wide CLOSE / GM-release handoff |
+| [A2/A3 Scheduling Tails](a2a3-scheduling-tails.md) | Periodic real-time CPU throttling, normal AICPU thread scheduling, and worker-policy lifetime |
 | [a2a3 AICPU Shared-SO Device Fault](a2a3-507899-aicpu-shared-so-fault.md) | Diagnosing mass `507899`/`507018` cascades caused by an AICPU shared-library device fault |
 | [Sim CPU Oversubscription](sim-oversubscription-hang.md) | Simulation hangs and false timeouts when AICPU and AICore host threads are CPU-starved |
 

--- a/docs/troubleshooting/a2a3-scheduling-tails.md
+++ b/docs/troubleshooting/a2a3-scheduling-tails.md
@@ -1,0 +1,48 @@
+# A2/A3 Scheduling Tails
+
+Continuous AICPU polling can exhaust the device Linux real-time CPU budget.
+On two A3 hosts, the executing CANN workers used `SCHED_FIFO` at priority 10,
+with `sched_rt_runtime_us=950000` and `sched_rt_period_us=1000000`. Dual-slot
+Qwen decode produced roughly one long completion interval per second.
+
+During a representative tail, an AICPU scheduler thread consumed 38.65 ms of
+CPU time over 82.73 ms of wall time and recorded one involuntary context
+switch. All three scheduler threads paused together. The typical frame
+duration was unchanged. Replacing FIFO with `SCHED_OTHER` for the scheduler
+threads removed the tails; restarting with FIFO restored them. All three
+groups passed the full token golden and native dual-slot validation.
+
+| Scheduler policy | Effective P50 | Effective max | Samples above 50 ms |
+| ---------------- | ------------: | ------------: | ------------------: |
+| FIFO baseline | 38.689 ms | 82.709 ms | 4/122 |
+| SCHED_OTHER | 38.690 ms | 39.044 ms | 0/122 |
+| FIFO repeated | 38.684 ms | 82.965 ms | 5/122 |
+
+These measurements establish a scheduling-policy dependency consistent with
+real-time bandwidth throttling. The device did not expose `/proc/sched_debug`,
+so a kernel throttle event was not captured directly. The Linux bandwidth
+controls are described in the [kernel documentation](https://docs.kernel.org/scheduler/sched-rt-group.html).
+
+## Execution Policy
+
+A2/A3 onboard execution selects `SCHED_OTHER` for every thread that survives
+the affinity gate before entering the runtime. This covers TMR orchestration
+and scheduling, and HBG's scheduling participants. The thread policy is
+checked on every invocation because a CANN worker can be reused or have its
+policy reset between calls. Already-normal threads need no setter call.
+
+The policy belongs to the CANN worker thread and persists after the Simpler
+entry returns. Switching back to FIFO can require privileges unavailable to
+device code. Callers sharing a CANN worker process must account for this
+lifetime; the policy is not scoped to one graph or model. Ordinary scheduling
+can introduce contention latency when other runnable threads share the CPU.
+
+If the policy query or update fails, the runtime emits one warning per loaded SO
+and continues with its current policy. Returning from only one participant
+would leave its peers waiting at the runtime barriers. Such a run is not
+guaranteed to avoid real-time throttling.
+
+Completion intervals, host runner time and device windows must all be checked:
+a pause before device-phase entry or after its completion appears in the
+runner window but can be absent from the device timing. Single-slot gaps can
+reduce budget pressure, but a single-slot workload is not inherently exempt.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -169,6 +169,7 @@ nav:
           - Overview and code reference: troubleshooting/device-error-codes.md
           - Diagnostic guide index: troubleshooting/device-error-codes/README.md
       - Local timeout defaults: troubleshooting/local-timeout-defaults.md
+      - A2/A3 scheduling tails: troubleshooting/a2a3-scheduling-tails.md
       - a2a3 507899 AICPU shared-SO fault: troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
       - Sim oversubscription hang: troubleshooting/sim-oversubscription-hang.md
       - macOS build: troubleshooting/macos-build.md

--- a/src/a2a3/platform/include/aicpu/thread_scheduling.h
+++ b/src/a2a3/platform/include/aicpu/thread_scheduling.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include <cerrno>
+#include <sched.h>
+
+inline int use_normal_aicpu_scheduling() {
+    const int policy = sched_getscheduler(0);
+    if (policy < 0) return errno;
+    if (policy == SCHED_OTHER) return 0;
+    const sched_param param{};
+    return sched_setscheduler(0, SCHED_OTHER, &param) == 0 ? 0 : errno;
+}

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -8,6 +8,7 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+#include <atomic>
 #include <cstdio>
 
 #include "common/unified_log.h"
@@ -22,6 +23,7 @@
 #include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/platform_aicpu_affinity.h"
+#include "aicpu/thread_scheduling.h"
 #include "aicpu/scope_stats_collector_aicpu.h"
 #include "aicpu/args_dump_aicpu.h"
 #include "runtime.h"
@@ -98,6 +100,16 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
             runtime->get_aicpu_allowed_cpus(), runtime->get_aicpu_allowed_cpu_count(), runtime->get_aicpu_launch_count()
         )) {
         return 0;
+    }
+
+    // CANN workers retain their policy across calls; continuous RT polling
+    // can exhaust the device's real-time CPU budget.
+    const int scheduling_error = use_normal_aicpu_scheduling();
+    if (scheduling_error != 0) {
+        static std::atomic<bool> warned{false};
+        if (!warned.exchange(true, std::memory_order_relaxed)) {
+            LOG_WARN("AICPU normal scheduling unavailable: errno=%d; retaining current policy", scheduling_error);
+        }
     }
 
     // Publish the phase-buffer base so the finer preamble/so_load/graph_build/

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -1395,6 +1395,20 @@ target_link_libraries(test_a2a3_aicpu_affinity_select PRIVATE
 add_test(NAME test_a2a3_aicpu_affinity_select COMMAND test_a2a3_aicpu_affinity_select)
 set_tests_properties(test_a2a3_aicpu_affinity_select PROPERTIES LABELS "no_hardware")
 
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_executable(test_a2a3_thread_scheduling a2a3/test_thread_scheduling.cpp)
+    target_include_directories(test_a2a3_thread_scheduling PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    )
+    target_link_libraries(test_a2a3_thread_scheduling PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+    target_link_options(test_a2a3_thread_scheduling PRIVATE
+        -Wl,--wrap=sched_getscheduler -Wl,--wrap=sched_setscheduler
+    )
+    add_test(NAME test_a2a3_thread_scheduling COMMAND test_a2a3_thread_scheduling)
+    set_tests_properties(test_a2a3_thread_scheduling PROPERTIES LABELS "no_hardware")
+endif()
+
 # a5 CPU_TOPO fallback and affinity selection. Pure logic; packaged fallback
 # entries enforce their own verified SoC, host-architecture, and OCCUPY constraints.
 set(A5_ONBOARD_HOST_DIR ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/onboard/host)

--- a/tests/ut/cpp/a2a3/test_thread_scheduling.cpp
+++ b/tests/ut/cpp/a2a3/test_thread_scheduling.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <gtest/gtest.h>
+
+#include "aicpu/thread_scheduling.h"
+
+namespace {
+int current_policy = SCHED_FIFO;
+int get_error = 0;
+int set_error = 0;
+int set_calls = 0;
+
+class ThreadScheduling : public ::testing::Test {
+    void SetUp() override {
+        current_policy = SCHED_FIFO;
+        get_error = 0;
+        set_error = 0;
+        set_calls = 0;
+    }
+};
+}  // namespace
+
+extern "C" int __wrap_sched_getscheduler(pid_t pid) {
+    EXPECT_EQ(pid, 0);
+    errno = get_error;
+    return get_error ? -1 : current_policy;
+}
+
+extern "C" int __wrap_sched_setscheduler(pid_t pid, int policy, const sched_param *param) {
+    EXPECT_EQ(pid, 0);
+    EXPECT_EQ(policy, SCHED_OTHER);
+    EXPECT_EQ(param->sched_priority, 0);
+    ++set_calls;
+    errno = set_error;
+    if (set_error) return -1;
+    current_policy = policy;
+    return 0;
+}
+
+TEST_F(ThreadScheduling, ConvertsRealtimePolicy) {
+    EXPECT_EQ(use_normal_aicpu_scheduling(), 0);
+    EXPECT_EQ(current_policy, SCHED_OTHER);
+    EXPECT_EQ(set_calls, 1);
+}
+
+TEST_F(ThreadScheduling, RechecksReusedWorker) {
+    EXPECT_EQ(use_normal_aicpu_scheduling(), 0);
+    EXPECT_EQ(use_normal_aicpu_scheduling(), 0);
+    EXPECT_EQ(set_calls, 1);
+    current_policy = SCHED_FIFO;
+    EXPECT_EQ(use_normal_aicpu_scheduling(), 0);
+    EXPECT_EQ(set_calls, 2);
+}
+
+TEST_F(ThreadScheduling, PreservesPolicyWhenDenied) {
+    set_error = EPERM;
+    EXPECT_EQ(use_normal_aicpu_scheduling(), EPERM);
+    EXPECT_EQ(current_policy, SCHED_FIFO);
+}
+
+TEST_F(ThreadScheduling, ReportsQueryFailure) {
+    get_error = EINVAL;
+    EXPECT_EQ(use_normal_aicpu_scheduling(), EINVAL);
+    EXPECT_EQ(set_calls, 0);
+}


### PR DESCRIPTION
## Summary

Continuous FIFO polling can exhaust the real-time CPU budget and produce periodic stalls. Hardware runs showed roughly 40 ms pauses near 1 Hz, with a configured RT budget of 950000 us per 1000000 us. The observations are consistent with real-time bandwidth throttling; a kernel throttle event was not captured directly.

After the affinity gate, A2/A3 onboard `simpler_aicpu_exec` calls a helper that checks each active CANN worker's policy on every invocation and sets `SCHED_OTHER`, priority 0, when needed. This covers TMR orchestration/scheduler workers and HBG scheduling workers.

Syscall failures produce one warning per loaded runtime SO, guarded atomically, while workers continue barrier participation. The policy persists across calls; contention under normal scheduling may add latency.

Adds four Linux syscall-wrapper tests and indexed troubleshooting documentation.

## Hardware Evidence

A3, CANN 9.0, GCC 10; Qwen3-14B, batch 16, 127 decode steps, two slots split 64/63, and 122 steady-state samples per qualification run:

| Runtime | Baseline runs | Final candidate runs | Max effective latency, baseline to candidate | Max completion interval, baseline to candidate |
| --- | ---: | ---: | --- | --- |
| TMR | 4 | 2 | 86.589 to 39.087 ms | 86.852 to 39.763 ms |
| HBG | 1 | 1 | 85.721 to 42.342 ms | 86.130 to 43.566 ms |

All final candidate runs passed golden checks. Effective latency measures TMR scheduler duration and HBG device wall time; compare each runtime against its own baseline. No candidate run had an effective sample above 50 ms.

One earlier TMR candidate run had a token mismatch at step 112. Across all candidate runs, TMR passed 4/5 golden checks and HBG 4/4. The mismatch did not recur in follow-up runs; its cause was not established.

Hardware evidence used base `39ce891`, before rebasing onto `7bcdc95`. Intervening main changes include DFX configuration, HBG early-dispatch prerequisites, A2/A3 worker retirement, and A5 HBG profiling. The scheduling implementation is unchanged; the only manual conflict resolution preserved both troubleshooting index entries. Hardware tests were not rerun on the rebased integration. These are qualification measurements, not the formal multi-run performance campaign.

## Validation

- 136 no-hardware CTest targets, 24 Qwen Python tests, pre-commit, and the full A2/A3 simulation sweep passed.
- Onboard L2: HBG 40 passed / 1 skipped; TMR 58 passed.
- Four communication-resource tests raised `BufferError: cannot close exported pointers exist`, reproduced individually on both baseline and candidate: `test_worker_chip_message_queue`, `test_worker_chip_orch_comm_stream`, `test_l3_single_hop_two_lifecycles`, and `test_l4_two_hop_two_lifecycles`.
- Separate SDMA and cross-host suites were not run.
