### PR TITLE
Add: hbg early dispatch across in-graph tasks and into a Graph body

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -560,10 +560,13 @@ struct SchedulerState {
     void push_ready_routed(ChipTaskSlotState *slot_state) {
         // Early-dispatch release: a pre-staged candidate launches by doorbell
         // right here — the moment its readiness is decided — and skips the
-        // queue round-trip. Only host-qualified candidates can hold a staging
-        // claim, so every other task pays one hot-line flag test. A ready
-        // sync_start candidate also publishes to its drain owner, which may
-        // already hold it for an all-or-nothing stage.
+        // queue round-trip. Only a candidate can hold a staging claim, so every
+        // other task pays one hot-line flag test. The verdict is the host's for
+        // a task it submitted, and materialization's for a Graph body root,
+        // which qualifies only under a shell the host qualified — the one
+        // release that can stage it. A ready sync_start candidate also
+        // publishes to its drain owner, which may already hold it for an
+        // all-or-nothing stage.
         if ((slot_state->ed_flags & ED_FLAG_CANDIDATE) != 0) {
             const bool early_handled = try_early_dispatch_release(*slot_state);
             if (slot_state->task_attrs.requires_sync_start()) {
@@ -749,7 +752,10 @@ struct SchedulerState {
     // sync cohort (producer done) can dispatch inline when it fits, so it reuses the
     // per-shape dispatch_shape. An EARLY sync cohort carries a non-zero src_payload
     // gate; its owner stages locally when one tracker fits and uses the global drain
-    // otherwise. HBG producer propagation currently leaves this queue dormant.
+    // otherwise. Any early-dispatch candidate carrying sync_start lands
+    // here, whatever cohort it belongs to: a top-level one, an in-graph one whose
+    // producers published, or a Graph root its shell staged. The queue is chosen
+    // by the task's own attribute, never by where it was submitted.
     ChipReadyQueue early_sync_start_queue;
 
     // Pending-drain queue of the publish list. Each entry is the head of a
@@ -821,7 +827,47 @@ struct SchedulerState {
     // NONE->STAGING CAS: a consumer that already became ready lost the state
     // to the release path's NONE->DISPATCHED and is dropped here. A failed
     // push returns the claim so readiness takes the ordinary queue path.
+    // A GRAPH shell occupies no core, so it has nothing of its own to stage.
+    // What its readiness gates is the body's roots, and a root is an ordinary
+    // AICore task — mask, blocks and all — so the shell stages those instead.
+    // Each is gated exactly like any pre-staged task and rings when the ordinary
+    // route reaches it: the shell's own producers complete, push_ready_routed
+    // hands the shell to graph_ready_queue, and activate_graph_task opens the
+    // external gate graph_route_ready_roots reads. So the data dependency the
+    // shell stands for is still honoured. The shell's own completion is a later
+    // and unrelated event — the body retiring.
+    //
+    // Only roots already published can be staged. A root materialized after
+    // this pass is not picked up: graph_incremental_publish skips roots by
+    // construction, and the shell's NONE->STAGING claim admits this pass once,
+    // so a late root simply takes the ordinary route. That costs the pre-stage,
+    // never correctness.
+    //
+    // Materialization decides which roots are stageable and marks them
+    // ED_FLAG_CANDIDATE; this pass only enqueues. route_cursor is untouched:
+    // staging is not routing, and the ordinary route must still run to ring.
+    inline void stage_graph_roots_early(ChipTaskSlotState &shell) {
+        auto *execution = static_cast<GraphExecution *>(shell.graph_context);
+        if (execution == nullptr) return;
+        const int32_t published = execution->published_tasks.load(std::memory_order_acquire);
+        for (int32_t i = 0; i < published; ++i) {
+            ChipTaskSlotState &root = execution->task_at(i).slot;
+            if ((root.ed_flags & ED_FLAG_CANDIDATE) == 0) continue;
+            if (execution->fanin_offsets[i] != execution->fanin_offsets[i + 1]) continue;
+            enqueue_early_dispatch_candidate(root);
+        }
+    }
+
     inline void enqueue_early_dispatch_candidate(ChipTaskSlotState &consumer) {
+        if (consumer.task_kind == TaskKind::GRAPH) {
+            uint8_t expected_shell = EARLY_DISPATCH_NONE;
+            if (consumer.to_payload().early_dispatch_state.compare_exchange_strong(
+                    expected_shell, EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+                )) {
+                stage_graph_roots_early(consumer);
+            }
+            return;
+        }
         uint8_t expected = EARLY_DISPATCH_NONE;
         if (!consumer.to_payload().early_dispatch_state.compare_exchange_strong(
                 expected, EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
@@ -907,6 +953,15 @@ struct SchedulerState {
     // reclaiming tensormap_and_ringbuffer runtime instead defers propagation
     // to launch visibility; whole-graph-resident hbg holds no reclaimable
     // resource a gated chain could pin, so placement is the sufficient gate.)
+    // The execution an early-dispatch task belongs to, or null when it is a
+    // GLOBAL task. complete_task routes on exactly this pair, and the publish
+    // chain follows it for the same reason: a GRAPH shell is a task of the run
+    // and takes the global path even though it carries a graph_context.
+    static GraphExecution *in_graph_execution_of(ChipTaskSlotState &slot_state) {
+        if (slot_state.graph_context == nullptr || slot_state.task_kind == TaskKind::GRAPH) return nullptr;
+        return static_cast<GraphExecution *>(slot_state.graph_context);
+    }
+
     // Called BEFORE the batch's MMIO token writes, with the count that batch is
     // about to publish. Returns true when this call reached the task's total,
     // i.e. this caller owns the seal and must call seal_ed_publish_list once its
@@ -935,7 +990,16 @@ struct SchedulerState {
             count
         );
         if (total != slot_state.logical_block_num) return false;
-        task_view.tasks->store_published(slot_state.to_descriptor().task_id.local_id());
+        // Which array carries this task's state is the one thing the two cohorts
+        // do not share: a GLOBAL task has a task-table slot, an IN_GRAPH task has
+        // only its execution's array. The bytes are the same shape, so nothing
+        // past this line differs.
+        GraphExecution *execution = in_graph_execution_of(slot_state);
+        if (execution != nullptr) {
+            execution->store_published(slot_state.in_graph_local_id);
+        } else {
+            task_view.tasks->store_published(slot_state.to_descriptor().task_id.local_id());
+        }
         return true;
     }
 
@@ -974,15 +1038,26 @@ struct SchedulerState {
     // meets the sentinel treats the producer as published and advances.
     bool advance_ed_publish_scan(ChipTaskSlotState &c) {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
-        const TaskPayload &p = c.to_payload();
-        const int32_t *fanin = p.fanin_data();
+        // The two cohorts differ in where the row lives and where the states do,
+        // and in nothing else: a GLOBAL candidate scans its payload's inline
+        // fanin against the task header, an IN_GRAPH one scans its Definition's
+        // CSR row against its execution. Both rows are sorted by producer index
+        // for a candidate, so the cursor means the same thing either way.
+        GraphExecution *execution = in_graph_execution_of(c);
+        const int32_t *fanin = execution == nullptr ? c.to_payload().fanin_data() : nullptr;
+        const int32_t csr_begin = execution == nullptr ? 0 : execution->fanin_offsets[c.in_graph_local_id];
         int32_t i = c.ed_publish_scan_cursor;
         while (i >= 0) {
-            if (tasks.is_published(fanin[i])) {
+            const int32_t producer_index =
+                execution == nullptr ? fanin[i] : static_cast<int32_t>(execution->fanin_indices[csr_begin + i]);
+            const bool published =
+                execution == nullptr ? tasks.is_published(producer_index) : execution->is_published(producer_index);
+            if (published) {
                 i--;
                 continue;
             }
-            ChipTaskSlotState &producer = tasks.get_slot_state_by_task_id(fanin[i]);
+            ChipTaskSlotState &producer = execution == nullptr ? tasks.get_slot_state_by_task_id(producer_index) :
+                                                                 execution->task_at(producer_index).slot;
             ChipTaskSlotState *expected = producer.ed_publish_list_head.load(std::memory_order_acquire);
             bool hung = false;
             while (expected != ED_PUBLISH_LIST_SENTINEL) {
@@ -995,7 +1070,7 @@ struct SchedulerState {
                 }
             }
             if (hung) {
-                c.ed_publish_scan_cursor = static_cast<uint8_t>(i);
+                c.ed_publish_scan_cursor = static_cast<uint16_t>(i);
                 return false;
             }
             // Sentinel: the producer published between the bit load and here.
@@ -1008,7 +1083,11 @@ struct SchedulerState {
     // is not yet ready (its completion classification hung it on a wake list).
     // Returns true when every producer is already published at intake.
     bool register_on_ed_publish_list(ChipTaskSlotState &c) {
-        c.ed_publish_scan_cursor = static_cast<uint8_t>(c.to_payload().fanin_count - 1);
+        const GraphExecution *execution = in_graph_execution_of(c);
+        const int32_t row_len = execution == nullptr ? c.to_payload().fanin_count :
+                                                       execution->fanin_offsets[c.in_graph_local_id + 1] -
+                                                           execution->fanin_offsets[c.in_graph_local_id];
+        c.ed_publish_scan_cursor = static_cast<uint16_t>(row_len - 1);
 #if SIMPLER_SCHED_PROFILING
         ed_publish_stats.registered.fetch_add(1, std::memory_order_relaxed);
 #endif
@@ -1261,6 +1340,14 @@ struct SchedulerState {
                 push_ready_routed(&task);
             } else {
                 register_graph_wake(execution, &graph_producer_at(execution, task, unmet), &task);
+                // Same rule the global intake applies, against this body's CSR:
+                // a not-yet-ready candidate also enters the publish list, and
+                // one whose producers are all published already goes straight to
+                // the ED queue. Materialization owns this graph alone (the
+                // prepare-queue slot), so no peer registers the same task.
+                if ((task.ed_flags & ED_FLAG_CANDIDATE) != 0 && register_on_ed_publish_list(task)) {
+                    enqueue_early_dispatch_candidate(task);
+                }
             }
         }
         execution.published_tasks.store(last, std::memory_order_release);
@@ -1354,6 +1441,10 @@ struct SchedulerState {
         // loses registration to the sentinel acquires this state when it
         // rescans the Orch-built fanin wire, so no wakeup can be lost.
         execution->store_completed(task_index);
+        // COMPLETED >= PUBLISHED, so a tracked producer that never published
+        // (DUMMY, predicate-retired) releases its publish-list waiters here.
+        // Idempotent after a publish-time seal, exactly as on the global path.
+        if ((slot_state.ed_flags & ED_FLAG_TRACKED) != 0) seal_ed_publish_list(slot_state);
         outcome.fanout_edges = drain_graph_wake_list(*execution, slot_state);
 
         const bool graph_completed = graph_execution_complete_in_graph_task(*execution);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler.h
@@ -571,10 +571,13 @@ struct SchedulerState {
     void push_ready_routed(ChipTaskSlotState *slot_state) {
         // Early-dispatch release: a pre-staged candidate launches by doorbell
         // right here — the moment its readiness is decided — and skips the
-        // queue round-trip. Only host-qualified candidates can hold a staging
-        // claim, so every other task pays one hot-line flag test. A ready
-        // sync_start candidate also publishes to its drain owner, which may
-        // already hold it for an all-or-nothing stage.
+        // queue round-trip. Only a candidate can hold a staging claim, so every
+        // other task pays one hot-line flag test. The verdict is the host's for
+        // a task it submitted, and materialization's for a Graph body root,
+        // which qualifies only under a shell the host qualified — the one
+        // release that can stage it. A ready sync_start candidate also
+        // publishes to its drain owner, which may already hold it for an
+        // all-or-nothing stage.
         if ((slot_state->ed_flags & ED_FLAG_CANDIDATE) != 0) {
             const bool early_handled = try_early_dispatch_release(*slot_state);
             if (slot_state->task_attrs.requires_sync_start()) {
@@ -760,7 +763,10 @@ struct SchedulerState {
     // sync cohort (producer done) can dispatch inline when it fits, so it reuses the
     // per-shape dispatch_shape. An EARLY sync cohort carries a non-zero src_payload
     // gate; its owner stages locally when one tracker fits and uses the global drain
-    // otherwise. HBG producer propagation currently leaves this queue dormant.
+    // otherwise. Any early-dispatch candidate carrying sync_start lands
+    // here, whatever cohort it belongs to: a top-level one, an in-graph one whose
+    // producers published, or a Graph root its shell staged. The queue is chosen
+    // by the task's own attribute, never by where it was submitted.
     ChipReadyQueue early_sync_start_queue;
 
     // Pending-drain queue of the publish list. Each entry is the head of a
@@ -832,7 +838,47 @@ struct SchedulerState {
     // NONE->STAGING CAS: a consumer that already became ready lost the state
     // to the release path's NONE->DISPATCHED and is dropped here. A failed
     // push returns the claim so readiness takes the ordinary queue path.
+    // A GRAPH shell occupies no core, so it has nothing of its own to stage.
+    // What its readiness gates is the body's roots, and a root is an ordinary
+    // AICore task — mask, blocks and all — so the shell stages those instead.
+    // Each is gated exactly like any pre-staged task and rings when the ordinary
+    // route reaches it: the shell's own producers complete, push_ready_routed
+    // hands the shell to graph_ready_queue, and activate_graph_task opens the
+    // external gate graph_route_ready_roots reads. So the data dependency the
+    // shell stands for is still honoured. The shell's own completion is a later
+    // and unrelated event — the body retiring.
+    //
+    // Only roots already published can be staged. A root materialized after
+    // this pass is not picked up: graph_incremental_publish skips roots by
+    // construction, and the shell's NONE->STAGING claim admits this pass once,
+    // so a late root simply takes the ordinary route. That costs the pre-stage,
+    // never correctness.
+    //
+    // Materialization decides which roots are stageable and marks them
+    // ED_FLAG_CANDIDATE; this pass only enqueues. route_cursor is untouched:
+    // staging is not routing, and the ordinary route must still run to ring.
+    inline void stage_graph_roots_early(ChipTaskSlotState &shell) {
+        auto *execution = static_cast<GraphExecution *>(shell.graph_context);
+        if (execution == nullptr) return;
+        const int32_t published = execution->published_tasks.load(std::memory_order_acquire);
+        for (int32_t i = 0; i < published; ++i) {
+            ChipTaskSlotState &root = execution->task_at(i).slot;
+            if ((root.ed_flags & ED_FLAG_CANDIDATE) == 0) continue;
+            if (execution->fanin_offsets[i] != execution->fanin_offsets[i + 1]) continue;
+            enqueue_early_dispatch_candidate(root);
+        }
+    }
+
     inline void enqueue_early_dispatch_candidate(ChipTaskSlotState &consumer) {
+        if (consumer.task_kind == TaskKind::GRAPH) {
+            uint8_t expected_shell = EARLY_DISPATCH_NONE;
+            if (consumer.to_payload().early_dispatch_state.compare_exchange_strong(
+                    expected_shell, EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
+                )) {
+                stage_graph_roots_early(consumer);
+            }
+            return;
+        }
         uint8_t expected = EARLY_DISPATCH_NONE;
         if (!consumer.to_payload().early_dispatch_state.compare_exchange_strong(
                 expected, EARLY_DISPATCH_STAGING, std::memory_order_seq_cst, std::memory_order_seq_cst
@@ -918,6 +964,15 @@ struct SchedulerState {
     // reclaiming tensormap_and_ringbuffer runtime instead defers propagation
     // to launch visibility; whole-graph-resident hbg holds no reclaimable
     // resource a gated chain could pin, so placement is the sufficient gate.)
+    // The execution an early-dispatch task belongs to, or null when it is a
+    // GLOBAL task. complete_task routes on exactly this pair, and the publish
+    // chain follows it for the same reason: a GRAPH shell is a task of the run
+    // and takes the global path even though it carries a graph_context.
+    static GraphExecution *in_graph_execution_of(ChipTaskSlotState &slot_state) {
+        if (slot_state.graph_context == nullptr || slot_state.task_kind == TaskKind::GRAPH) return nullptr;
+        return static_cast<GraphExecution *>(slot_state.graph_context);
+    }
+
     // Called BEFORE the batch's MMIO token writes, with the count that batch is
     // about to publish. Returns true when this call reached the task's total,
     // i.e. this caller owns the seal and must call seal_ed_publish_list once its
@@ -946,7 +1001,16 @@ struct SchedulerState {
             count
         );
         if (total != slot_state.logical_block_num) return false;
-        task_view.tasks->store_published(slot_state.to_descriptor().task_id.local_id());
+        // Which array carries this task's state is the one thing the two cohorts
+        // do not share: a GLOBAL task has a task-table slot, an IN_GRAPH task has
+        // only its execution's array. The bytes are the same shape, so nothing
+        // past this line differs.
+        GraphExecution *execution = in_graph_execution_of(slot_state);
+        if (execution != nullptr) {
+            execution->store_published(slot_state.in_graph_local_id);
+        } else {
+            task_view.tasks->store_published(slot_state.to_descriptor().task_id.local_id());
+        }
         return true;
     }
 
@@ -985,15 +1049,26 @@ struct SchedulerState {
     // meets the sentinel treats the producer as published and advances.
     bool advance_ed_publish_scan(ChipTaskSlotState &c) {
         SharedMemoryTaskHeader &tasks = *task_view.tasks;
-        const TaskPayload &p = c.to_payload();
-        const int32_t *fanin = p.fanin_data();
+        // The two cohorts differ in where the row lives and where the states do,
+        // and in nothing else: a GLOBAL candidate scans its payload's inline
+        // fanin against the task header, an IN_GRAPH one scans its Definition's
+        // CSR row against its execution. Both rows are sorted by producer index
+        // for a candidate, so the cursor means the same thing either way.
+        GraphExecution *execution = in_graph_execution_of(c);
+        const int32_t *fanin = execution == nullptr ? c.to_payload().fanin_data() : nullptr;
+        const int32_t csr_begin = execution == nullptr ? 0 : execution->fanin_offsets[c.in_graph_local_id];
         int32_t i = c.ed_publish_scan_cursor;
         while (i >= 0) {
-            if (tasks.is_published(fanin[i])) {
+            const int32_t producer_index =
+                execution == nullptr ? fanin[i] : static_cast<int32_t>(execution->fanin_indices[csr_begin + i]);
+            const bool published =
+                execution == nullptr ? tasks.is_published(producer_index) : execution->is_published(producer_index);
+            if (published) {
                 i--;
                 continue;
             }
-            ChipTaskSlotState &producer = tasks.get_slot_state_by_task_id(fanin[i]);
+            ChipTaskSlotState &producer = execution == nullptr ? tasks.get_slot_state_by_task_id(producer_index) :
+                                                                 execution->task_at(producer_index).slot;
             ChipTaskSlotState *expected = producer.ed_publish_list_head.load(std::memory_order_acquire);
             bool hung = false;
             while (expected != ED_PUBLISH_LIST_SENTINEL) {
@@ -1006,7 +1081,7 @@ struct SchedulerState {
                 }
             }
             if (hung) {
-                c.ed_publish_scan_cursor = static_cast<uint8_t>(i);
+                c.ed_publish_scan_cursor = static_cast<uint16_t>(i);
                 return false;
             }
             // Sentinel: the producer published between the bit load and here.
@@ -1019,7 +1094,11 @@ struct SchedulerState {
     // is not yet ready (its completion classification hung it on a wake list).
     // Returns true when every producer is already published at intake.
     bool register_on_ed_publish_list(ChipTaskSlotState &c) {
-        c.ed_publish_scan_cursor = static_cast<uint8_t>(c.to_payload().fanin_count - 1);
+        const GraphExecution *execution = in_graph_execution_of(c);
+        const int32_t row_len = execution == nullptr ? c.to_payload().fanin_count :
+                                                       execution->fanin_offsets[c.in_graph_local_id + 1] -
+                                                           execution->fanin_offsets[c.in_graph_local_id];
+        c.ed_publish_scan_cursor = static_cast<uint16_t>(row_len - 1);
 #if SIMPLER_SCHED_PROFILING
         ed_publish_stats.registered.fetch_add(1, std::memory_order_relaxed);
 #endif
@@ -1272,6 +1351,14 @@ struct SchedulerState {
                 push_ready_routed(&task);
             } else {
                 register_graph_wake(execution, &graph_producer_at(execution, task, unmet), &task);
+                // Same rule the global intake applies, against this body's CSR:
+                // a not-yet-ready candidate also enters the publish list, and
+                // one whose producers are all published already goes straight to
+                // the ED queue. Materialization owns this graph alone (the
+                // prepare-queue slot), so no peer registers the same task.
+                if ((task.ed_flags & ED_FLAG_CANDIDATE) != 0 && register_on_ed_publish_list(task)) {
+                    enqueue_early_dispatch_candidate(task);
+                }
             }
         }
         execution.published_tasks.store(last, std::memory_order_release);
@@ -1365,6 +1452,10 @@ struct SchedulerState {
         // loses registration to the sentinel acquires this state when it
         // rescans the Orch-built fanin wire, so no wakeup can be lost.
         execution->store_completed(task_index);
+        // COMPLETED >= PUBLISHED, so a tracked producer that never published
+        // (DUMMY, predicate-retired) releases its publish-list waiters here.
+        // Idempotent after a publish-time seal, exactly as on the global path.
+        if ((slot_state.ed_flags & ED_FLAG_TRACKED) != 0) seal_ed_publish_list(slot_state);
         outcome.fanout_edges = drain_graph_wake_list(*execution, slot_state);
 
         const bool graph_completed = graph_execution_complete_in_graph_task(*execution);

--- a/src/common/host_build_graph/device/graph_execution.cpp
+++ b/src/common/host_build_graph/device/graph_execution.cpp
@@ -129,6 +129,18 @@ bool bind_graph_topology(GraphExecution &execution) {
         const int32_t end = fanin_offsets[consumer + 1];
         if (begin > end || end > definition.edge_count) return false;
         if (begin == end) observed_roots++;
+        // ED_FLAG_CANDIDATE steers dispatch from materialization onward, so the
+        // image must carry the whole conjunction the recorder decided it by, not
+        // merely a known bit: a candidate with no producer has nothing to bet on,
+        // a DUMMY one would index early_dispatch_queues[] one past its last
+        // shape, and a predicated one would be released before its predicate is
+        // ever tested. graph_fill_definition is the only writer of this field and
+        // holds all three, so a violation means the image is not one it produced.
+        if ((tasks[consumer].ed_flags & ED_FLAG_CANDIDATE) != 0 &&
+            (begin == end || tasks[consumer].predicate_slot != 0 ||
+             ActiveMask(tasks[consumer].active_mask).to_shape() == ResourceShape::DUMMY)) {
+            return false;
+        }
         for (int32_t edge = begin; edge < end; ++edge) {
             if (fanin_indices[edge] >= consumer) return false;
         }
@@ -393,6 +405,12 @@ GraphMaterializeResult graph_execution_materialize_slice(
     const int32_t first = execution.materialized_tasks;
     const int32_t last = std::min(execution.task_count, first + max_tasks);
     const uintptr_t outer_base = reinterpret_cast<uintptr_t>(outer_slot.to_descriptor().packed_buffer_base);
+    // stage_graph_roots_early is the only path that gives a body root a staging
+    // claim, and it runs only when the shell itself is released early, so under
+    // a shell the host did not qualify no root can ever be staged. The shell's
+    // verdict is written by the host before upload and never changes, so this is
+    // loop-invariant for the whole execution.
+    const bool shell_stages_roots = (outer_slot.ed_flags & ED_FLAG_CANDIDATE) != 0;
     for (int32_t i = first; i < last; ++i) {
         ChipTaskStorage *storage = &execution.task_at(i);
         if (i >= execution.constructed_tasks) {
@@ -419,12 +437,36 @@ GraphMaterializeResult graph_execution_materialize_slice(
         execution.reset_task_state(i);
         slot.active_mask = ActiveMask(source.active_mask);
         slot.task_attrs = TaskAttrs(source.task_attrs);
+        // Recording decided these once for the whole body; every execution of the
+        // same Definition qualifies the same tasks, so materialization only
+        // replays the verdict.
+        slot.ed_flags = source.ed_flags;
         slot.total_required_subtasks = source.total_required_subtasks;
         slot.logical_block_num = source.logical_block_num;
         slot.in_graph_local_id = i;
         // A task in a Graph body is an ordinary leaf, classified by the same rule as
         // one submitted outside a Graph. Its membership is carried by graph_context.
         slot.task_kind = slot.active_mask.is_dummy() ? TaskKind::DUMMY : TaskKind::KERNEL;
+        // A root carries no recorded verdict — qualification needs a producer to
+        // bet on and a root has none inside the body — but an early-released
+        // shell stages roots on the body's behalf, and push_ready_routed reads
+        // this flag to decide whether a task may hold a staging claim. The two
+        // per-task terms are the ones the recorded conjunction applies to the
+        // task itself, and both are load-bearing rather than defensive: a DUMMY
+        // task has no dispatchable shape to index a per-shape queue with, and a
+        // predicated task must reach the predicate test in push_ready_routed,
+        // which an early release returns before. The shell term keeps the flag
+        // off a root nothing can stage, which would otherwise pay a seq_cst CAS
+        // on every route for a claim it can never hold.
+        //
+        // Deciding it here rather than at staging time is what makes it safe:
+        // materialization owns this slot exclusively and runs strictly before
+        // any path can route the root, so the flag is never written beside a
+        // reader.
+        const bool root_stageable = shell_stages_roots &&
+                                    execution.fanin_offsets[i] == execution.fanin_offsets[i + 1] &&
+                                    !slot.task_attrs.has_predicate() && slot.task_kind != TaskKind::DUMMY;
+        if (root_stageable) slot.ed_flags |= ED_FLAG_CANDIDATE;
         slot.graph_context = &execution;
         payload.tensor_count = source.tensor_count;
         payload.scalar_count = source.scalar_count;

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -376,9 +376,13 @@ Definition. It contains:
   dispatchable shape and at least one internal producer; `ED_FLAG_TRACKED` when
   some candidate names it as a producer). A candidate's fanin CSR row is stored
   sorted by producer index, so its tail names its deepest producer; every other
-  row keeps record order. `bind_graph_topology` validates these flags but
-  nothing propagates them to a task slot, so they steer no dispatch yet — the
-  sorted row is the only part of the verdict the device acts on;
+  row keeps record order. `bind_graph_topology` validates these flags and
+  materialization replays them onto each task's slot, where the publish chain
+  reads them: a candidate registers on its producers' chains and pre-stages
+  once they have all published. The verdict covers non-root tasks only —
+  qualification needs a producer to bet on, and a body root has none inside the
+  body — so a root's verdict is not recorded here but decided at
+  materialization;
 - one packed-heap offset per in-graph task;
 - each in-graph task's ChipTensor source:
   `BOUNDARY_EXACT`, `BOUNDARY_VIEW`, `INTERNAL`, or `OWN_OUTPUT`;
@@ -504,6 +508,32 @@ dependency wiring remains an Orchestrator responsibility:
   monotonic, so rows above the cursor stay complete and are never re-walked;
 - `WAKE_LIST_SENTINEL` closes the completion/registration race: a failed
   registration observes completion and immediately rescans.
+
+Early dispatch enters a body from two directions, and each is decided by a
+different party:
+
+- **Into the body.** The outer shell qualifies at submit, by the top-level rule
+  minus the terms that describe dispatching to cores: a shell carries no
+  predicate, has no resource shape and occupies no core, so its producers alone
+  decide it. A qualified shell that its producers release early does not stage
+  itself — it has nothing of its own to place — but stages the body's roots,
+  each an ordinary AICore task. They ring on the ordinary route, when the
+  shell's producers complete and `activate_graph_task` opens the external gate.
+  A Graph as a *producer* is the direction not supported: a shell publishes no
+  placement of its own for a consumer to bet on.
+- **A root's own verdict.** Materialization, not recording, decides it, and the
+  decision is three terms rather than the recorded conjunction: the shell must
+  itself be a candidate, since staging a root can only ever happen on a shell
+  release; and the root must be neither `DUMMY` (no dispatchable shape to index
+  a per-shape early-dispatch queue with) nor predicated (an early release
+  returns before the predicate test). Deciding it at materialization is what
+  keeps the flag off a slot a reader can already see.
+
+Which early-dispatch queue a released candidate enters is chosen by the task's
+own `sync_start` attribute, never by its cohort: a `sync_start` candidate needs
+an all-or-nothing stage and parks in the single shape-agnostic queue, every
+other candidate in its per-shape one. An in-graph task reaches that fork by the
+same path a top-level one does.
 
 The runtime wake-list registration is a transient polling subscription, not
 dependency discovery or Graph rewiring. Fanout CSR remains in the Definition

--- a/src/common/host_build_graph/graph_execution.h
+++ b/src/common/host_build_graph/graph_execution.h
@@ -28,8 +28,15 @@ static_assert(
     "an in-graph local id must fit the low field of an IN_GRAPH task id"
 );
 // A body's producers precede their consumers, so a fanin CSR row holds at most
-// task_count - 1 entries and the wake-scan cursor indexes one of them.
+// task_count - 1 entries, and both of the slot's row cursors index one of them.
+// An in-graph row has no cap of its own — unlike a GLOBAL task's inline row,
+// which append_fanin_or_fail holds to CHIP_MAX_FANIN — so this is what bounds
+// them, and a cursor too narrow for it would report a row scanned that was not.
 static_assert(MAX_IN_GRAPH_TASKS - 1 < 0xFFFF, "a fanin CSR row index must fit ChipTaskSlotState::wake_scan_cursor");
+static_assert(
+    MAX_IN_GRAPH_TASKS - 1 < 0xFFFF && CHIP_MAX_FANIN - 1 < 0xFFFF,
+    "a fanin row index from either cohort must fit ChipTaskSlotState::ed_publish_scan_cursor"
+);
 inline constexpr int32_t GRAPH_MATERIALIZE_SLICE_TASKS = 4;
 
 enum class GraphTensorSourceKind : uint8_t {
@@ -453,6 +460,14 @@ struct GraphExecution {
 
     void store_completed(int32_t index, std::memory_order order = std::memory_order_release) const {
         task_states[index].store(CHIP_TASK_COMPLETED, order);
+    }
+
+    bool is_published(int32_t index, std::memory_order order = std::memory_order_acquire) const {
+        return task_states[index].load(order) >= CHIP_TASK_PUBLISHED;
+    }
+
+    void store_published(int32_t index, std::memory_order order = std::memory_order_release) const {
+        task_states[index].store(CHIP_TASK_PUBLISHED, order);
     }
 
     void reset_task_state(int32_t index) const {

--- a/src/common/host_build_graph/host/orchestrator.cpp
+++ b/src/common/host_build_graph/host/orchestrator.cpp
@@ -2108,6 +2108,12 @@ bool graph_submit_outer(
     slot.active_mask = ActiveMask{};
     slot.task_attrs = TaskAttrs{};
     slot.total_required_subtasks = 0;
+    // A shell places no block, but this must stay positive: an early-released
+    // shell sits in EARLY_DISPATCH_STAGING, so its readiness runs through
+    // try_early_dispatch_release, which returns next_block_idx >= this. At zero
+    // that is true for a shell's never-advanced cursor, push_ready_routed
+    // returns before graph_ready_queue, and the Graph silently never activates —
+    // visible only as SIMPLER_ERROR_SCHEDULER_TIMEOUT.
     slot.logical_block_num = 1;
     slot.task_kind = TaskKind::GRAPH;
 
@@ -2167,6 +2173,32 @@ bool graph_submit_outer(
     // region, which is what makes the deferred advance safe.
     debug_assert(orch->fanin_pool_cursor == static_cast<int32_t>(payload.fanin_data() - orch->fanin_pool));
     orch->fanin_pool_cursor += CHIP_ALIGN_UP(payload.fanin_count, ARG_POOL_ALIGN / (int32_t)sizeof(int32_t));
+
+    // Early-dispatch qualification for the shell. Its fanin is an ordinary
+    // inline row of GLOBAL producers, so the rule is the top-level one, minus
+    // the terms that describe dispatching a task to cores: a shell has no
+    // predicate, no resource shape, and never occupies a core itself. What its
+    // release does instead is admit the body's roots, which is why a shell
+    // qualifies on producers alone.
+    //
+    // A GRAPH producer still disqualifies, as it does at top level: a shell
+    // publishes no placement of its own, so there is nothing for a consumer to
+    // bet on. That is the graph-as-producer direction, deliberately left out.
+    int32_t *const shell_fanin = payload.fanin_data();
+    bool shell_candidate = payload.fanin_count > 0;
+    for (int32_t i = 0; shell_candidate && i < payload.fanin_count; i++) {
+        const ChipTaskSlotState &producer = orch->sm_header->tasks.get_slot_state_by_task_id(shell_fanin[i]);
+        if (producer.task_kind == TaskKind::GRAPH || !producer.task_attrs.allow_early_resolve()) {
+            shell_candidate = false;
+        }
+    }
+    if (shell_candidate) {
+        std::sort(shell_fanin, shell_fanin + payload.fanin_count);
+        slot.ed_flags |= ED_FLAG_CANDIDATE;
+        for (int32_t i = 0; i < payload.fanin_count; i++) {
+            orch->sm_header->tasks.get_slot_state_by_task_id(shell_fanin[i]).ed_flags |= ED_FLAG_TRACKED;
+        }
+    }
 
     pending.outer_slot = &slot;
     state->pending_uploads.push_back(pending);

--- a/src/common/host_build_graph/runtime_types.h
+++ b/src/common/host_build_graph/runtime_types.h
@@ -646,8 +646,22 @@ struct alignas(64) ChipTaskSlotState {
     // The row it indexes is the payload's inline fanin region for a GLOBAL task
     // and the Definition's fanin CSR row for an IN_GRAPH one. The CSR row is
     // bounded by the in-graph task cap rather than by CHIP_MAX_FANIN, which is
-    // what makes this wider than its early-dispatch twin below.
+    // why neither cursor is a byte.
     uint16_t wake_scan_cursor{0xFFFF};
+
+    // Publish-list scan cursor of an ED candidate: the fanin-row index this
+    // task is hung on in the publish list. The row is sorted and the state byte
+    // is monotone, so indices above the cursor are known-published forever
+    // and every rescan resumes here — each row entry is loaded once per life.
+    //
+    // The row it indexes is the payload's inline fanin region for a GLOBAL task
+    // and the Definition's fanin CSR row for an IN_GRAPH one, so it is bounded
+    // by the wider of the two: append_fanin_or_fail hard-caps an inline row at
+    // CHIP_MAX_FANIN, while an in-graph row has no cap of its own and is
+    // bounded only by the body's task count. That is why this is not a byte —
+    // a truncated cursor would report a row scanned that was not, and stage a
+    // candidate whose producers have not all published.
+    uint16_t ed_publish_scan_cursor{0};
 
     // --- Set per-submit (depend on task inputs) ---
     ActiveMask active_mask;  // Bitmask of active subtask slots (set once)
@@ -664,29 +678,21 @@ struct alignas(64) ChipTaskSlotState {
     std::atomic<bool> any_subtask_deferred{false};
     TaskKind task_kind{TaskKind::KERNEL};
 
-    // Early-dispatch verdicts, decided by the host orchestrator once this task's
-    // fanin region is final (this slot is part of the host-built SM image).
-    // Plain-write on the single-threaded submit path, before the slot is
-    // scheduler-visible; the device only ever reads them.
+    // Early-dispatch verdicts. A GLOBAL task's are decided by the host
+    // orchestrator once its fanin region is final, and an IN_GRAPH task's are
+    // replayed from its Definition at materialization, which also decides
+    // whether a root is stageable. Both writers are single-owner and both
+    // precede the slot becoming schedulable, so these are plain writes; every
+    // reader past that point only loads them.
     //   ED_FLAG_CANDIDATE  every producer carries allow_early_resolve, no
     //                      dispatch predicate, dispatchable shape, fanin >= 1
     //   ED_FLAG_TRACKED    at least one candidate names this task as a producer,
     //                      so its publication state must be recorded
     uint8_t ed_flags{0};
 
-    // Publish-list scan cursor of an ED candidate: the fanin-row index this
-    // task is hung on in the publish list. The row is sorted and the state byte
-    // is monotone, so indices above the cursor are known-published forever
-    // and every rescan resumes here — each row entry is loaded once per life.
-    // Only a GLOBAL task holds a publish list, so this indexes the payload's
-    // inline fanin region alone, which append_fanin_or_fail hard-caps at
-    // CHIP_MAX_FANIN with a named fatal.
-    uint8_t ed_publish_scan_cursor{0};
-    static_assert(CHIP_MAX_FANIN <= 0xFF, "ed_publish_scan_cursor is a uint8_t fanin-row index");
-
     // Keeps the record at one cache line. Members run widest-first up to the
     // byte block above, so their sizes sum to exactly the bytes this leaves.
-    uint8_t reserved[4];
+    uint8_t reserved[3];
 
     int32_t claim_block_range(int32_t block_limit, int32_t max_count, int32_t &start) {
         int16_t current = next_block_idx.load(std::memory_order_relaxed);
@@ -755,7 +761,7 @@ static_assert(sizeof(ChipTaskSlotState) == 64);
 static_assert(
     offsetof(ChipTaskSlotState, ed_publish_list_head) == 16, "the ED publish pair sits right after its wake-list twin"
 );
-static_assert(offsetof(ChipTaskSlotState, reserved) == 60, "ChipTaskSlotState grew interior padding");
+static_assert(offsetof(ChipTaskSlotState, reserved) == 61, "ChipTaskSlotState grew interior padding");
 
 // =============================================================================
 // Per-Task Storage

--- a/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -29,6 +29,12 @@ void layer(const GraphTaskArgs &args, int variant) {
     const std::array<uint32_t, 1> shape{a.shapes[0]};
     TensorCreateInfo intermediate(shape.data(), static_cast<uint32_t>(shape.size()), DataType::FLOAT32);
 
+    // A dependency-only root. Its shape is DUMMY, which indexes no per-shape
+    // dispatch queue, so it must never be staged by the shell's early release —
+    // this body is where that is exercised on device.
+    CoreTaskArgs dummy_root_args;
+    rt_submit_dummy_task(dummy_root_args);
+
     CoreTaskArgs add_args;
     add_args.add_input(a, b);
     add_args.add_output(intermediate);
@@ -94,6 +100,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     seed_args.add_input(a);
     seed_args.add_output(seeded_input_info);
     seed_args.add_scalar(0.0F);
+    // Flagged so the Graph shells that consume its output qualify as
+    // early-dispatch candidates: a shell's release materializes its body ahead
+    // of this task's completion, which is the ordinary-task-to-Graph edge.
+    seed_args.set_allow_early_resolve(true);
     TaskOutputTensors seed_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, seed_args);
     simpler::hbg::Tensor seeded_a = seed_outputs.get_ref(0);
 

--- a/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
+++ b/tests/st/a5/host_build_graph/graph_execution/kernels/orchestration/graph_execution_orch.cpp
@@ -29,6 +29,12 @@ void layer(const GraphTaskArgs &args, int variant) {
     const std::array<uint32_t, 1> shape{a.shapes[0]};
     TensorCreateInfo intermediate(shape.data(), static_cast<uint32_t>(shape.size()), DataType::FLOAT32);
 
+    // A dependency-only root. Its shape is DUMMY, which indexes no per-shape
+    // dispatch queue, so it must never be staged by the shell's early release —
+    // this body is where that is exercised on device.
+    CoreTaskArgs dummy_root_args;
+    rt_submit_dummy_task(dummy_root_args);
+
     CoreTaskArgs add_args;
     add_args.add_input(a, b);
     add_args.add_output(intermediate);
@@ -94,6 +100,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     seed_args.add_input(a);
     seed_args.add_output(seeded_input_info);
     seed_args.add_scalar(0.0F);
+    // Flagged so the Graph shells that consume its output qualify as
+    // early-dispatch candidates: a shell's release materializes its body ahead
+    // of this task's completion, which is the ordinary-task-to-Graph edge.
+    seed_args.set_allow_early_resolve(true);
     TaskOutputTensors seed_outputs = rt_submit_aiv_task(FUNC_ADD_SCALAR, seed_args);
     simpler::hbg::Tensor seeded_a = seed_outputs.get_ref(0);
 

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -54,8 +54,20 @@ GraphTensor make_test_tensor(uint64_t address) {
     return tensor;
 }
 
-std::vector<std::byte>
-make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t boundary_scalar_count = 1) {
+// What task 0 — this body's only root — is shaped like. Materialization decides
+// a root's staging verdict from the root itself, so each variant is one term of
+// that decision.
+enum class TestRoot { ORDINARY, PREDICATED, DUMMY };
+
+// Ways an image can carry ED_FLAG_CANDIDATE without the conjunction the recorder
+// decides it by. graph_fill_definition produces none of these; bind_graph_topology
+// is what has to say so.
+enum class TestEdDefect { NONE, CANDIDATE_ON_ROOT, CANDIDATE_WITH_PREDICATE, CANDIDATE_ON_DUMMY };
+
+std::vector<std::byte> make_test_definition(
+    uint64_t graph_key, uint64_t boundary_address, uint32_t boundary_scalar_count = 1,
+    TestRoot root_variant = TestRoot::ORDINARY, TestEdDefect ed_defect = TestEdDefect::NONE
+) {
     std::vector<std::byte> image(sizeof(GraphDefinition));
 
     std::vector<int32_t> fanin_offsets{0, 0, 1};
@@ -81,6 +93,52 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     tasks[1].dump_metadata.scalar_dtypes[0] = static_cast<uint8_t>(DataType::INT32);
     tasks[1].tensor_offset = 1;
     tasks[1].scalar_offset = 1;
+    std::vector<GraphPredicate> predicates;
+    if (root_variant == TestRoot::PREDICATED) {
+        // The attribute bit and the one-based slot are written together; a
+        // Definition where they disagree is rejected before the verdict is read.
+        TaskAttrs root_attrs{};
+        root_attrs.set_predicate();
+        tasks[0].task_attrs = root_attrs.raw();
+        tasks[0].predicate_slot = 1;
+        GraphPredicate predicate{};
+        predicate.operand = make_test_tensor(boundary_address);
+        predicate.operand_source.source_kind = static_cast<uint8_t>(GraphTensorSourceKind::BOUNDARY_EXACT);
+        predicate.elem_size = static_cast<uint8_t>(get_element_size(DataType::FLOAT32));
+        predicate.op = static_cast<uint8_t>(PredicateOp::EQ);
+        predicates.push_back(predicate);
+    } else if (root_variant == TestRoot::DUMMY) {
+        // A dependency-only task: no core mask, and therefore no subtask to
+        // require and no kernel on any slot — bind_graph_topology pairs each
+        // mask bit with its slot's kernel id. active_mask is what
+        // ChipTaskSlotState::task_kind is read from.
+        tasks[0].active_mask = 0;
+        tasks[0].total_required_subtasks = 0;
+        std::fill(std::begin(tasks[0].kernel_id), std::end(tasks[0].kernel_id), INVALID_KERNEL_ID);
+    }
+    // Task 0 is this body's root (empty CSR row); task 1 has one producer.
+    if (ed_defect == TestEdDefect::CANDIDATE_ON_ROOT) {
+        tasks[0].ed_flags |= ED_FLAG_CANDIDATE;
+    } else if (ed_defect == TestEdDefect::CANDIDATE_WITH_PREDICATE) {
+        tasks[1].ed_flags |= ED_FLAG_CANDIDATE;
+        TaskAttrs attrs{};
+        attrs.set_predicate();
+        tasks[1].task_attrs = attrs.raw();
+        tasks[1].predicate_slot = static_cast<uint16_t>(predicates.size() + 1);
+        GraphPredicate predicate{};
+        predicate.operand = make_test_tensor(boundary_address);
+        predicate.operand_source.source_kind = static_cast<uint8_t>(GraphTensorSourceKind::BOUNDARY_EXACT);
+        predicate.elem_size = static_cast<uint8_t>(get_element_size(DataType::FLOAT32));
+        predicate.op = static_cast<uint8_t>(PredicateOp::EQ);
+        predicates.push_back(predicate);
+    } else if (ed_defect == TestEdDefect::CANDIDATE_ON_DUMMY) {
+        // Cleared kernel ids keep the mask/kernel pairing check from rejecting
+        // this image first, so only the flag conjunction can.
+        tasks[1].ed_flags |= ED_FLAG_CANDIDATE;
+        tasks[1].active_mask = 0;
+        tasks[1].total_required_subtasks = 0;
+        std::fill(std::begin(tasks[1].kernel_id), std::end(tasks[1].kernel_id), INVALID_KERNEL_ID);
+    }
     std::vector<GraphTensor> tensors{make_test_tensor(boundary_address), make_test_tensor(boundary_address)};
     tensors[1].buffer_size = 32;
     std::vector<GraphTensorSourceRef> tensor_sources(2);
@@ -114,6 +172,10 @@ make_test_definition(uint64_t graph_key, uint64_t boundary_address, uint32_t bou
     definition.off_tensor_sources = append_section(image, tensor_sources);
     definition.off_scalars = append_section(image, scalars);
     definition.off_scalar_inheritance = append_section(image, scalar_inheritance);
+    if (!predicates.empty()) {
+        definition.predicate_count = static_cast<uint32_t>(predicates.size());
+        definition.off_predicates = append_section(image, predicates);
+    }
     size_t execution_storage_bytes = 0;
     graph_execution_storage_bytes(
         definition.task_count, definition.tensor_arg_count, definition.scalar_arg_count, &execution_storage_bytes
@@ -553,11 +615,20 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     ChipTaskSlotState &outer_slot = outer.slot;
     outer_slot.task_kind = TaskKind::GRAPH;
     outer_slot.graph_context = execution;
+    // Only a shell the host qualified can stage its body's roots, so this is
+    // what makes the root verdict below reachable at all.
+    outer_slot.ed_flags = ED_FLAG_CANDIDATE;
 
     // The execution and in-graph task storage both occupy the outer heap tail after
     // required_heap.
     EXPECT_EQ(static_cast<void *>(execution), heap.execution());
     EXPECT_EQ(graph_execution_materialize_slice(outer_slot, *execution, 2), GraphMaterializeResult::PREPARED);
+    // A shell released early stages its body's roots, and materialization is what
+    // decides which roots it may stage. Task 0 is this body's root and is an
+    // ordinary dispatchable task, so it qualifies; task 1 has a producer, so its
+    // verdict is the recorded one instead, which this Definition leaves clear.
+    EXPECT_NE(execution->task_at(0).slot.ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_EQ(execution->task_at(1).slot.ed_flags & ED_FLAG_CANDIDATE, 0);
     ChipTaskStorage &storage = execution->task_at(0);
     ASSERT_EQ(storage.payload.scalar_count, 1);
     ASSERT_EQ(storage.payload.tensor_count, 1);
@@ -601,6 +672,95 @@ TEST(GraphExecutionReplay, ResubmissionRebuildsFromDefinition) {
     EXPECT_EQ(storage.slot.completed_subtasks.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(storage.payload.published_block_count.load(std::memory_order_relaxed), 0);
     EXPECT_EQ(storage.payload.dump_metadata.dump_arg_mask, uint64_t{1} << 0);
+}
+
+// Each term that withholds ED_FLAG_CANDIDATE from a body root, one per case.
+// ResubmissionRebuildsFromDefinition covers the conjunction's true side; these
+// are the three ways it comes out false, and each is load-bearing: a shell the
+// host did not qualify never stages anything, a predicated task must reach the
+// predicate test an early release returns before, and a DUMMY task has no
+// dispatchable shape to index a per-shape early-dispatch queue with.
+TEST(GraphExecutionReplay, RootStagingVerdictWithholdsCandidate) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
+
+    struct Case {
+        const char *name;
+        TestRoot root_variant;
+        uint8_t shell_ed_flags;
+    };
+    const Case cases[] = {
+        {"shell the host did not qualify", TestRoot::ORDINARY, 0},
+        {"predicated root", TestRoot::PREDICATED, ED_FLAG_CANDIDATE},
+        {"dummy root", TestRoot::DUMMY, ED_FLAG_CANDIDATE},
+    };
+
+    for (const Case &test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        std::array<uint8_t, 64> boundary{};
+        const std::vector<std::byte> definition = make_test_definition(
+            GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 1, test_case.root_variant
+        );
+        const TestDefinitionObject definition_object(definition);
+        OuterHeap heap(definition, 0xAA);
+        GraphExecution *execution =
+            heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17);
+        ASSERT_NE(execution, nullptr);
+
+        ChipTaskStorage outer{};
+        outer.task.task_id = TaskId::make_global(7);
+        outer.task.packed_buffer_base = heap.base();
+        outer.task.packed_buffer_end = heap.end();
+        outer.slot.task_kind = TaskKind::GRAPH;
+        outer.slot.graph_context = execution;
+        outer.slot.ed_flags = test_case.shell_ed_flags;
+
+        ASSERT_EQ(graph_execution_materialize_slice(outer.slot, *execution, 2), GraphMaterializeResult::PREPARED);
+        EXPECT_EQ(execution->task_at(0).slot.ed_flags & ED_FLAG_CANDIDATE, 0);
+    }
+}
+
+// ED_FLAG_CANDIDATE stopped being inert once materialization began replaying it
+// onto a slot, so the image reader has to hold the conjunction that decides it
+// rather than only rejecting unknown bits. None of these images is one
+// graph_fill_definition can produce; each would otherwise reach dispatch, and
+// the DUMMY one would index early_dispatch_queues[] one past its last shape.
+TEST(GraphExecutionReplay, RejectsCandidateFlagWithoutItsConjunction) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
+
+    struct Case {
+        const char *name;
+        TestEdDefect defect;
+    };
+    const Case cases[] = {
+        {"candidate with no producer", TestEdDefect::CANDIDATE_ON_ROOT},
+        {"candidate carrying a predicate", TestEdDefect::CANDIDATE_WITH_PREDICATE},
+        {"candidate with no dispatchable shape", TestEdDefect::CANDIDATE_ON_DUMMY},
+    };
+
+    for (const Case &test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        std::array<uint8_t, 64> boundary{};
+        const std::vector<std::byte> definition = make_test_definition(
+            GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()), 1, TestRoot::ORDINARY, test_case.defect
+        );
+        const TestDefinitionObject definition_object(definition);
+        OuterHeap heap(definition, 0xAA);
+        EXPECT_EQ(
+            heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr
+        );
+    }
+}
+
+// The same builder without a defect must still localize, so the test above
+// rejects on the flag conjunction and not on something it broke in passing.
+TEST(GraphExecutionReplay, AcceptsTheSameImageWithoutTheDefect) {
+    constexpr uint64_t GRAPH_KEY_VALUE = 0x1234;
+    std::array<uint8_t, 64> boundary{};
+    const std::vector<std::byte> definition =
+        make_test_definition(GRAPH_KEY_VALUE, reinterpret_cast<uint64_t>(boundary.data()));
+    const TestDefinitionObject definition_object(definition);
+    OuterHeap heap(definition, 0xAA);
+    EXPECT_NE(heap.initialize_execution(definition_object, reinterpret_cast<uint64_t>(boundary.data()), 17), nullptr);
 }
 
 // The boundary scalar pool is bounded by the Graph boundary contract

--- a/tests/ut/cpp/common/test_hbg_graph_ed_qualification.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_ed_qualification.cpp
@@ -154,6 +154,33 @@ protected:
         return out.task_id();
     }
 
+    // One top-level task writing the boundary the body reads, so a shell
+    // submitted for that body names it as a producer. `flagged` sets
+    // allow_early_resolve, the term the shell's conjunction turns on.
+    TaskId submit_boundary_producer(const simpler::hbg::Tensor &boundary, bool flagged) {
+        CoreTaskArgs args;
+        args.add_output(boundary);
+        args.set_allow_early_resolve(flagged);
+        MixedKernels mixed{};
+        mixed.aiv0_kernel_id = 0;
+        TaskOutputTensors out = orch.submit_task(mixed, args);
+        EXPECT_TRUE(out.task_id().is_valid());
+        return out.task_id();
+    }
+
+    // Replays a recorded body by its key. The cache hit is what submits the
+    // outer shell, which is where the shell's own verdict is decided.
+    TaskId submit_shell(uint64_t key, GraphTaskArgs &boundary_args) {
+        const GraphScopeResult replay = orch.graph_begin(key, boundary_args, 0);
+        EXPECT_FALSE(replay.recording) << "the body is already recorded, so this must be a cache hit";
+        EXPECT_TRUE(replay.task_id.is_valid());
+        return replay.task_id;
+    }
+
+    const ChipTaskSlotState &slot_of(TaskId id) {
+        return orch.sm_header->tasks.get_slot_state_by_task_id(id.local_id());
+    }
+
     const GraphDefinition *published_definition() {
         const GraphHostDefinitionList published = graph_host_definitions(*graph_state);
         EXPECT_EQ(published.entries.size(), 1u);
@@ -263,6 +290,41 @@ TEST_F(HbgGraphEdQualificationTest, HiddenAllocProducerDoesNotDisqualifyItsConsu
     EXPECT_NE(tasks[1].ed_flags & ED_FLAG_TRACKED, 0);
 }
 
+// The outer shell's own verdict, decided per submit against its inline row of
+// GLOBAL producers rather than against the body's CSR. A shell occupies no core,
+// so its conjunction is the top-level one minus the dispatch-shape terms: it
+// qualifies on producers alone. What its release does instead is admit the
+// body's roots, which is why the verdict below is also what decides whether
+// materialization may flag any of them.
+TEST_F(HbgGraphEdQualificationTest, FlaggedProducerMakesTheShellACandidate) {
+    GraphTaskArgs boundary_args;
+    const simpler::hbg::Tensor boundary = begin_body(0x6ED0B001, boundary_args);
+    record_task(boundary, /*flagged=*/true);
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+
+    const TaskId producer = submit_boundary_producer(boundary, /*flagged=*/true);
+    const TaskId shell = submit_shell(0x6ED0B001, boundary_args);
+
+    EXPECT_EQ(slot_of(shell).task_kind, TaskKind::GRAPH);
+    EXPECT_NE(slot_of(shell).ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_NE(slot_of(producer).ed_flags & ED_FLAG_TRACKED, 0);
+}
+
+TEST_F(HbgGraphEdQualificationTest, OneUnflaggedProducerDisqualifiesTheShell) {
+    GraphTaskArgs boundary_args;
+    const simpler::hbg::Tensor boundary = begin_body(0x6ED0B002, boundary_args);
+    record_task(boundary, /*flagged=*/true);
+    ASSERT_TRUE(orch.graph_end());
+    orch.graph_commit();
+
+    const TaskId producer = submit_boundary_producer(boundary, /*flagged=*/false);
+    const TaskId shell = submit_shell(0x6ED0B002, boundary_args);
+
+    EXPECT_EQ(slot_of(shell).ed_flags & ED_FLAG_CANDIDATE, 0);
+    EXPECT_EQ(slot_of(producer).ed_flags & ED_FLAG_TRACKED, 0);
+}
+
 // The device side of a body's fanin CSR row. The scheduler reads only the CSR
 // pair and the slots it indexes, so a topology can be stated directly here
 // rather than materialized from a Definition.
@@ -329,6 +391,46 @@ protected:
         return popped == 1 ? out : nullptr;
     }
 };
+
+// A wide in-graph row exceeds what a byte cursor can index. The scan must
+// report the row unfinished until every producer has published: a truncated
+// cursor would wrap to a low index, find that one entry published, and stage a
+// candidate whose remaining producers have not.
+TEST_F(HbgGraphWakeScanTest, WideRowCursorDoesNotTruncate) {
+    constexpr int32_t kProducers = 300;  // > 0xFF, the old cursor width
+    std::vector<std::vector<uint16_t>> rows(kProducers);
+    std::vector<uint16_t> consumer_row;
+    consumer_row.reserve(kProducers);
+    for (int32_t i = 0; i < kProducers; ++i)
+        consumer_row.push_back(static_cast<uint16_t>(i));
+    rows.push_back(consumer_row);
+    build(rows);
+
+    ChipTaskSlotState &consumer = slot(kProducers);
+    consumer.ed_flags |= ED_FLAG_CANDIDATE;
+    for (int32_t i = 0; i < kProducers; ++i)
+        slot(i).ed_flags |= ED_FLAG_TRACKED;
+
+    // Intake hangs it on the row's tail, and the cursor must name that entry
+    // rather than a wrapped one.
+    ASSERT_FALSE(sched.register_on_ed_publish_list(consumer));
+    EXPECT_EQ(consumer.ed_publish_scan_cursor, kProducers - 1);
+
+    // Publishing every producer but the first leaves the row unfinished.
+    for (int32_t i = kProducers - 1; i > 0; --i) {
+        execution.store_published(i);
+        sched.seal_ed_publish_list(slot(i));
+    }
+    ChipTaskSlotState *detached = nullptr;
+    while (sched.ed_publish_drain_queue.pop_batch(&detached, 1) == 1) {
+        if (sched.advance_ed_publish_scan(*detached)) FAIL() << "staged while producer 0 is unpublished";
+    }
+
+    execution.store_published(0);
+    sched.seal_ed_publish_list(slot(0));
+    ASSERT_EQ(sched.ed_publish_drain_queue.pop_batch(&detached, 1), 1);
+    EXPECT_TRUE(sched.advance_ed_publish_scan(*detached));
+}
 
 // Each classification resumes where the last one hung and never re-walks the
 // row's completed tail. Completion is monotone, so the resume reaches the same


### PR DESCRIPTION
Early dispatch reached only top-level tasks. This extends it to a Graph body's internal edges and to the edge from an ordinary task into a Graph. One direction is deliberately left out: a Graph as a *producer*, since a shell publishes no placement of its own for a consumer to bet on — that needs a definition of "shell published" and belongs in its own change.

This is the payoff step for the three prerequisites that preceded it (#2130, #2144, #2159); it adds no new mechanism.

## In-graph to in-graph

The publish chain #2095 built is reused rather than forked. The behaviour is unchanged: a candidate hangs on its deepest unpublished producer, a producer that places its last logical block seals the chain, detached waiters rescan and pre-stage.

The two cohorts differed only in **where the fanin row lives** and **where the states do**, and both were already made to match — the row by #2144's sorted CSR, the states by #2159's per-execution array. So three call sites take a cohort and everything else is shared. `in_graph_execution_of` names that cohort once; it returns null for a GLOBAL task and for a GRAPH shell, which is a task of the run despite carrying a `graph_context` — the same pair `complete_task` already routes on.

Registration happens at materialization, where a body's tasks are already walked to hang each non-root on its first unmet producer. That point is single-owner per graph (the prepare-queue slot), so no peer can register the same task — a stronger guarantee than the top-level intake has. The completion path seals a tracked in-graph producer for the reason the global one does: `COMPLETED >= PUBLISHED`, so a producer that never publishes (a DUMMY, or one a predicate retired) still releases its waiters.

Materialization also copies the Definition's `ed_flags` onto the slot. #2144 recorded those verdicts and left them inert — validated but propagated nowhere; this is the line that consumes them.

## Ordinary task into a Graph

A shell qualifies by the top-level rule minus the terms that describe dispatching to cores, since it has no predicate, no shape, and occupies no core: its producers alone decide it. What its release does is stage the body's **roots**, each an ordinary AICore task with its own mask and blocks, gated exactly like any pre-staged task. They ring on the ordinary route: the shell's producers complete, `push_ready_routed` hands the shell to `graph_ready_queue`, and `activate_graph_task` opens the external gate `graph_route_ready_roots` reads. So the dependency the shell stands for is still honoured — **the producers' PUBLISHED buys the roots' placement; only their COMPLETED launches them**. The shell's own completion is a later and unrelated event: the body retiring.

Two things worth review attention here:

- **A root carries no host verdict.** Qualification needs a producer to bet on and a root has none inside the body, so materialization sets `ED_FLAG_CANDIDATE` on it. `push_ready_routed` reads that flag as "this task may hold a staging claim, so check for a release", which is true of a root from that point on. Without it a staged root is gated and never rung — I hit exactly that, and the run ends in `SIMPLER_ERROR_SCHEDULER_TIMEOUT` rather than anything that names the cause. The verdict is three terms, none of them the recorded conjunction: the shell must itself be a candidate, since `stage_graph_roots_early` is the only thing that can stage a root and it runs only on a shell release — without this term every root under a non-ED Graph pays a `seq_cst` CAS per route for a claim it can never hold; and the root must be neither DUMMY (no dispatchable shape to index a per-shape queue with) nor predicated (an early release returns before the predicate test). Deciding all three at materialization rather than at staging time is what keeps them off a slot a reader can already see.
- **`route_cursor` is untouched.** Staging is not routing; the ordinary route must still run, because that is what rings.

An earlier attempt had the shell call `prepare_graph_task` instead, on the theory that early release buys earlier materialization. It does not: intake pushes every shell onto the prepare queue as it is classified, and that path never waited on the shell's producers, so materialization was already running early. That version also dragged `graph_execution_materialize_slice` into the link line of unit tests that do not build it.

## Testing

- [x] C++ unit tests 140/140. `RejectsCandidateFlagWithoutItsConjunction` pins the image check below, mutation-verified: with the check removed all three malformed images localize. Plus five assertions for the two host/device verdicts this PR introduces: `RootStagingVerdictWithholdsCandidate` covers each way a root fails to qualify (non-candidate shell, predicated root, DUMMY root), and `FlaggedProducerMakesTheShellACandidate` / `OneUnflaggedProducerDisqualifiesTheShell` cover the shell's own conjunction through a real `graph_submit_outer`.
- [x] a2a3 `host_build_graph` sim 12 passed / 7 skipped; a5 13 passed
- [x] Both paths verified as actually firing, not merely compiling. Temporary probes on the a2a3 sim `graph_execution` case showed the in-graph candidate registering, both its producers publishing and sealing, and the shell staging its root — the full chain, three times over the case's three layers.
- [x] Hardware A/B on a2a3 device 4, `host_build_graph`, 100 rounds trimmed to 80. One discarded warm-up arm, then base/head interleaved twice. `qwen3_14b_decode` — the only case with a Graph body — improves and is the only case whose sign agrees across both repetitions on both metrics: device **-0.68% / -1.23%**, host **-0.78% / -1.60%**. Every other case sits inside +-0.6% on device with mixed signs, except `batch_paged_attention` at a sign-consistent **+0.32% / +0.33%**, which is the shared-path cost of the cohort test and is smaller than the +0.7% the pre-review revision measured.

The `graph_execution` scene tests flag the seed task feeding the Graph shells and carry a dependency-only root, so onboard CI exercises the ordinary-to-Graph edge and the DUMMY-root exclusion rather than only the sim.

## Image validation

`ED_FLAG_CANDIDATE` was inert until this PR: #2144 recorded the verdicts and nothing propagated them, so `bind_graph_topology` only had to reject unknown bits. Materialization now replays the flag onto a slot and it steers dispatch, so the reader holds the whole conjunction the recorder decides it by — a candidate must have a producer, a dispatchable shape and no predicate.

The exit this closes is not the root path: `stage_graph_roots_early` requires an empty CSR row and a recorded candidate always has `fanin_count > 0`, so that one was already shut. It is the **non-root** path. A malformed image with `ED_FLAG_CANDIDATE` on a DUMMY non-root reaches `early_dispatch_queues[active_mask.to_shape()]` with `ResourceShape::DUMMY == 3` against `early_dispatch_queues[NUM_RESOURCE_SHAPES == 3]` — one past the end. The predicated variant is a correctness bug rather than a memory one: an early release returns before the predicate is tested.

`graph_fill_definition` is the only writer of this field and holds all three terms, so the check can only reject images it cannot produce.

## Known gap

An in-graph `sync_start` root now reaches the early-dispatch sync-start drain queue, and the only scene test on that path is top level. Tracked as #2184 — it wants a pass over how `sync_start` is scoped under hbg, not one more scene test bolted onto the existing shape.


