### PR TITLE
Support: adopt shared documentation theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,10 +22,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Read shared theme revision
+        id: theme
+        shell: bash
+        run: |
+          theme_revision=$(cat docs/theme-revision.txt)
+          if [[ ! "$theme_revision" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::docs/theme-revision.txt must contain a full Git commit SHA"
+            exit 1
+          fi
+          printf 'revision=%s\n' "$theme_revision" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout shared documentation theme
+        uses: actions/checkout@v4
+        with:
+          repository: hw-native-sys/hw-native-sys.github.io
+          ref: ${{ steps.theme.outputs.revision }}
+          path: .site-theme
+          persist-credentials: false
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: pip
+          cache-dependency-path: |
+            docs/requirements.txt
+            .site-theme/docs-theme/constraints.txt
 
       # Deliberately not `pip install .`: that runs scikit-build-core and builds
       # the C++ runtime. mkdocstrings reads `python/simpler` through griffe, which

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ profiling_logs_*/
 # mkdocs build output
 _site/
 site/
+.site-theme/

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ The top-level [README](../README.md) links only the handful of entry-point docs;
 this page is the complete map.
 
 These pages are also published as a searchable site at
-<https://hw-native-sys.github.io/simpler/>, which adds a generated API reference
+<https://www.pypto.ai/simpler/>, which adds a generated API reference
 for `simpler.worker`, `simpler.task_interface` and `simpler.orchestrator`. The
 site is built by `.github/workflows/docs.yml`; `mkdocs.yml` owns its navigation,
 so a new page needs a `nav` entry there as well as a row here.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,8 @@
 # the C++ runtime, which the docs build does not need. mkdocstrings reads
 # `python/simpler` through griffe, which parses the source statically — nothing
 # is imported, so no CANN toolkit and no built extension are required.
+-c ../.site-theme/docs-theme/constraints.txt
+
 mkdocs>=1.6
 mkdocs-material>=9.5
 mkdocstrings[python]>=0.26

--- a/docs/theme-revision.txt
+++ b/docs/theme-revision.txt
@@ -1,0 +1,1 @@
+318b8a9edcd447ae73cd5ad8e3eaf73b9bc0738e

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -4,7 +4,7 @@ The surface you write against, hand-maintained: what `**config` keys `Worker`
 accepts, `CallConfig` defaults, and the argument-order footguns a generator
 cannot state. For the complete generated listing of every public symbol and
 signature, see the API pages on the
-[documentation site](https://hw-native-sys.github.io/simpler/user/reference/api/worker/).
+[documentation site](https://www.pypto.ai/simpler/user/reference/api/worker/).
 Treat the source as authoritative when the two disagree, and fix this page in the
 same change.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
+INHERIT: .site-theme/docs-theme/base.yml
+
 site_name: simpler
 site_description: "Simple Runtime — make writing runtime simpler"
-site_url: https://hw-native-sys.github.io/simpler/
+site_url: https://www.pypto.ai/simpler/
 repo_url: https://github.com/hw-native-sys/simpler
 repo_name: hw-native-sys/simpler
 edit_uri: edit/main/docs/
@@ -10,22 +12,27 @@ docs_dir: docs
 exclude_docs: |
   _hooks/
   requirements.txt
+  theme-revision.txt
 
 theme:
-  name: material
+  custom_dir: .site-theme/docs-theme/overrides
+  language: en
   features:
     - navigation.instant
     - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.indexes
     - navigation.top
+    - navigation.footer
+    - content.action.edit
     - content.code.copy
     - search.suggest
-  palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      toggle: { icon: material/weather-night, name: Switch to dark mode }
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      toggle: { icon: material/weather-sunny, name: Switch to light mode }
+    - search.highlight
+    - toc.follow
+
+extra:
+  pypto_project: simpler
 
 # A page absent from nav builds fine by default and only shows up as an INFO
 # line, so it silently disappears from the site's navigation. Promote it to a


### PR DESCRIPTION
The Simpler documentation uses the shared PyPTO header, project switcher,
colors, and page layout at https://www.pypto.ai/simpler/. Existing navigation,
instant page transitions, generated API pages, and strict link checks remain
available.

The docs workflow checks out the shared theme at the full revision recorded
in `docs/theme-revision.txt` and installs its tested MkDocs/Material versions.
The pinned revision is merged in the shared website repository.

Validation: strict documentation build (113 HTML pages), generated-page
checks for shared assets and canonical URLs, and all applicable repository
pre-commit hooks passed.

Browser validation also passed for the home and generated API pages at
1440, 768, 390, and 320 pixels, including instant navigation, theme controls,
mobile menus, API heading links, and code copying.
