### PR TITLE
Support: refine A5 HBG scheduler swimlane phases

### DIFF
--- a/docs/dfx/chip-swimlane-profiling.md
+++ b/docs/dfx/chip-swimlane-profiling.md
@@ -77,6 +77,13 @@ that loads directly in Perfetto. For the scheduler-overhead deep-dive, capture
   emit them (PR #1079's Scan/Poll debug overlay was removed;
   Fanout was renamed Resolve and now also filters out <1 µs walks;
   Prestage was renamed EarlyDispatch).
+  A5 `host_build_graph` uses the AICore Scheduler as the producer and emits one
+  flat lane per Scheduler. Its task-processing phases are `complete`,
+  `resolve`, `state_probe`, and exactly one of `dispatch`, `worksteal`, or
+  `refill`; the converter displays them as Completion, Resolve, StateProbe,
+  Dispatch, Worksteal, and Refill. Bootstrap ends before the initial task
+  dispatch, and its dependency initialization is not emitted again as a nested
+  `fanin` phase.
 - **Orchestrator submit envelope** — one record per `submit_task()`
   / `alloc_tensors()` call covering the whole submit's
   `[start, end]` window (`orch_submit` phase). Per-sub-step
@@ -244,6 +251,26 @@ layers to be aware of:**
     "records": [[...], ...]
   },
 
+  // A5 HBG AICPU control-plane records (level >= 2 only), one per
+  // participating AICPU thread. Every phase is an explicit start/end pair.
+  "aicpu_lifecycle_records": [{
+    "aicpu_thread_id": <int>,
+    "handshake_start_cycles": <int>,
+    "handshake_complete_cycles": <int>,
+    "config_start_cycles": <int>,
+    "topology_complete_cycles": <int>,
+    "context_publish_start_cycles": <int>,
+    "context_publish_complete_cycles": <int>,
+    "bootstrap_wait_start_cycles": <int>,
+    "bootstrap_complete_cycles": <int>,
+    "register_release_start_cycles": <int>,
+    "register_release_end_cycles": <int>,
+    "exit_signal_start_cycles": <int>,
+    "exit_signal_end_cycles": <int>,
+    "exit_wait_start_cycles": <int>,
+    "exit_wait_end_cycles": <int>
+  }],
+
   // Producer-neutral per-Scheduler streams (level >= 3 only).
   "scheduler_records": {
     "schema_version": 1,
@@ -307,7 +334,7 @@ Phase records (per Scheduler stream, level >= 3 in raw
 | `phase` | Lowercase phase name. Scheduler: see the table below. Orchestrator: `orch_submit` — one record per `submit_task()` / `alloc_tensors()` call spanning its full `[start, end]` window. Legacy per-sub-step strings (`orch_sync` / `orch_alloc` / `orch_params` / `orch_lookup` / `orch_insert` / `orch_fanin`) may appear in old captures. |
 | `loop_iter` (scheduler) / `submit_idx` (orchestrator) | Iteration / submit-call counter for the producing thread |
 | `tasks_processed` (scheduler) | Number of tasks or blocks handled by the phase; `dummy_task` and `predicated_skip` record one task |
-| `task_id` | Full runtime task id on orchestrator records and scheduler `dummy_task` / `predicated_skip` records |
+| `task_id` | Full runtime task id on orchestrator records, A5 HBG AICore Scheduler task phases, and scheduler `dummy_task` / `predicated_skip` records |
 | `pop_hit` / `pop_miss` (dispatch only) | Ready-queue pop deltas since the previous dispatch emit |
 
 The raw scheduler record has a phase-tagged union: `dispatch` stores
@@ -320,15 +347,19 @@ field but render differently in Perfetto:
 
 | Phase | Role | Lane | `tasks_processed` semantic |
 | ----- | ---- | ---- | -------------------------- |
-| `complete` | outer | sched (pid=2) | FIN'd subtasks + sub-block retires this iter |
+| `bootstrap` | A5 HBG AICore outer | AICore Scheduler lane | initial executable tasks classified and published before normal scheduling |
+| `complete` | outer | sched (pid=2) | FIN'd subtasks + sub-block retires this iter; A5 HBG ends this phase before dependency resolution |
 | `async_poll` | outer | sched | async-wait completions resolved; zero means polling consumed CPU without completing work |
 | `dispatch` | outer | sched | subtasks published this iter |
+| `state_probe` | A5 HBG AICore outer | AICore Scheduler lane | Cluster Slot / Ready state checked, a Ready task acquired, and immediate or deferred placement decided |
+| `worksteal` | A5 HBG AICore outer | AICore Scheduler lane | a task acquired from another non-empty Inbox is published |
+| `refill` | A5 HBG AICore outer | AICore Scheduler lane | completed Slot reused for one replacement task |
 | `release` | outer | sched | deferred-release slots drained this iter |
 | `dummy` | outer | sched | `dummy_ready_queue` entries handled this iter (explicit dummies and false-predicate tasks) |
 | `early_dispatch` | outer | sched | blocks staged by speculative early-dispatch this pass |
 | `drain` | outer | sched | blocks staged by this thread's global sync-start drain pass |
 | `graph_prepare` | outer | sched | Graph Definition nodes expanded this pass |
-| `resolve` | inner (TMR) | TMR sched sub-lane | consumers visited in `on_task_complete` |
+| `resolve` | inner (TMR); A5 HBG AICore outer | TMR sched sub-lane or AICore Scheduler lane | consumers visited after completion |
 | `resolve_standalone` | P-thread outer (HBG); rendered as `resolve` | HBG P sched lane | completed SPSC slots |
 | `drain_prepare` | inner | sched, nested in `drain` | subtasks prepared for global sync-start publication |
 | `drain_publish` | inner | sched, nested in `drain` | subtasks published during global sync-start staging |
@@ -349,6 +380,29 @@ lane. In `host_build_graph`, standalone `resolve` stays beside `async_poll` and
 Separate-lane phases are routed to a different lane by the converter
 (Worker View AICPU_N), so they never overlap visually with the sched lane
 bars even when their timestamps fall inside an outer span.
+
+For the A5 HBG AICore producer, all phases render on the single
+`Scheduler_<physical-AIV-ID>` lane. Completion, Resolve, StateProbe, and the
+selected publication phase are mutually time-exclusive. StateProbe includes
+Ready claim or steal and ends when immediate or deferred placement has been
+decided. Deferred waiting is intentionally left as an empty interval before
+the eventual Dispatch, Worksteal, or Refill. Worksteal identifies a task whose
+Ready source was another Inbox when its publication mode is not Refill; a
+completed Slot reused for a replacement task remains Refill regardless of its
+Ready source. The steal operation itself is included in StateProbe. The older
+`fanin`, `ready_claim`, `ready_steal`, and `direct_refill` records remain
+accepted only for existing captures.
+
+Task-bound A5 HBG Scheduler bars use the runtime task identity in their label,
+for example `StateProbe(t23)` and `Dispatch(t23)`. Bootstrap and Idle have no
+task identity and use the phase name alone; `tasks_processed` remains available
+in the event arguments.
+
+A5 HBG AICPU lifecycle records and lanes are indexed by AICPU thread, not by
+the AIC/AIV workers managed by that thread. Parallel handshake, context
+publication, register release, and shutdown spans are recorded on each thread;
+leader-only topology configuration is emitted only on thread 0. Bootstrap wait
+covers each thread's synchronization before the common register release.
 
 On the HBG P thread, consecutive empty async-wait polls are compacted into one
 `async_poll(0)` record. Its duration is the exact sum of time spent inside the
@@ -531,6 +585,14 @@ same lane structure — the directory form repeats it once per Rank under the
   appears on an adjacent `Sched_N` sub-lane; HBG's standalone `resolve` stays
   on the P thread's first lane. `drain_prepare` and `drain_publish` nest within
   `drain`.
+  A5 HBG AICore Scheduler streams instead use one named `Scheduler_N` lane;
+  their Resolve and all dispatch variants remain on that lane. Task-bound bars
+  use labels such as `StateProbe(t23)`; taskless Bootstrap and Idle bars use
+  only the phase name.
+- **AICPU Lifecycle** (pid=6) — one lane per participating AICPU thread,
+  containing its handshake, context publication, bootstrap synchronization,
+  register release, and shutdown intervals. Topology configuration appears
+  only on the leader thread.
 - **Scheduler View** (pid=3) — task-execution overlay using Scheduler
   dispatch/finish timestamps (level >= 2), with the same labels
   as Worker View.

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -359,7 +359,7 @@ Emitted in six parts:
 - **Part 1: Overhead verdict** — per-engine overhead (idle T-core *and* a ready, undispatched T-task, MIX-aware) + system `all_overhead` / `has_overhead`, all as % of makespan. An engine with no ready work is not overhead (dependency-mandated idle, not waste).
 - **Part 2: aicore switch** — the pre-dispatched pickup gap (`dispatch < prev_end`), reported **per core** (min/mean/max, ~0.8 µs each), the overhead-vs-independent split, and the makespan switch bound `[min over cores, sum of per-engine minima]`.
 - **Part 3 / 4: Head / Tail OH distributions** — P10–P99 + mean + total (per-task pickup and detect-latency magnitude).
-- **Part 5: Scheduler phase breakdown** — Level >= 3 reports the producer's phases. AICPU includes per-thread loop, queue-pop, fanout/fanin, and tail-vs-loop metrics; AICore reports its bootstrap/fanin/ready/dispatch/complete/refill/resolve/idle phase totals without applying AICPU-only queue formulas. At Level 2 this section is explicitly marked unavailable while Parts 1–4 and 6 remain available.
+- **Part 5: Scheduler phase breakdown** — Level >= 3 reports the producer's phases. AICPU includes per-thread loop, queue-pop, fanout/fanin, and tail-vs-loop metrics; AICore reports its flat bootstrap, completion, resolve, StateProbe, dispatch/worksteal/refill, and idle phase totals without applying AICPU-only queue formulas. Deferred waiting is left as an empty interval between StateProbe and publication. At Level 2 this section is explicitly marked unavailable while Parts 1–4 and 6 remain available.
 - **Part 6: Critical-path latency attribution** — along the makespan path, scheduler-injected µs vs compute µs ("scheduler adds X% to the critical path").
 
 The common dependency-aware analysis works at chip_swimlane_level >= 2 for
@@ -801,11 +801,14 @@ Top-level layout depends on `chip_swimlane_level`:
 - All levels: `chip_swimlane_level`, `tasks[]` (per-task fields above).
 - A5 HBG `>= 2`: also `aicpu_lifecycle_records[]`; the converter renders the
   real handshake, topology/configuration, context-publication, bootstrap-wait,
-  register-release, and exit timestamps under `AICPU Lifecycle`.
+  register-release, and exit intervals under `AICPU Lifecycle`, with one record
+  and lane per participating AICPU thread.
 - `>= 3`: also `scheduler_records.streams[]`. Every Record has the common
   `start_cycles`, `end_cycles`, `loop_iter`, `kind`, `tasks_processed`, and
   nullable `task_id` fields. Stream metadata selects the AICPU or AICore
   interpretation; producer-specific counters live in `metrics[]`.
+  A5 HBG task-bound phase labels use the actual task id, for example
+  `StateProbe(t23)`; Bootstrap and Idle use the phase name alone.
 - `>= 4`: also `aicpu_orchestrator_phases[]` (per-task orchestrator
   phase records).
 

--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -1034,7 +1034,10 @@ def run_analysis(  # noqa: PLR0912, PLR0915
     phase_labels = {
         "complete": "Complete (poll handshake, completion handling)",
         "async_poll": "AsyncPoll (async-wait completion: SDMA/RoCE/URMA/CCU)",
+        "state_probe": "StateProbe (available work and Cluster Slot query)",
         "dispatch": "Dispatch (pop queue, build payload, flush)",
+        "worksteal": "Worksteal (remote Inbox claim and dispatch)",
+        "refill": "Refill (completed Slot reuse)",
         "release": "Release (deferred producer release)",
         "dummy": "Dummy (dependency-only task resolution)",
         "early_dispatch": "EarlyDispatch (speculative staging)",

--- a/simpler_setup/tools/scheduler_phase_records.py
+++ b/simpler_setup/tools/scheduler_phase_records.py
@@ -13,7 +13,10 @@ import bisect
 SCHED_OUTER_PHASES = (
     "complete",
     "async_poll",
+    "state_probe",
     "dispatch",
+    "worksteal",
+    "refill",
     "release",
     "dummy",
     "early_dispatch",
@@ -21,7 +24,19 @@ SCHED_OUTER_PHASES = (
     "graph_prepare",
 )
 
-_SCHEDULER_WORK_PHASES = frozenset({"complete", "dispatch", "release", "early_dispatch", "drain", "graph_prepare"})
+_SCHEDULER_WORK_PHASES = frozenset(
+    {
+        "complete",
+        "state_probe",
+        "dispatch",
+        "worksteal",
+        "refill",
+        "release",
+        "early_dispatch",
+        "drain",
+        "graph_prepare",
+    }
+)
 _RESOLUTION_WORK_PHASES = frozenset({"resolve", "resolve_standalone", "async_poll", "dummy"})
 
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -44,6 +44,15 @@ from simpler_setup.tools.scheduler_phase_records import (
 )
 from simpler_setup.tools.strace_timing import host_process_lanes, parse_spans, span_family
 
+_AICORE_SCHEDULER_PHASE_DISPLAY_NAMES = {
+    "complete": "Completion",
+    "resolve": "Resolve",
+    "state_probe": "StateProbe",
+    "dispatch": "Dispatch",
+    "worksteal": "Worksteal",
+    "refill": "Refill",
+}
+
 
 def _func_id_to_letter(func_id):
     """Map a non-negative integer func_id to a numeric+letter label.
@@ -255,7 +264,7 @@ def _decode_perf_data(data, *, timeline_origin_ns=None, placement=None):  # noqa
             "records": [[core_id, reg_task_id, dispatch_cycles, finish_cycles], ...]
           },
           "scheduler_records": {"schema_version": 1, "streams": [...]},
-          "aicpu_lifecycle_records": [{worker_id, aicpu_thread_id, ..._cycles}, ...],
+          "aicpu_lifecycle_records": [{aicpu_thread_id, ..._cycles}, ...],
           "aicpu_orchestrator_phases":  [ [ {submit_idx, task_id, start_cycles, end_cycles}, ... ], ... ],
           "host_orchestrator_phases":   [ [ {submit_idx, task_id, start_host_ns, end_host_ns}, ... ], ... ]
         }
@@ -574,16 +583,20 @@ def _decode_perf_data(data, *, timeline_origin_ns=None, placement=None):  # noqa
             _track(int(pr.get("start_cycles", 0)))
             _track(int(pr.get("end_cycles", 0)))
     lifecycle_cycle_fields = (
-        "handshake_observed_cycles",
-        "handshake_partition_complete_cycles",
+        "handshake_start_cycles",
+        "handshake_complete_cycles",
         "config_start_cycles",
         "topology_complete_cycles",
+        "context_publish_start_cycles",
         "context_publish_complete_cycles",
         "bootstrap_wait_start_cycles",
         "bootstrap_complete_cycles",
-        "register_release_cycles",
-        "exit_signal_cycles",
-        "exit_ack_cycles",
+        "register_release_start_cycles",
+        "register_release_end_cycles",
+        "exit_signal_start_cycles",
+        "exit_signal_end_cycles",
+        "exit_wait_start_cycles",
+        "exit_wait_end_cycles",
     )
     for record in lifecycle_raw:
         for field in lifecycle_cycle_fields:
@@ -1637,19 +1650,20 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             {"args": {"sort_index": 2}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 6}
         )
         lifecycle_intervals = (
-            ("handshake_partition", "handshake_observed_time_us", "handshake_partition_complete_time_us"),
+            ("handshake_partition", "handshake_start_time_us", "handshake_complete_time_us"),
             ("topology_config", "config_start_time_us", "topology_complete_time_us"),
-            ("context_publish", "topology_complete_time_us", "context_publish_complete_time_us"),
+            ("context_publish", "context_publish_start_time_us", "context_publish_complete_time_us"),
             ("bootstrap_wait", "bootstrap_wait_start_time_us", "bootstrap_complete_time_us"),
-            ("exit_wait", "exit_signal_time_us", "exit_ack_time_us"),
+            ("register_release", "register_release_start_time_us", "register_release_end_time_us"),
+            ("exit_signal", "exit_signal_start_time_us", "exit_signal_end_time_us"),
+            ("exit_wait", "exit_wait_start_time_us", "exit_wait_end_time_us"),
         )
         for record in aicpu_lifecycle_records:
-            worker_id = int(record.get("worker_id", record.get("record_index", 0)))
-            thread_id = int(record.get("aicpu_thread_id", -1))
-            tid = 60000 + worker_id
+            thread_id = int(record.get("aicpu_thread_id", record.get("record_index", 0)))
+            tid = 60000 + thread_id
             events.append(
                 {
-                    "args": {"name": f"worker_{worker_id} (AICPU thread {thread_id})"},
+                    "args": {"name": f"AICPU Thread {thread_id}"},
                     "cat": "__metadata",
                     "name": "thread_name",
                     "ph": "M",
@@ -1657,12 +1671,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "tid": tid,
                 }
             )
-            identity = {
-                "worker_id": worker_id,
-                "aicpu_thread_id": thread_id,
-                "core_type": record.get("core_type"),
-                "physical_core_id": record.get("physical_core_id"),
-            }
+            identity = {"aicpu_thread_id": thread_id}
             for name, start_field, end_field in lifecycle_intervals:
                 start = float(record.get(start_field, 0.0))
                 end = float(record.get(end_field, 0.0))
@@ -1678,20 +1687,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         "tid": tid,
                         "ts": start,
                         "dur": end - start,
-                    }
-                )
-            if "register_release_time_us" in record:
-                register_release = float(record["register_release_time_us"])
-                events.append(
-                    {
-                        "args": identity,
-                        "cat": "aicpu_lifecycle",
-                        "name": "register_release",
-                        "ph": "i",
-                        "s": "t",
-                        "pid": 6,
-                        "tid": tid,
-                        "ts": register_release,
                     }
                 )
 
@@ -2028,9 +2023,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             "graph_prepare": "rail_animation",  # bounded Scheduler-side Definition expansion
             "bootstrap": "rail_animation",
             "fanin": "cq_build_running",
+            "state_probe": "cq_build_running",
             "ready_claim": "cq_build_attempt_runnable",
             "ready_steal": "cq_build_attempt_failed",
             "direct_refill": "cq_build_attempt_passed",
+            "worksteal": "cq_build_attempt_failed",
+            "refill": "cq_build_attempt_passed",
             "idle": "grey",
             # Inner in TMR; standalone on HBG's dedicated P thread.
             "resolve": "vsync_highlight_color",  # on_task_complete: walk consumer list
@@ -2106,13 +2104,13 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
 
             # Thread name metadata
             stream = scheduler_streams[thread_idx] if scheduler_streams and thread_idx < len(scheduler_streams) else {}
+            is_aicore_scheduler = stream.get("producer") == "aicore"
             scheduler_id = stream.get("scheduler_id", thread_idx)
-            worker_id = stream.get("worker_id")
-            core_type = stream.get("core_type")
             physical_core_id = stream.get("physical_core_id")
             lane_name = f"Sched_{scheduler_id}"
-            if stream.get("producer") == "aicore":
-                lane_name = f"Scheduler_{scheduler_id} ({core_type}_{physical_core_id}, worker {worker_id})"
+            if is_aicore_scheduler:
+                display_id = physical_core_id if physical_core_id is not None else scheduler_id
+                lane_name = f"Scheduler_{display_id}"
             events.append(
                 {
                     "args": {"name": lane_name},
@@ -2123,7 +2121,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "tid": tid,
                 }
             )
-            if nested_resolve_ids:
+            if nested_resolve_ids and not is_aicore_scheduler:
                 events.append(
                     {
                         "args": {"name": f"Sched_{thread_idx}"},
@@ -2212,9 +2210,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "graph_prepare",
                     "bootstrap",
                     "fanin",
+                    "state_probe",
                     "ready_claim",
                     "ready_steal",
                     "direct_refill",
+                    "worksteal",
+                    "refill",
                     "idle",
                 ):
                     continue
@@ -2242,6 +2243,9 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                     "loop_iter": record.get("loop_iter", 0),
                     "tasks_processed": tasks_processed,
                 }
+                task_id = normalize_task_id_int(record.get("task_id"))
+                if is_aicore_scheduler and task_id is not None:
+                    phase_args["task_id"] = task_id
                 if depths_valid:
                     # Perfetto's args SQL parses key names; `[...]` looks like
                     # an array-index op and crashes the details-panel query.
@@ -2266,8 +2270,20 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                         phase_args["finishes_processed"] = matched_finish_rows
                         tasks_processed = matched_finish_rows
                         phase_args["tasks_processed"] = tasks_processed
-                display_name = f"{phase}({tasks_processed})"
-                event_tid = resolve_tid if raw_phase == "resolve" and id(record) in nested_resolve_ids else tid
+                display_phase = (
+                    _AICORE_SCHEDULER_PHASE_DISPLAY_NAMES.get(phase, phase) if is_aicore_scheduler else phase
+                )
+                if not is_aicore_scheduler:
+                    display_name = f"{display_phase}({tasks_processed})"
+                elif task_id is not None:
+                    display_name = f"{display_phase}({format_task_display(task_id)})"
+                else:
+                    display_name = display_phase
+                event_tid = (
+                    resolve_tid
+                    if not is_aicore_scheduler and raw_phase == "resolve" and id(record) in nested_resolve_ids
+                    else tid
+                )
                 events.append(
                     {
                         "args": phase_args,

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -46,11 +46,9 @@ struct SchedulerWorkerStats {
     uint64_t completion_enqueue_cycles{0};
     uint64_t bootstrap_start_cycles{0};
     uint64_t bootstrap_scan_end_cycles{0};
-    uint64_t bootstrap_end_cycles{0};
     uint64_t target_bootstrap_start_cycles{0};
     uint64_t target_bootstrap_end_cycles{0};
     uint64_t bootstrap_target_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-    uint64_t bootstrap_ready_claim_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
     uint64_t bootstrap_slot_fill_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
     uint64_t drain_start_cycles{0};
     uint64_t drain_end_cycles{0};
@@ -59,54 +57,6 @@ struct SchedulerWorkerStats {
     uint64_t final_stats_publish_start_cycles{0};
     uint64_t final_stats_publish_end_cycles{0};
     uint64_t exit_ack_publish_cycles{0};
-};
-
-struct SchedulerInterTaskTiming {
-    uint64_t completion_service_cycles{0};
-    uint64_t dispatch_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-    SchedulerCompletionServiceTiming completion{};
-    uint64_t gang_service_cycles{0};
-    SchedulerNormalDispatchTiming dispatch{};
-    uint64_t ready_poll_cycles{0};
-    uint64_t backoff_cycles{0};
-
-    __aicore__ void reset() { *this = {}; }
-};
-
-__aicore__ __attribute__((always_inline)) void publish_scheduler_tail_trace(
-    __gm__ SchedulerWorkerContext *context, uint64_t start_cycles, uint64_t end_cycles,
-    const SchedulerInterTaskTiming &timing
-) {
-    __gm__ SchedulerTailTrace *trace = &context->scheduler_tail_trace;
-    trace->start_cycles = start_cycles;
-    trace->end_cycles = end_cycles;
-    trace->completion_scan_cycles = timing.completion.scan_cycles;
-    trace->completion_consume_cycles = timing.completion.consume_cycles;
-    trace->completion_resolve_cycles = timing.completion.resolve_cycles;
-    trace->completion_ready_publish_cycles = timing.completion.ready_publish_cycles;
-    trace->completion_refill_cycles = timing.completion.refill_cycles;
-    trace->completion_finalize_cycles = timing.completion.finalize_cycles;
-    trace->gang_service_cycles = timing.gang_service_cycles;
-    for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
-        trace->dispatch_probe_cycles[type] = timing.dispatch.probe_cycles[type];
-        trace->dispatch_claim_cycles[type] = timing.dispatch.claim_cycles[type];
-        trace->dispatch_prepare_cycles[type] = timing.dispatch.prepare_cycles[type];
-        trace->dispatch_materialize_cycles[type] = timing.dispatch.materialize_cycles[type];
-        trace->dispatch_publish_cycles[type] = timing.dispatch.publish_cycles[type];
-    }
-    trace->ready_poll_cycles = timing.ready_poll_cycles;
-    trace->backoff_cycles = timing.backoff_cycles;
-    scheduler_publish_cache_line(&trace->start_cycles);
-    scheduler_publish_cache_line(&trace->dispatch_materialize_cycles[0]);
-    scheduler_gm_publish(trace->valid, UINT64_C(1));
-}
-
-struct SchedulerExecutionRecord {
-    int64_t task_id{SCHEDULER_TASK_ID_INVALID};
-    uint64_t claim_worker_id{0};
-    uint64_t claim_start_cycles{0};
-    uint64_t claim_end_cycles{0};
-    SchedulerReadySource ready_source{SchedulerReadySource::LOCAL};
 };
 
 __aicore__ __attribute__((always_inline)) void execute_task(__gm__ DispatchPayload *payload) {
@@ -156,7 +106,6 @@ publish_worker_stats(__gm__ SchedulerWorkerContext *context, const SchedulerWork
 
     context->completion_enqueue_cycles = stats.completion_enqueue_cycles;
     context->bootstrap_start_cycles = stats.bootstrap_start_cycles;
-    context->bootstrap_end_cycles = stats.bootstrap_end_cycles;
     context->drain_start_cycles = stats.drain_start_cycles;
     context->drain_end_cycles = stats.drain_end_cycles;
     context->exit_wait_start_cycles = stats.exit_wait_start_cycles;
@@ -174,8 +123,6 @@ publish_worker_stats(__gm__ SchedulerWorkerContext *context, const SchedulerWork
     scheduler_gm_publish(context->target_bootstrap_end_cycles, stats.target_bootstrap_end_cycles);
     scheduler_gm_publish(context->bootstrap_target_aic_cycles, stats.bootstrap_target_cycles[0]);
     scheduler_gm_publish(context->bootstrap_target_aiv_cycles, stats.bootstrap_target_cycles[1]);
-    scheduler_gm_publish(context->bootstrap_ready_claim_aic_cycles, stats.bootstrap_ready_claim_cycles[0]);
-    scheduler_gm_publish(context->bootstrap_ready_claim_aiv_cycles, stats.bootstrap_ready_claim_cycles[1]);
 }
 
 // Keep the pre-kernel timestamps out of the indirect kernel call's live set.
@@ -230,23 +177,12 @@ __aicore__ bool bootstrap_ready_graph(
         scheduler_observe_cache_line(metadata);
         if (!scheduler_task_is_executable(metadata->flags)) continue;
         const bool has_fanin = scheduler_task_has_fanin(metadata->flags);
-        const uint64_t fanin_start_cycles = phase_timing_enabled && has_fanin ? scheduler_cycles() : 0;
         SchedulerRouteResult route =
             has_fanin ? scheduler_bootstrap_route_task(
                             graph, scheduler_state_base, scheduler, run_control, static_cast<int64_t>(task_id),
                             phase_timing_enabled ? &stats->wake : nullptr
                         ) :
                         SchedulerRouteResult::READY_TO_ENQUEUE;
-        if (phase_timing_enabled && has_fanin) {
-            __gm__ SchedulerTaskTrace *traces =
-                scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, scheduler->trace_cells_offset);
-            __gm__ SchedulerTaskTrace *trace = &traces[task_id];
-            trace->fanin_start_cycles = fanin_start_cycles;
-            trace->fanin_end_cycles = scheduler_cycles();
-            trace->fanin_scheduler_worker_id = scheduler->worker_index;
-            trace->fanin_loop_iter = 0;
-            scheduler_publish_cache_line(&trace->ready_transition_cycles);
-        }
         if (route == SchedulerRouteResult::ERROR) return false;
         if (route == SchedulerRouteResult::READY_TO_ENQUEUE &&
             !scheduler_bootstrap_ready_batch_append(
@@ -329,8 +265,7 @@ __aicore__ bool bootstrap_ready_graph(
     bool fill_failed = false;
     (void)scheduler_fill_cluster_normal_slots(
         graph, scheduler_state_base, scheduler, run_control, ready_victim_cursors,
-        phase_timing_enabled ? &stats->ready : nullptr, profiling_level, 0, nullptr, deferred_aiv, ready_owner,
-        &fill_failed
+        phase_timing_enabled ? &stats->ready : nullptr, profiling_level, 0, deferred_aiv, ready_owner, &fill_failed
     );
     if (fill_failed) return false;
     // No peer can make progress while the launch gate is closed. Materialize
@@ -347,7 +282,6 @@ __aicore__ bool bootstrap_ready_graph(
     // one and only DMB release. Schedulers do not wait on another barrier.
     arrived = scheduler_gm_fetch_add(run_control->bootstrap_arrived_count, UINT64_C(1)) + 1;
     if (arrived == scheduler_count) scheduler_gm_publish(run_control->bootstrap_complete, UINT64_C(1));
-    if (phase_timing_enabled) stats->bootstrap_end_cycles = scheduler_cycles();
     return true;
 }
 
@@ -370,14 +304,12 @@ __aicore__ bool run_ready_dispatch_loop(
         scheduler_worker ? (context->inbox_index + 1) % scheduler_count : 0,
     };
     uint64_t seen_publication[SCHEDULER_PENDING_SLOT_COUNT]{};
-    uint64_t inter_task_start_cycles = context->trace_register_release_cycles;
     uint32_t scan_start = 0;
     uint32_t backoff_iterations = kInitialBackoffIterations;
     uint32_t scheduler_error_poll_count = 0;
     uint32_t loop_iter = 0;
     uint64_t idle_start_cycles = 0;
     bool idle_active = false;
-    SchedulerInterTaskTiming inter_task_timing{};
     while (true) {
         if (static_cast<uint32_t>(read_reg(RegId::DATA_MAIN_BASE)) == AICORE_EXIT_SIGNAL) {
             if (phase_timing_enabled) {
@@ -387,9 +319,6 @@ __aicore__ bool run_ready_dispatch_loop(
                         scheduler_state_base, context, idle_start_cycles, stats->exit_observed_cycles
                     );
                 }
-                publish_scheduler_tail_trace(
-                    context, inter_task_start_cycles, stats->exit_observed_cycles, inter_task_timing
-                );
             }
             break;
         }
@@ -415,7 +344,7 @@ __aicore__ bool run_ready_dispatch_loop(
             if (!scheduler_drain_deferred_aiv_to_peer(
                     graph, scheduler_state_base, context, run_control, deferred_aiv,
                     phase_timing_enabled ? &stats->wake : nullptr, phase_timing_enabled ? &stats->ready : nullptr,
-                    phase_timing_enabled ? &stats->completion : nullptr, profiling_level, nullptr, nullptr, ready_owner
+                    phase_timing_enabled ? &stats->completion : nullptr, profiling_level, ready_owner
                 ))
                 return false;
             scheduler_progress = deferred_aiv->count != deferred_before;
@@ -426,58 +355,27 @@ __aicore__ bool run_ready_dispatch_loop(
                 return false;
         }
         if (scheduler_worker && preferred_ready_slot == UINT32_MAX) {
-            uint64_t operation_start = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
             uint64_t direct_refilled_slot_mask = 0;
-            SchedulerCompletionServiceTiming completion_timing{};
             const bool completion_progress = scheduler_service_cluster_completions(
                 graph, scheduler_state_base, context, run_control, phase_timing_enabled ? &stats->wake : nullptr,
                 phase_timing_enabled ? &stats->ready : nullptr, phase_timing_enabled ? &stats->completion : nullptr,
-                ready_victim_cursors, profiling_level, &direct_refilled_slot_mask,
-                phase_timing_enabled ? &completion_timing : nullptr, ready_owner
+                ready_victim_cursors, profiling_level, &direct_refilled_slot_mask, ready_owner
             );
-            if (phase_timing_enabled) {
-                uint64_t completion_total = get_sys_cnt_aicore() - operation_start;
-                uint64_t completion_detail = completion_timing.consume_cycles + completion_timing.resolve_cycles +
-                                             completion_timing.ready_publish_cycles + completion_timing.refill_cycles +
-                                             completion_timing.finalize_cycles;
-                completion_timing.scan_cycles +=
-                    completion_total > completion_detail ? completion_total - completion_detail : 0;
-                inter_task_timing.completion_service_cycles += completion_total;
-                inter_task_timing.completion.scan_cycles += completion_timing.scan_cycles;
-                inter_task_timing.completion.consume_cycles += completion_timing.consume_cycles;
-                inter_task_timing.completion.resolve_cycles += completion_timing.resolve_cycles;
-                inter_task_timing.completion.ready_publish_cycles += completion_timing.ready_publish_cycles;
-                inter_task_timing.completion.refill_cycles += completion_timing.refill_cycles;
-                inter_task_timing.completion.finalize_cycles += completion_timing.finalize_cycles;
-            }
             scheduler_progress = completion_progress;
-            operation_start = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
-            SchedulerNormalDispatchTiming dispatch_timing{};
             bool fill_failed = false;
             const bool dispatch_progress = scheduler_fill_cluster_normal_slots(
                 graph, scheduler_state_base, context, run_control, ready_victim_cursors,
                 phase_timing_enabled ? &stats->ready : nullptr, profiling_level, direct_refilled_slot_mask,
-                phase_timing_enabled ? &dispatch_timing : nullptr, deferred_aiv, ready_owner, &fill_failed
+                deferred_aiv, ready_owner, &fill_failed
             );
             scheduler_progress = dispatch_progress || scheduler_progress;
             if (fill_failed) return false;
-            if (phase_timing_enabled) {
-                inter_task_timing.dispatch_cycles[0] += get_sys_cnt_aicore() - operation_start;
-                for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
-                    inter_task_timing.dispatch.probe_cycles[type] += dispatch_timing.probe_cycles[type];
-                    inter_task_timing.dispatch.claim_cycles[type] += dispatch_timing.claim_cycles[type];
-                    inter_task_timing.dispatch.prepare_cycles[type] += dispatch_timing.prepare_cycles[type];
-                    inter_task_timing.dispatch.materialize_cycles[type] += dispatch_timing.materialize_cycles[type];
-                    inter_task_timing.dispatch.publish_cycles[type] += dispatch_timing.publish_cycles[type];
-                }
-            }
             if (deferred_aiv != nullptr && deferred_aiv->count != 0) {
                 const uint32_t deferred_before = deferred_aiv->count;
                 if (!scheduler_drain_deferred_aiv_to_peer(
                         graph, scheduler_state_base, context, run_control, deferred_aiv,
                         phase_timing_enabled ? &stats->wake : nullptr, phase_timing_enabled ? &stats->ready : nullptr,
-                        phase_timing_enabled ? &stats->completion : nullptr, profiling_level, nullptr, nullptr,
-                        ready_owner
+                        phase_timing_enabled ? &stats->completion : nullptr, profiling_level, ready_owner
                     ))
                     return false;
                 scheduler_progress = scheduler_progress || deferred_aiv->count != deferred_before;
@@ -527,8 +425,6 @@ __aicore__ bool run_ready_dispatch_loop(
                 }
             }
         }
-        uint64_t ready_poll_end = phase_timing_enabled ? get_sys_cnt_aicore() : 0;
-
         if (ready_slot >= 0) {
             uint32_t slot_index = static_cast<uint32_t>(ready_slot);
             __gm__ SchedulerDispatchSlot *slot =
@@ -556,17 +452,11 @@ __aicore__ bool run_ready_dispatch_loop(
                 return false;
             }
             seen_publication[slot_index] = ready_publication;
-            SchedulerExecutionRecord record{
-                slot->task_id,
-                slot->claim_worker_id,
-                slot->claim_start_cycles,
-                slot->claim_end_cycles,
-                static_cast<SchedulerReadySource>(slot->ready_source),
-            };
+            const int64_t task_id = slot->task_id;
             const bool commit_scheduler_trace =
                 task_timing_enabled && should_commit_scheduler_trace(scheduler_state_base, context, slot);
             __gm__ SchedulerTaskMetadata *task_metadata =
-                scheduler_task_metadata_at(scheduler_state_base, context, record.task_id);
+                scheduler_task_metadata_at(scheduler_state_base, context, task_id);
             scheduler_observe_cache_line(task_metadata);
             const bool commit_task_timing = task_metadata->timing_slot >= 0 &&
                                             task_metadata->timing_slot < SCHEDULER_TASK_TIMING_SLOT_COUNT &&
@@ -582,7 +472,7 @@ __aicore__ bool run_ready_dispatch_loop(
             uint64_t kernel_start = get_sys_cnt_aicore();
             if (phase_timing_enabled) {
                 __gm__ SchedulerTaskControl *control =
-                    scheduler_task_control_at(scheduler_state_base, context, record.task_id);
+                    scheduler_task_control_at(scheduler_state_base, context, task_id);
                 scheduler_observe_cache_line(&control->next_waiter);
                 if (control->ready_publish_cycles != 0 && kernel_start >= control->ready_publish_cycles) {
                     uint64_t lag = kernel_start - control->ready_publish_cycles;
@@ -614,16 +504,8 @@ __aicore__ bool run_ready_dispatch_loop(
             }
             scan_start = (slot_index + 1) % SCHEDULER_PENDING_SLOT_COUNT;
             backoff_iterations = kInitialBackoffIterations;
-            if (commit_scheduler_trace) {
-                inter_task_start_cycles = get_sys_cnt_aicore();
-            } else if (phase_timing_enabled) {
-                inter_task_start_cycles = get_sys_cnt_aicore();
-            }
-            inter_task_timing.reset();
             continue;
         }
-
-        if (phase_timing_enabled) inter_task_timing.ready_poll_cycles += ready_poll_end - ready_scan_start;
 
         if (scheduler_progress) {
             backoff_iterations = kInitialBackoffIterations;
@@ -635,7 +517,6 @@ __aicore__ bool run_ready_dispatch_loop(
         uint64_t backoff_end = get_sys_cnt_aicore();
         if (phase_timing_enabled) stats->backoff_cycles += backoff_end - backoff_start;
         if (phase_timing_enabled) {
-            inter_task_timing.backoff_cycles += backoff_end - backoff_start;
             if (scheduler_worker && !idle_active) {
                 idle_start_cycles = idle_candidate_start;
                 idle_active = true;

--- a/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.cpp
@@ -65,9 +65,11 @@ int32_t AicoreLifecycle::pre_handshake_init(Runtime *runtime, int32_t aicpu_thre
 
     std::memset(cores_, 0, sizeof(cores_));
     std::memset(physical_core_ids_, 0, sizeof(physical_core_ids_));
+    std::memset(thread_handshake_timing_, 0, sizeof(thread_handshake_timing_));
     core_count_ = runtime->worker_count;
     aicpu_thread_num_ = aicpu_thread_num;
     regs_base_ = regs_base;
+    lifecycle_traces_ = nullptr;
     handshake_failed_.store(false, std::memory_order_release);
 
     const bool chip_swimlane_enabled = is_chip_swimlane_enabled();
@@ -92,12 +94,13 @@ void AicoreLifecycle::handshake_partition(Runtime *runtime, int32_t tidx, int32_
         uint32_t physical_core_id;
         uint64_t reg_addr;
         CoreType core_type;
-        uint64_t handshake_observed_cycles;
     };
     ReadyCore ready[kMaxWorkers]{};
     bool observed[kMaxWorkers]{};
     int32_t ready_count = 0;
+    const bool record_lifecycle_timing = lifecycle_timing_enabled();
     const uint64_t wait_start = get_sys_cnt_aicpu();
+    if (record_lifecycle_timing) thread_handshake_timing_[tidx].start_cycles = wait_start;
     const uint64_t timeout_cycles = resident_scheduler_timeout_cycles();
 
     for (int32_t remaining = hi - lo; remaining > 0;) {
@@ -120,10 +123,7 @@ void AicoreLifecycle::handshake_partition(Runtime *runtime, int32_t tidx, int32_
                 handshake_failed_.store(true, std::memory_order_release);
                 continue;
             }
-            ready[ready_count++] = {
-                i, physical_core_id, regs[physical_core_id], handshake->core_type,
-                lifecycle_timing_enabled() ? get_sys_cnt_aicpu() : 0
-            };
+            ready[ready_count++] = {i, physical_core_id, regs[physical_core_id], handshake->core_type};
         }
         if (scheduler_watchdog_expired(wait_start, get_sys_cnt_aicpu(), timeout_cycles)) {
             LOG_ERROR("A5 HBG AICore Scheduler handshake timeout thread=%d remaining=%d", tidx, remaining);
@@ -135,13 +135,10 @@ void AicoreLifecycle::handshake_partition(Runtime *runtime, int32_t tidx, int32_
 
     for (int32_t i = 0; i < ready_count; ++i) {
         const ReadyCore &core = ready[i];
-        cores_[core.worker_id] = {core.reg_addr, core.physical_core_id,          core.core_type,
-                                  nullptr,       core.handshake_observed_cycles, 0};
+        cores_[core.worker_id] = {core.reg_addr, core.physical_core_id, core.core_type};
         physical_core_ids_[core.worker_id] = core.physical_core_id;
     }
-    const uint64_t partition_complete_cycles = lifecycle_timing_enabled() ? get_sys_cnt_aicpu() : 0;
-    for (int32_t i = lo; i < hi; ++i)
-        cores_[i].handshake_partition_complete_cycles = partition_complete_cycles;
+    if (record_lifecycle_timing) thread_handshake_timing_[tidx].end_cycles = get_sys_cnt_aicpu();
 }
 
 int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
@@ -158,12 +155,22 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
     if (scheduler_state_base == nullptr || run_control == nullptr) return -1;
     auto *contexts =
         scheduler_state_at<SchedulerWorkerContext>(scheduler_state_base, bootstrap_context->worker_contexts_offset);
-    auto *lifecycle_traces = scheduler_state_at<AicpuCoreLifecycleTrace>(
+    auto *lifecycle_traces = scheduler_state_at<AicpuThreadLifecycleTrace>(
         scheduler_state_base, bootstrap_context->aicpu_lifecycle_traces_offset
     );
+    lifecycle_traces_ = lifecycle_traces;
     cache_invalidate_range(run_control, sizeof(*run_control));
     cache_invalidate_range(contexts, static_cast<size_t>(core_count_) * sizeof(*contexts));
-    cache_invalidate_range(lifecycle_traces, static_cast<size_t>(core_count_) * sizeof(*lifecycle_traces));
+    cache_invalidate_range(
+        lifecycle_traces, static_cast<size_t>(PLATFORM_MAX_AICPU_THREADS) * sizeof(*lifecycle_traces)
+    );
+
+    for (int32_t thread_idx = 0; thread_idx < aicpu_thread_num_; ++thread_idx) {
+        lifecycle_traces[thread_idx].aicpu_thread_id = static_cast<uint64_t>(thread_idx);
+        lifecycle_traces[thread_idx].handshake_start_cycles = thread_handshake_timing_[thread_idx].start_cycles;
+        lifecycle_traces[thread_idx].handshake_complete_cycles = thread_handshake_timing_[thread_idx].end_cycles;
+    }
+    lifecycle_traces[0].config_start_cycles = config_start_cycles;
 
     int32_t aic_count = 0;
     int32_t aiv_count = 0;
@@ -179,13 +186,6 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
         contexts[i].core_type = static_cast<int32_t>(cores_[i].core_type);
         contexts[i].physical_core_id = static_cast<int32_t>(cores_[i].physical_core_id);
         contexts[i].active = 0;
-        cores_[i].trace = &lifecycle_traces[i];
-        lifecycle_traces[i].worker_id = static_cast<uint64_t>(i);
-        lifecycle_traces[i].core_type = static_cast<uint64_t>(cores_[i].core_type);
-        lifecycle_traces[i].physical_core_id = static_cast<uint64_t>(cores_[i].physical_core_id);
-        lifecycle_traces[i].handshake_observed_cycles = cores_[i].handshake_observed_cycles;
-        lifecycle_traces[i].handshake_partition_complete_cycles = cores_[i].handshake_partition_complete_cycles;
-        lifecycle_traces[i].config_start_cycles = config_start_cycles;
     }
     LOG_INFO("Core discovery complete: %d AIC, %d AIV", aic_count, aiv_count);
 
@@ -298,13 +298,12 @@ int32_t AicoreLifecycle::post_handshake_init(Runtime *runtime) {
     }
 
     const uint64_t topology_complete_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
-    for (int32_t i = 0; i < core_count_; ++i)
-        lifecycle_traces[i].topology_complete_cycles = topology_complete_cycles;
+    lifecycle_traces[0].topology_complete_cycles = topology_complete_cycles;
 
     if (is_pmu_enabled()) pmu_aicpu_init(physical_core_ids_, core_count_);
     cache_flush_range(contexts, static_cast<size_t>(core_count_) * sizeof(*contexts));
     cache_flush_range(run_control, sizeof(*run_control));
-    cache_flush_range(lifecycle_traces, static_cast<size_t>(core_count_) * sizeof(*lifecycle_traces));
+    cache_flush_range(lifecycle_traces, static_cast<size_t>(aicpu_thread_num_) * sizeof(*lifecycle_traces));
     wmb();
     return 0;
 }
@@ -315,6 +314,8 @@ void AicoreLifecycle::publish_context_partition(Runtime *runtime, int32_t thread
     Handshake *handshakes = runtime->workers;
     SchedulerWorkerContext *bootstrap_context = aicore_scheduler_bootstrap_context(runtime);
     if (bootstrap_context == nullptr) return;
+    AicpuThreadLifecycleTrace *trace = thread_lifecycle_trace(thread_idx);
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->context_publish_start_cycles = get_sys_cnt_aicpu();
     cache_invalidate_range(bootstrap_context, 256);
     void *scheduler_state_base = aicore_scheduler_state_base(bootstrap_context);
     for (int32_t i = lo; i < hi; ++i) {
@@ -326,10 +327,17 @@ void AicoreLifecycle::publish_context_partition(Runtime *runtime, int32_t thread
     }
     if (hi > lo) cache_flush_range(&handshakes[lo], static_cast<size_t>(hi - lo) * sizeof(Handshake));
     wmb();
-    const uint64_t publish_complete_cycles = lifecycle_timing_enabled() ? get_sys_cnt_aicpu() : 0;
-    for (int32_t i = lo; i < hi; ++i) {
-        if (cores_[i].trace != nullptr) cores_[i].trace->context_publish_complete_cycles = publish_complete_cycles;
-    }
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->context_publish_complete_cycles = get_sys_cnt_aicpu();
+}
+
+void AicoreLifecycle::begin_bootstrap_wait(int32_t thread_idx) {
+    AicpuThreadLifecycleTrace *trace = thread_lifecycle_trace(thread_idx);
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->bootstrap_wait_start_cycles = get_sys_cnt_aicpu();
+}
+
+void AicoreLifecycle::end_bootstrap_wait(int32_t thread_idx) {
+    AicpuThreadLifecycleTrace *trace = thread_lifecycle_trace(thread_idx);
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->bootstrap_complete_cycles = get_sys_cnt_aicpu();
 }
 
 int32_t AicoreLifecycle::wait_bootstrap_complete(Runtime *runtime) {
@@ -338,8 +346,6 @@ int32_t AicoreLifecycle::wait_bootstrap_complete(Runtime *runtime) {
     cache_invalidate_range(context, 128);
     auto *run_control = aicore_scheduler_run_control(context);
     if (run_control == nullptr) return -1;
-    const bool record_lifecycle_timing = lifecycle_timing_enabled();
-    const uint64_t wait_start_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
     const uint64_t watchdog_start = get_sys_cnt_aicpu();
     const uint64_t timeout_cycles = resident_scheduler_timeout_cycles();
     uint32_t error_poll_count = 0;
@@ -362,12 +368,6 @@ int32_t AicoreLifecycle::wait_bootstrap_complete(Runtime *runtime) {
         }
         SPIN_WAIT_HINT();
     }
-    const uint64_t complete_cycles = record_lifecycle_timing ? get_sys_cnt_aicpu() : 0;
-    for (int32_t i = 0; i < core_count_; ++i) {
-        if (cores_[i].trace == nullptr) continue;
-        cores_[i].trace->bootstrap_wait_start_cycles = wait_start_cycles;
-        cores_[i].trace->bootstrap_complete_cycles = complete_cycles;
-    }
     return 0;
 }
 
@@ -375,33 +375,33 @@ int32_t AicoreLifecycle::release_partition(int32_t thread_idx, bool start_execut
     const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(thread_idx) * core_count_) / aicpu_thread_num_);
     const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(thread_idx + 1) * core_count_) / aicpu_thread_num_);
     int32_t rc = 0;
+    AicpuThreadLifecycleTrace *trace = thread_lifecycle_trace(thread_idx);
+    if (start_execution && trace != nullptr && lifecycle_timing_enabled())
+        trace->register_release_start_cycles = get_sys_cnt_aicpu();
     wmb();
     for (int32_t i = lo; i < hi; ++i) {
         if (cores_[i].reg_addr == 0) continue;
         if (start_execution) {
-            if (cores_[i].trace != nullptr) {
-                cores_[i].trace->aicpu_thread_id = static_cast<uint64_t>(thread_idx);
-                cores_[i].trace->register_release_cycles = get_sys_cnt_aicpu();
-            }
             platform_init_aicore_regs(cores_[i].reg_addr);
         } else {
             if (platform_deinit_aicore_regs(cores_[i].reg_addr) != 0) rc = -1;
         }
     }
+    if (start_execution && trace != nullptr && lifecycle_timing_enabled())
+        trace->register_release_end_cycles = get_sys_cnt_aicpu();
     return rc;
 }
 
 void AicoreLifecycle::signal_shutdown_partition(int32_t thread_idx) {
     const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(thread_idx) * core_count_) / aicpu_thread_num_);
     const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(thread_idx + 1) * core_count_) / aicpu_thread_num_);
+    AicpuThreadLifecycleTrace *trace = thread_lifecycle_trace(thread_idx);
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->exit_signal_start_cycles = get_sys_cnt_aicpu();
     for (int32_t i = lo; i < hi; ++i) {
         if (cores_[i].reg_addr == 0) continue;
-        if (cores_[i].trace != nullptr) {
-            cores_[i].trace->aicpu_thread_id = static_cast<uint64_t>(thread_idx);
-            cores_[i].trace->exit_signal_cycles = get_sys_cnt_aicpu();
-        }
         write_reg(cores_[i].reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
     }
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->exit_signal_end_cycles = get_sys_cnt_aicpu();
 }
 
 int32_t AicoreLifecycle::finish_shutdown_partition(int32_t thread_idx, Runtime *runtime) {
@@ -409,17 +409,18 @@ int32_t AicoreLifecycle::finish_shutdown_partition(int32_t thread_idx, Runtime *
     const int32_t lo = static_cast<int32_t>((static_cast<int64_t>(thread_idx) * core_count_) / aicpu_thread_num_);
     const int32_t hi = static_cast<int32_t>((static_cast<int64_t>(thread_idx + 1) * core_count_) / aicpu_thread_num_);
     int32_t rc = 0;
+    AicpuThreadLifecycleTrace *trace = thread_lifecycle_trace(thread_idx);
+    if (trace != nullptr && lifecycle_timing_enabled()) trace->exit_wait_start_cycles = get_sys_cnt_aicpu();
     for (int32_t i = lo; i < hi; ++i) {
         if (cores_[i].reg_addr == 0) continue;
         if (platform_deinit_aicore_regs(cores_[i].reg_addr) != 0) {
             rc = -1;
-        } else if (cores_[i].trace != nullptr) {
-            cores_[i].trace->exit_ack_cycles = get_sys_cnt_aicpu();
         }
     }
     rmb();
-    if (hi > lo && cores_[lo].trace != nullptr) {
-        cache_flush_range(cores_[lo].trace, static_cast<size_t>(hi - lo) * sizeof(AicpuCoreLifecycleTrace));
+    if (trace != nullptr && lifecycle_timing_enabled()) {
+        trace->exit_wait_end_cycles = get_sys_cnt_aicpu();
+        cache_flush_range(trace, sizeof(*trace));
     }
 
     int32_t core_ids[kMaxWorkers]{};
@@ -436,8 +437,15 @@ int32_t AicoreLifecycle::finish_shutdown_partition(int32_t thread_idx, Runtime *
 void AicoreLifecycle::deinit() {
     std::memset(cores_, 0, sizeof(cores_));
     std::memset(physical_core_ids_, 0, sizeof(physical_core_ids_));
+    std::memset(thread_handshake_timing_, 0, sizeof(thread_handshake_timing_));
     handshake_failed_.store(false, std::memory_order_release);
+    lifecycle_traces_ = nullptr;
     core_count_ = 0;
     aicpu_thread_num_ = 0;
     regs_base_ = 0;
+}
+
+AicpuThreadLifecycleTrace *AicoreLifecycle::thread_lifecycle_trace(int32_t thread_idx) {
+    if (lifecycle_traces_ == nullptr || thread_idx < 0 || thread_idx >= aicpu_thread_num_) return nullptr;
+    return &lifecycle_traces_[thread_idx];
 }

--- a/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.h
+++ b/src/a5/runtime/host_build_graph/aicpu/aicore_lifecycle.h
@@ -15,9 +15,10 @@
 #include <cstdint>
 
 #include "common/core_type.h"
+#include "common/platform_config.h"
 
 class Runtime;
-struct AicpuCoreLifecycleTrace;
+struct AicpuThreadLifecycleTrace;
 
 class AicoreLifecycle {
 public:
@@ -25,6 +26,8 @@ public:
     void handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads);
     int32_t post_handshake_init(Runtime *runtime);
     void publish_context_partition(Runtime *runtime, int32_t thread_idx);
+    void begin_bootstrap_wait(int32_t thread_idx);
+    void end_bootstrap_wait(int32_t thread_idx);
     int32_t wait_bootstrap_complete(Runtime *runtime);
     int32_t release_partition(int32_t thread_idx, bool start_execution);
     void signal_shutdown_partition(int32_t thread_idx);
@@ -38,14 +41,20 @@ private:
         uint64_t reg_addr;
         uint32_t physical_core_id;
         CoreType core_type;
-        AicpuCoreLifecycleTrace *trace;
-        uint64_t handshake_observed_cycles;
-        uint64_t handshake_partition_complete_cycles;
     };
+
+    struct ThreadHandshakeTiming {
+        uint64_t start_cycles;
+        uint64_t end_cycles;
+    };
+
+    AicpuThreadLifecycleTrace *thread_lifecycle_trace(int32_t thread_idx);
 
     CoreState cores_[kMaxWorkers]{};
     uint32_t physical_core_ids_[kMaxWorkers]{};
+    ThreadHandshakeTiming thread_handshake_timing_[PLATFORM_MAX_AICPU_THREADS]{};
     std::atomic<bool> handshake_failed_{false};
+    AicpuThreadLifecycleTrace *lifecycle_traces_{nullptr};
     int32_t core_count_{0};
     int32_t aicpu_thread_num_{0};
     uint64_t regs_base_{0};

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -270,6 +270,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     // Only the leader polls the shared bootstrap line. Peers wait in AICPU
     // local memory, avoiding six concurrent cache invalidates on the same GM
     // cache line. The following release is the sole AICore-wide DMB gate.
+    aicore_lifecycle_.begin_bootstrap_wait(tidx);
     if (is_leader) {
         if (!init_failed_.load(std::memory_order_acquire) && aicore_lifecycle_.wait_bootstrap_complete(runtime) != 0) {
             init_failed_.store(true, std::memory_order_release);
@@ -284,6 +285,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
             init_failed_.store(true, std::memory_order_release);
         }
     }
+    aicore_lifecycle_.end_bootstrap_wait(tidx);
 
     // The DMB register is the only execution gate. On failure the same
     // partitioned path sends EXIT and waits for every ACK.

--- a/src/a5/runtime/host_build_graph/docs/profiling_levels.md
+++ b/src/a5/runtime/host_build_graph/docs/profiling_levels.md
@@ -444,7 +444,9 @@ AICPU Scheduler: `dispatch_time` is the end of dispatch publication and
 `scheduler_tasks.producer` field identifies which Scheduler produced these
 timestamps. At level 2 and above, A5 HBG also exports AICPU lifecycle timestamps
 for handshake, topology/configuration, context publication, bootstrap wait,
-register release, and exit; these are supplemental control-plane records.
+register release, and exit. Collection and rendering use one record per AICPU
+thread; topology/configuration is present only on the leader thread. These are
+supplemental control-plane records.
 
 At level 3 and above, A5 HBG AICore Scheduler task intervals reuse the per-task
 trace. Consecutive taskless scheduler-loop iterations are coalesced into one
@@ -454,6 +456,28 @@ keeps capture size dependent on idle-to-active transitions instead of Host CPU
 speed in simulation. The buffer is not allocated below level 3. Interval
 endpoints are captured at operation entry and exit; no interval is synthesized
 from aggregate durations.
+
+Each AICore Scheduler stream renders on one lane. Bootstrap covers dependency
+initialization and Slot setup, then ends before the initial task dispatch; the
+per-task Fanin work is therefore not emitted as a nested phase. Runtime task
+processing uses flat, non-overlapping phases:
+
+- `complete` consumes a Completion Inbox entry and marks the task done.
+- `resolve` updates successor dependencies and publishes newly Ready tasks.
+- `state_probe` checks Cluster Slot / Ready state, acquires a Ready task locally
+  or by stealing, and decides immediate or deferred placement.
+- `dispatch` fills and publishes a task acquired from the local Inbox.
+- `worksteal` fills and publishes a task acquired from another Inbox; the steal
+  operation itself is included in `state_probe`.
+- `refill` republishes a completed Slot with replacement work.
+
+Deferred waiting is not emitted as a Scheduler phase. The original
+`state_probe` ends before the wait, and the eventual publication begins at its
+actual `dispatch` or `refill` start.
+
+Every executed task is published by exactly one of `dispatch`, `worksteal`, or
+`refill`. The converter displays these phases as Completion, Resolve,
+StateProbe, Dispatch, Worksteal, and Refill.
 
 At level 1 the AICore record carries the full `task_token_raw`
 (a `TaskId::raw`; see `src/common/host_build_graph/task_id.h`), read straight from

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -490,28 +490,29 @@ bool publish_aicore_scheduler_profiling(Runtime *runtime, const HostApi *api) {
         }
 
         const auto *lifecycle =
-            scheduler_state_at<AicpuCoreLifecycleTrace>(host_base, owner.layout.aicpu_lifecycle_traces_offset);
+            scheduler_state_at<AicpuThreadLifecycleTrace>(host_base, owner.layout.aicpu_lifecycle_traces_offset);
         std::ostringstream lifecycle_json;
         lifecycle_json << "[";
         bool first = true;
-        for (uint64_t worker = 0; worker < SCHEDULER_WORKER_CAPACITY; ++worker) {
-            const AicpuCoreLifecycleTrace &trace = lifecycle[worker];
-            if (trace.handshake_observed_cycles == 0) continue;
+        for (uint64_t thread = 0; thread < PLATFORM_MAX_AICPU_THREADS; ++thread) {
+            const AicpuThreadLifecycleTrace &trace = lifecycle[thread];
+            if (trace.handshake_start_cycles == 0) continue;
             if (!first) lifecycle_json << ",";
-            lifecycle_json << "\n    {\"worker_id\": " << trace.worker_id
-                           << ", \"aicpu_thread_id\": " << trace.aicpu_thread_id << ", \"core_type\": \""
-                           << scheduler_core_type_name(static_cast<int32_t>(trace.core_type))
-                           << "\", \"physical_core_id\": " << trace.physical_core_id
-                           << ", \"handshake_observed_cycles\": " << trace.handshake_observed_cycles
-                           << ", \"handshake_partition_complete_cycles\": " << trace.handshake_partition_complete_cycles
+            lifecycle_json << "\n    {\"aicpu_thread_id\": " << trace.aicpu_thread_id
+                           << ", \"handshake_start_cycles\": " << trace.handshake_start_cycles
+                           << ", \"handshake_complete_cycles\": " << trace.handshake_complete_cycles
                            << ", \"config_start_cycles\": " << trace.config_start_cycles
                            << ", \"topology_complete_cycles\": " << trace.topology_complete_cycles
+                           << ", \"context_publish_start_cycles\": " << trace.context_publish_start_cycles
                            << ", \"context_publish_complete_cycles\": " << trace.context_publish_complete_cycles
                            << ", \"bootstrap_wait_start_cycles\": " << trace.bootstrap_wait_start_cycles
                            << ", \"bootstrap_complete_cycles\": " << trace.bootstrap_complete_cycles
-                           << ", \"register_release_cycles\": " << trace.register_release_cycles
-                           << ", \"exit_signal_cycles\": " << trace.exit_signal_cycles
-                           << ", \"exit_ack_cycles\": " << trace.exit_ack_cycles << "}";
+                           << ", \"register_release_start_cycles\": " << trace.register_release_start_cycles
+                           << ", \"register_release_end_cycles\": " << trace.register_release_end_cycles
+                           << ", \"exit_signal_start_cycles\": " << trace.exit_signal_start_cycles
+                           << ", \"exit_signal_end_cycles\": " << trace.exit_signal_end_cycles
+                           << ", \"exit_wait_start_cycles\": " << trace.exit_wait_start_cycles
+                           << ", \"exit_wait_end_cycles\": " << trace.exit_wait_end_cycles << "}";
             first = false;
         }
         if (!first) lifecycle_json << "\n  ";
@@ -532,31 +533,26 @@ bool publish_aicore_scheduler_profiling(Runtime *runtime, const HostApi *api) {
         const SchedulerWorkerContext &context = contexts[worker];
         if (context.is_scheduler == 0 || context.worker_index >= SCHEDULER_WORKER_CAPACITY) continue;
         append_scheduler_record(
-            &records[context.worker_index], context.bootstrap_start_cycles, context.bootstrap_end_cycles, 0,
+            &records[context.worker_index], context.bootstrap_start_cycles, context.target_bootstrap_end_cycles, 0,
             "bootstrap", context.bootstrap_task_count, 0, false
         );
     }
     for (uint64_t task_id = 0; task_id < owner.layout.task_count; ++task_id) {
         const SchedulerTaskTrace &trace = traces[task_id];
-        if (trace.fanin_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+        if (trace.state_probe_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
             append_scheduler_record(
-                &records[trace.fanin_scheduler_worker_id], trace.fanin_start_cycles, trace.fanin_end_cycles,
-                trace.fanin_loop_iter, "fanin", 1, task_id
+                &records[trace.state_probe_scheduler_worker_id], trace.state_probe_start_cycles,
+                trace.state_probe_end_cycles, trace.dispatch_loop_iter, "state_probe", 1, task_id
             );
         }
-        if (trace.claim_worker_id < SCHEDULER_WORKER_CAPACITY) {
-            append_scheduler_record(
-                &records[trace.claim_worker_id], trace.claim_start_cycles, trace.claim_end_cycles,
-                trace.claim_loop_iter,
-                trace.ready_source == static_cast<uint64_t>(SchedulerReadySource::STOLEN) ? "ready_steal" :
-                                                                                            "ready_claim",
-                1, task_id
-            );
-        }
-        if (trace.dispatch_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
+        const auto ready_source = static_cast<SchedulerReadySource>(trace.ready_source);
+        const auto publication_mode = static_cast<SchedulerPublicationMode>(trace.publication_mode);
+        const bool refill = publication_mode == SchedulerPublicationMode::REFILL;
+        if (trace.dispatch_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY && !refill) {
             append_scheduler_record(
                 &records[trace.dispatch_scheduler_worker_id], trace.dispatch_start_cycles, trace.dispatch_end_cycles,
-                trace.dispatch_loop_iter, "dispatch", 1, task_id
+                trace.dispatch_loop_iter, ready_source == SchedulerReadySource::STOLEN ? "worksteal" : "dispatch", 1,
+                task_id
             );
         }
         if (trace.complete_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
@@ -568,7 +564,7 @@ bool publish_aicore_scheduler_profiling(Runtime *runtime, const HostApi *api) {
         if (trace.refill_scheduler_worker_id < SCHEDULER_WORKER_CAPACITY) {
             append_scheduler_record(
                 &records[trace.refill_scheduler_worker_id], trace.refill_start_cycles, trace.refill_end_cycles,
-                trace.refill_loop_iter, "direct_refill", 1, trace.refill_task_id
+                trace.refill_loop_iter, "refill", 1, trace.refill_task_id
             );
         }
         const SchedulerTaskControl &control = controls[task_id];

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_completion.h
@@ -36,7 +36,7 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     uint32_t completed_generation, SchedulerWakeStats *wake_stats, SchedulerReadyStats *ready_stats,
     SchedulerCompletionStats *completion_stats, uint64_t *ready_victim_cursors, uint64_t profiling_level,
     const SchedulerReadyClaim *replacement_ready, bool *direct_refilled,
-    SchedulerCompletionServiceTiming *timing = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
 ) {
     if (direct_refilled != nullptr) *direct_refilled = false;
     if (cluster_lane >= PLATFORM_CORES_PER_BLOCKDIM || pending_slot >= SCHEDULER_PENDING_SLOT_COUNT ||
@@ -63,9 +63,7 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     const bool chip_task_timing_enabled = scheduler_task_timing_enabled(profiling_level);
     const bool schedule_timing_enabled = scheduler_schedule_timing_enabled(profiling_level);
     const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
-    const bool record_timeline = phase_timing_enabled;
     const uint64_t completion_start = schedule_timing_enabled ? scheduler_cycles() : 0;
-    uint64_t operation_start = record_timeline ? completion_start : 0;
     scheduler_observe_cache_line(slot);
     const int64_t task_id = slot->task_id;
     if (task_id < 0 || static_cast<uint64_t>(task_id) >= graph.task_count) {
@@ -133,28 +131,21 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     }
     const uint8_t completed_subtask_slot = slot->subtask_slot;
     scheduler_gm_store(completion_line->completed_generations[pending_slot], UINT32_C(0));
-    uint64_t operation_end = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) timing->consume_cycles += operation_end - operation_start;
-    operation_start = operation_end;
-    uint64_t ready_publish_cycles = 0;
-    uint64_t refill_cycles = 0;
-    uint64_t finalize_cycles = 0;
     uint64_t refill_start_cycles = 0;
     uint64_t refill_end_cycles = 0;
     bool refilled = false;
     __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, scheduler, task_id);
     scheduler_gm_store(control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
+    const uint64_t completion_phase_end = phase_timing_enabled ? scheduler_cycles() : 0;
     if (!scheduler_resolve_completion(
             graph, scheduler_state_base, scheduler, run_control, task_id, wake_stats, ready_stats, completion_stats,
-            owner_state, profiling_level, false, timing == nullptr ? nullptr : &ready_publish_cycles
+            owner_state, profiling_level, false
         )) {
         scheduler_account_failed_completion(
             graph, scheduler, run_control, task_id, SchedulerErrorSite::COMPLETION_RESOLVE_FAILED
         );
         return false;
     }
-    if (timing != nullptr) timing->ready_publish_cycles += ready_publish_cycles;
-    refill_start_cycles = record_timeline ? scheduler_cycles() : 0;
     SchedulerReadyClaim ready{};
     bool ready_available = replacement_ready != nullptr;
     if (ready_available) {
@@ -163,18 +154,26 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
         // A normal AIV task is never refilled directly onto the Scheduler.
         // Its completed slot becomes capacity for late binding instead.
         const uint32_t core_type = scheduler_metadata_core_type_index(completed_subtask_slot);
+        const uint64_t state_probe_start_cycles = phase_timing_enabled ? scheduler_cycles() : 0;
         if (!scheduler_claim_ready_for_slot(
                 graph, scheduler_state_base, scheduler, run_control, scheduler->scheduler_count, core_type,
-                &ready_victim_cursors[core_type], ready_stats, &ready, owner_state, profiling_level
+                &ready_victim_cursors[core_type], ready_stats, &ready, owner_state
             )) {
             scheduler_account_failed_completion(
                 graph, scheduler, run_control, task_id, SchedulerErrorSite::COMPLETION_REFILL_CLAIM_FAILED
             );
             return false;
         }
+        ready.state_probe_start_cycles = state_probe_start_cycles;
         ready_available = ready.task_id >= 0;
+        if (ready_available) {
+            ready.state_probe_end_cycles = phase_timing_enabled ? scheduler_cycles() : 0;
+            refill_start_cycles = ready.state_probe_end_cycles;
+        }
     }
     if (ready_available) {
+        if (refill_start_cycles == 0) refill_start_cycles = phase_timing_enabled ? scheduler_cycles() : 0;
+        ready.publication_mode = SchedulerPublicationMode::REFILL;
         SchedulerFreeSlotClaim claim{worker_id, pending_slot, slot->generation};
         if (!scheduler_fill_dispatch_slot(
                 graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level
@@ -186,18 +185,8 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
         }
         refilled = true;
     }
-    refill_end_cycles = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) {
-        refill_cycles = refill_end_cycles - refill_start_cycles;
-        timing->refill_cycles += refill_cycles;
-    }
-    operation_end = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) {
-        uint64_t resolve_total = operation_end - operation_start;
-        uint64_t excluded = ready_publish_cycles + refill_cycles + finalize_cycles;
-        timing->resolve_cycles += resolve_total > excluded ? resolve_total - excluded : 0;
-    }
-    operation_start = operation_end;
+    refill_end_cycles = phase_timing_enabled ? scheduler_cycles() : 0;
+    if (refill_start_cycles == 0) refill_start_cycles = refill_end_cycles;
     if (!refilled) {
         slot->task_id = SCHEDULER_TASK_ID_INVALID;
         scheduler_writeback_cache_line(slot);
@@ -205,11 +194,9 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
             slot->publication, scheduler_dispatch_publication(slot->generation, SchedulerDispatchSlotState::FREE)
         );
     }
-    const uint64_t completion_end = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) timing->finalize_cycles += completion_end - operation_start;
     if (chip_task_timing_enabled) {
         if (phase_timing_enabled) {
-            completed_trace->complete_end_cycles = completion_end;
+            completed_trace->complete_end_cycles = completion_phase_end;
         }
         if (phase_timing_enabled && refilled) {
             completed_trace->refill_scheduler_worker_id = scheduler->worker_index;
@@ -233,12 +220,7 @@ inline __aicore__ bool scheduler_service_cluster_completion_slot(
     } else if (completed_trace != nullptr) {
         scheduler_publish_cache_line(&completed_trace->kernel_start_cycles);
     }
-    const uint64_t resolved_count_start = timing == nullptr ? 0 : scheduler_cycles();
     scheduler_gm_fetch_add(run_control->resolved_task_count, UINT64_C(1));
-    if (timing != nullptr) {
-        finalize_cycles = scheduler_cycles() - resolved_count_start;
-        timing->finalize_cycles += finalize_cycles;
-    }
     if (direct_refilled != nullptr) *direct_refilled = refilled;
     return true;
 }
@@ -252,8 +234,7 @@ inline __aicore__ bool scheduler_service_cluster_completions(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, SchedulerWakeStats *wake_stats, SchedulerReadyStats *ready_stats,
     SchedulerCompletionStats *completion_stats, uint64_t *ready_victim_cursors = nullptr, uint64_t profiling_level = 0,
-    uint64_t *direct_refilled_slot_mask = nullptr, SchedulerCompletionServiceTiming *timing = nullptr,
-    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+    uint64_t *direct_refilled_slot_mask = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr
 ) {
     if (scheduler->is_scheduler == 0) return false;
     if (direct_refilled_slot_mask != nullptr) *direct_refilled_slot_mask = 0;
@@ -284,7 +265,7 @@ inline __aicore__ bool scheduler_service_cluster_completions(
                 if (!scheduler_service_cluster_completion_slot(
                         graph, scheduler_state_base, scheduler, run_control, cluster_lane, pending_slot,
                         completed_generation, wake_stats, ready_stats, completion_stats, ready_victim_cursors,
-                        profiling_level, nullptr, &direct_refilled, timing, owner_state
+                        profiling_level, nullptr, &direct_refilled, owner_state
                     ))
                     return false;
                 if (direct_refilled && direct_refilled_slot_mask != nullptr)

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.h
@@ -35,29 +35,6 @@ inline __aicore__ void scheduler_deferred_aiv_pop_front(SchedulerDeferredAivQueu
     queue->entries[queue->count] = {};
 }
 
-struct SchedulerNormalDispatchTiming {
-    uint64_t probe_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-    uint64_t claim_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-    uint64_t prepare_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-    uint64_t materialize_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-    uint64_t publish_cycles[SCHEDULER_CORE_TYPE_COUNT]{};
-};
-
-inline __aicore__ uint64_t
-scheduler_normal_dispatch_detail_cycles(const SchedulerNormalDispatchTiming &timing, uint32_t core_type) {
-    return timing.claim_cycles[core_type] + timing.prepare_cycles[core_type] + timing.materialize_cycles[core_type] +
-           timing.publish_cycles[core_type];
-}
-
-inline __aicore__ void scheduler_finish_normal_dispatch_stage(
-    SchedulerNormalDispatchTiming *timing, uint32_t core_type, uint64_t stage_start, uint64_t detail_start
-) {
-    if (timing == nullptr) return;
-    uint64_t stage_cycles = scheduler_cycles() - stage_start;
-    uint64_t detail_cycles = scheduler_normal_dispatch_detail_cycles(*timing, core_type) - detail_start;
-    timing->probe_cycles[core_type] += stage_cycles > detail_cycles ? stage_cycles - detail_cycles : 0;
-}
-
 inline __aicore__ bool scheduler_normal_aiv_worker_precedes(
     uint32_t candidate_occupied_slots, bool candidate_is_scheduler, uint32_t selected_occupied_slots,
     bool selected_is_scheduler
@@ -70,15 +47,13 @@ inline __aicore__ bool scheduler_normal_aiv_worker_precedes(
 inline __aicore__ bool scheduler_fill_cluster_normal_slots(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, uint64_t *ready_victim_cursors, SchedulerReadyStats *ready_stats,
-    uint64_t profiling_level, uint64_t skip_slot_mask = 0, SchedulerNormalDispatchTiming *timing = nullptr,
-    SchedulerDeferredAivQueue *deferred_aiv = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr,
-    bool *failed = nullptr
+    uint64_t profiling_level, uint64_t skip_slot_mask = 0, SchedulerDeferredAivQueue *deferred_aiv = nullptr,
+    __gm__ SchedulerReadyOwnerState *owner_state = nullptr, bool *failed = nullptr
 ) {
     if (failed != nullptr) *failed = false;
     if (scheduler->is_scheduler == 0) return false;
     const uint32_t aic_core_type = static_cast<uint32_t>(CoreType::AIC);
-    uint64_t stage_start = timing == nullptr ? 0 : scheduler_cycles();
-    uint64_t detail_start = timing == nullptr ? 0 : scheduler_normal_dispatch_detail_cycles(*timing, aic_core_type);
+    uint64_t state_probe_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
     bool progress = false;
 
     // AIC has no peer lane in its Cluster, so preserve the existing slot order.
@@ -104,17 +79,17 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
                 SchedulerReadyClaim ready{};
                 if (!scheduler_claim_ready_for_slot(
                         graph, scheduler_state_base, scheduler, run_control, scheduler->scheduler_count, aic_core_type,
-                        &ready_victim_cursors[aic_core_type], ready_stats, &ready, owner_state, profiling_level
+                        &ready_victim_cursors[aic_core_type], ready_stats, &ready, owner_state
                     )) {
                     if (failed != nullptr) *failed = true;
                     return progress;
                 }
-                if (timing != nullptr && ready.claim_end_cycles >= ready.claim_start_cycles)
-                    timing->claim_cycles[aic_core_type] += ready.claim_end_cycles - ready.claim_start_cycles;
                 if (ready.task_id < 0) {
                     aic_ready_available = false;
                     break;
                 }
+                ready.state_probe_start_cycles = state_probe_start_cycles;
+                ready.state_probe_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
                 SchedulerFreeSlotClaim claim{
                     worker_id,
                     pending_slot,
@@ -124,25 +99,17 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
                     slot->publication,
                     scheduler_dispatch_publication(claim.generation, SchedulerDispatchSlotState::FILLING)
                 );
-                SchedulerDispatchFillTiming fill_timing{};
                 if (!scheduler_fill_dispatch_slot(
-                        graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level,
-                        timing == nullptr ? nullptr : &fill_timing
+                        graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level
                     )) {
                     if (failed != nullptr) *failed = true;
                     return progress;
                 }
-                if (timing != nullptr) {
-                    timing->prepare_cycles[aic_core_type] += fill_timing.prepare_cycles;
-                    timing->materialize_cycles[aic_core_type] += fill_timing.materialize_cycles;
-                    timing->publish_cycles[aic_core_type] += fill_timing.publish_cycles;
-                }
                 progress = true;
+                state_probe_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
             }
         }
     }
-    scheduler_finish_normal_dispatch_stage(timing, aic_core_type, stage_start, detail_start);
-
     // A Scheduler shares its AIV with Executor work. Exhaust the non-Scheduler
     // peer's free slots first, then claim more work only against reserved
     // Scheduler capacity. The caller decides the reserved work's owner after
@@ -155,8 +122,7 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
         bool is_scheduler{false};
     };
     const uint32_t aiv_core_type = static_cast<uint32_t>(CoreType::AIV);
-    stage_start = timing == nullptr ? 0 : scheduler_cycles();
-    detail_start = timing == nullptr ? 0 : scheduler_normal_dispatch_detail_cycles(*timing, aiv_core_type);
+    state_probe_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
     if (scheduler_ready_directory_nonempty(
             scheduler_state_base, scheduler, scheduler->scheduler_count, aiv_core_type
         )) {
@@ -226,7 +192,7 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
             SchedulerReadyClaim ready{};
             if (!scheduler_claim_ready_for_slot(
                     graph, scheduler_state_base, scheduler, run_control, scheduler->scheduler_count, aiv_core_type,
-                    &ready_victim_cursors[aiv_core_type], ready_stats, &ready, owner_state, profiling_level
+                    &ready_victim_cursors[aiv_core_type], ready_stats, &ready, owner_state
                 )) {
                 scheduler_gm_store(
                     slot->publication,
@@ -235,8 +201,6 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
                 if (failed != nullptr) *failed = true;
                 return progress;
             }
-            if (timing != nullptr && ready.claim_end_cycles >= ready.claim_start_cycles)
-                timing->claim_cycles[aiv_core_type] += ready.claim_end_cycles - ready.claim_start_cycles;
             if (ready.task_id < 0) {
                 scheduler_gm_store(
                     slot->publication,
@@ -244,30 +208,28 @@ inline __aicore__ bool scheduler_fill_cluster_normal_slots(
                 );
                 break;
             }
+            ready.state_probe_start_cycles = state_probe_start_cycles;
             if (worker.is_scheduler) {
-                deferred_aiv->entries[deferred_aiv->count++] = {ready, claim};
+                SchedulerDeferredAivDispatch &entry = deferred_aiv->entries[deferred_aiv->count++];
+                entry = {ready, claim};
                 ++worker.occupied_slots;
                 progress = true;
+                state_probe_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
+                entry.ready.state_probe_end_cycles = state_probe_start_cycles;
                 continue;
             }
-            SchedulerDispatchFillTiming fill_timing{};
+            ready.state_probe_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
             if (!scheduler_fill_dispatch_slot(
-                    graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level,
-                    timing == nullptr ? nullptr : &fill_timing
+                    graph, scheduler_state_base, scheduler, run_control, claim, ready, profiling_level
                 )) {
                 if (failed != nullptr) *failed = true;
                 return progress;
             }
-            if (timing != nullptr) {
-                timing->prepare_cycles[aiv_core_type] += fill_timing.prepare_cycles;
-                timing->materialize_cycles[aiv_core_type] += fill_timing.materialize_cycles;
-                timing->publish_cycles[aiv_core_type] += fill_timing.publish_cycles;
-            }
             ++worker.occupied_slots;
             progress = true;
+            state_probe_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
         }
     }
-    scheduler_finish_normal_dispatch_stage(timing, aiv_core_type, stage_start, detail_start);
     return progress;
 }
 
@@ -318,8 +280,7 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, SchedulerDeferredAivQueue *queue, SchedulerWakeStats *wake_stats,
     SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats, uint64_t profiling_level,
-    SchedulerCompletionServiceTiming *completion_timing = nullptr,
-    SchedulerNormalDispatchTiming *dispatch_timing = nullptr, __gm__ SchedulerReadyOwnerState *owner_state = nullptr
+    __gm__ SchedulerReadyOwnerState *owner_state = nullptr
 ) {
     if (queue == nullptr || queue->count == 0) return true;
     const int32_t peer_lane = scheduler_deferred_aiv_peer_lane(scheduler_state_base, scheduler);
@@ -330,7 +291,6 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
     const uint64_t peer_worker_id = scheduler->cluster_worker_ids[static_cast<uint32_t>(peer_lane)];
     __gm__ SchedulerCompletionInbox *completion_line =
         scheduler_completion_inbox_at(scheduler_state_base, scheduler, peer_worker_id);
-    const uint32_t aiv_core_type = static_cast<uint32_t>(CoreType::AIV);
 
     for (uint32_t pass = 0; pass < 2 && queue->count != 0; ++pass) {
         const uint64_t completed_generations =
@@ -349,18 +309,12 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
                     peer_slot->publication,
                     scheduler_dispatch_publication(generation, SchedulerDispatchSlotState::FILLING)
                 );
-                SchedulerDispatchFillTiming fill_timing{};
                 if (!scheduler_fill_dispatch_slot(
                         graph, scheduler_state_base, scheduler, run_control,
                         SchedulerFreeSlotClaim{peer_worker_id, pending_slot, generation}, queue->entries[0].ready,
-                        profiling_level, dispatch_timing == nullptr ? nullptr : &fill_timing
+                        profiling_level
                     ))
                     return false;
-                if (dispatch_timing != nullptr) {
-                    dispatch_timing->prepare_cycles[aiv_core_type] += fill_timing.prepare_cycles;
-                    dispatch_timing->materialize_cycles[aiv_core_type] += fill_timing.materialize_cycles;
-                    dispatch_timing->publish_cycles[aiv_core_type] += fill_timing.publish_cycles;
-                }
                 refilled = true;
             } else {
                 if (state != SchedulerDispatchSlotState::READY) continue;
@@ -372,7 +326,7 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
                 if (!scheduler_service_cluster_completion_slot(
                         graph, scheduler_state_base, scheduler, run_control, static_cast<uint32_t>(peer_lane),
                         pending_slot, completed_generation, wake_stats, ready_stats, completion_stats, nullptr,
-                        profiling_level, &queue->entries[0].ready, &refilled, completion_timing, owner_state
+                        profiling_level, &queue->entries[0].ready, &refilled, owner_state
                     ) ||
                     !refilled)
                     return false;
@@ -390,7 +344,7 @@ inline __aicore__ bool scheduler_drain_deferred_aiv_to_peer(
 inline __aicore__ bool scheduler_publish_deferred_aiv_local(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, SchedulerDeferredAivQueue *queue, uint64_t profiling_level,
-    uint32_t *published_slot, SchedulerNormalDispatchTiming *timing = nullptr
+    uint32_t *published_slot
 ) {
     if (published_slot != nullptr) *published_slot = UINT32_MAX;
     if (queue == nullptr || queue->count == 0) return true;
@@ -417,18 +371,10 @@ inline __aicore__ bool scheduler_publish_deferred_aiv_local(
         );
         return false;
     }
-    const uint32_t aiv_core_type = static_cast<uint32_t>(CoreType::AIV);
-    SchedulerDispatchFillTiming fill_timing{};
     if (!scheduler_fill_dispatch_slot(
-            graph, scheduler_state_base, scheduler, run_control, entry.reserved_slot, entry.ready, profiling_level,
-            timing == nullptr ? nullptr : &fill_timing
+            graph, scheduler_state_base, scheduler, run_control, entry.reserved_slot, entry.ready, profiling_level
         ))
         return false;
-    if (timing != nullptr) {
-        timing->prepare_cycles[aiv_core_type] += fill_timing.prepare_cycles;
-        timing->materialize_cycles[aiv_core_type] += fill_timing.materialize_cycles;
-        timing->publish_cycles[aiv_core_type] += fill_timing.publish_cycles;
-    }
     if (published_slot != nullptr) *published_slot = entry.reserved_slot.slot_index;
     scheduler_deferred_aiv_pop_front(queue);
     return true;

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_ready.h
@@ -97,29 +97,15 @@ struct SchedulerReadyClaim {
     int64_t task_id{SCHEDULER_TASK_ID_INVALID};
     uint64_t inbox_index{UINT64_MAX};
     SchedulerReadySource source{SchedulerReadySource::LOCAL};
-    uint64_t claim_start_cycles{0};
-    uint64_t claim_end_cycles{0};
+    SchedulerPublicationMode publication_mode{SchedulerPublicationMode::DISPATCH};
+    uint64_t state_probe_start_cycles{0};
+    uint64_t state_probe_end_cycles{0};
 };
 
 struct SchedulerFreeSlotClaim {
     uint64_t worker_id{UINT64_MAX};
     uint32_t slot_index{UINT32_MAX};
     uint32_t generation{0};
-};
-
-struct SchedulerCompletionServiceTiming {
-    uint64_t scan_cycles{0};
-    uint64_t consume_cycles{0};
-    uint64_t resolve_cycles{0};
-    uint64_t ready_publish_cycles{0};
-    uint64_t refill_cycles{0};
-    uint64_t finalize_cycles{0};
-};
-
-struct SchedulerDispatchFillTiming {
-    uint64_t prepare_cycles{0};
-    uint64_t materialize_cycles{0};
-    uint64_t publish_cycles{0};
 };
 
 inline __aicore__ uint64_t scheduler_cycles() {
@@ -829,7 +815,7 @@ inline __aicore__ uint64_t scheduler_load_ready_directory_shard(
 inline __aicore__ bool scheduler_steal_ready_from_shard(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, uint32_t core_type_index, uint64_t shard_begin, uint64_t shard_end,
-    uint64_t start, uint64_t bits, SchedulerReadyStats *stats, SchedulerReadyClaim *claim, uint64_t profiling_level
+    uint64_t start, uint64_t bits, SchedulerReadyStats *stats, SchedulerReadyClaim *claim
 ) {
     int64_t task_id = SCHEDULER_TASK_ID_INVALID;
     bits &= ~(UINT64_C(1) << (context->inbox_index - shard_begin));
@@ -852,7 +838,6 @@ inline __aicore__ bool scheduler_steal_ready_from_shard(
                 claim->task_id = task_id;
                 claim->inbox_index = victim;
                 claim->source = SchedulerReadySource::STOLEN;
-                claim->claim_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
                 if (stats != nullptr) ++stats->steal_count;
                 return true;
             }
@@ -865,14 +850,13 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, uint64_t scheduler_count, uint32_t core_type_index,
     uint64_t *victim_cursor, SchedulerReadyStats *stats, SchedulerReadyClaim *claim,
-    __gm__ SchedulerReadyOwnerState *owner_state, uint64_t profiling_level = 0
+    __gm__ SchedulerReadyOwnerState *owner_state
 ) {
     if (victim_cursor == nullptr || claim == nullptr || owner_state == nullptr || scheduler_count == 0 ||
         scheduler_count > SCHEDULER_CAPACITY || context->inbox_index >= scheduler_count ||
         core_type_index >= SCHEDULER_CORE_TYPE_COUNT)
         return false;
     *claim = {};
-    claim->claim_start_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
     if (!scheduler_ready_owner_maintain_type(scheduler_state_base, context, core_type_index, owner_state)) return false;
     int64_t task_id = SCHEDULER_TASK_ID_INVALID;
     if (!scheduler_ready_pop_from_inbox(
@@ -882,7 +866,6 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
     if (task_id >= 0) {
         claim->task_id = task_id;
         claim->inbox_index = context->inbox_index;
-        claim->claim_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
         return true;
     }
 
@@ -897,13 +880,11 @@ inline __aicore__ bool scheduler_claim_ready_for_slot(
         scheduler_load_ready_directory_shard(directory, scheduler_count, core_type_index, context->inbox_index);
     if (bits != 0 && !scheduler_steal_ready_from_shard(
                          graph, scheduler_state_base, context, run_control, core_type_index, shard_begin, shard_end,
-                         start, bits, stats, claim, profiling_level
+                         start, bits, stats, claim
                      ))
         return false;
     const uint64_t cursor_base = claim->task_id >= 0 ? claim->inbox_index : start;
     *victim_cursor = cursor_base + 1 == shard_end ? shard_begin : cursor_base + 1;
-    if (claim->task_id >= 0) return true;
-    claim->claim_end_cycles = scheduler_phase_timing_enabled(profiling_level) ? scheduler_cycles() : 0;
     return true;
 }
 
@@ -932,18 +913,16 @@ inline __aicore__ void scheduler_initialize_free_slot(__gm__ SchedulerDispatchSl
 inline __aicore__ bool scheduler_fill_dispatch_slot(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *scheduler,
     __gm__ SchedulerRunControl *run_control, const SchedulerFreeSlotClaim &slot_claim,
-    const SchedulerReadyClaim &ready_claim, uint64_t profiling_level = 0, SchedulerDispatchFillTiming *timing = nullptr
+    const SchedulerReadyClaim &ready_claim, uint64_t profiling_level = 0
 ) {
     if (ready_claim.task_id < 0 || static_cast<uint64_t>(ready_claim.task_id) >= graph.task_count ||
         slot_claim.worker_id >= scheduler->runtime_worker_count ||
         slot_claim.slot_index >= SCHEDULER_PENDING_SLOT_COUNT)
         return false;
-    const bool record_timeline = timing != nullptr;
     const bool task_timing_enabled = scheduler_task_timing_enabled(profiling_level);
     const bool schedule_timing_enabled = scheduler_schedule_timing_enabled(profiling_level);
     const bool phase_timing_enabled = scheduler_phase_timing_enabled(profiling_level);
     const uint64_t dispatch_start_cycles = phase_timing_enabled ? scheduler_cycles() : 0;
-    uint64_t operation_start = record_timeline ? scheduler_cycles() : 0;
     __gm__ SchedulerTaskMetadata *metadata_source =
         scheduler_task_metadata_at(scheduler_state_base, scheduler, ready_claim.task_id);
     scheduler_observe_cache_line(metadata_source);
@@ -989,14 +968,9 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
     }
 
     slot->task_id = ready_claim.task_id;
-    slot->ready_inbox_index = ready_claim.inbox_index;
-    slot->claim_start_cycles = ready_claim.claim_start_cycles;
-    slot->claim_end_cycles = ready_claim.claim_end_cycles;
-    slot->claim_worker_id = scheduler->worker_index;
     slot->kernel_id = kernel_id;
     slot->subtask_slot = subtask_slot;
     slot->has_fanin = scheduler_task_has_fanin(metadata.flags) ? 1 : 0;
-    slot->ready_source = static_cast<uint8_t>(ready_claim.source);
     slot->pending_slot = static_cast<uint8_t>(slot_claim.slot_index);
     slot->generation = generation;
     slot->block_idx = 0;
@@ -1008,9 +982,6 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
 
     const uint64_t dispatch_payload_offset =
         target->dispatch_payload_offset + static_cast<uint64_t>(slot_claim.slot_index) * sizeof(DispatchPayload);
-
-    uint64_t operation_end = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) timing->prepare_cycles += operation_end - operation_start;
 
     SchedulerTaskInfo task{
         ready_claim.task_id,
@@ -1044,8 +1015,6 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
         );
         return false;
     }
-    uint64_t materialize_end = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) timing->materialize_cycles += materialize_end - operation_end;
     scheduler_publish_dispatch_payload(payload);
     __gm__ SchedulerTaskControl *control =
         scheduler_task_control_at(scheduler_state_base, scheduler, ready_claim.task_id);
@@ -1054,8 +1023,6 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
         control->ready_publish_cycles = scheduler_cycles();
         scheduler_publish_cache_line(&control->next_waiter);
     }
-    uint64_t publish_end = record_timeline ? scheduler_cycles() : 0;
-    if (timing != nullptr) timing->publish_cycles += publish_end - materialize_end;
     if (task_timing_enabled) {
         __gm__ SchedulerTaskTrace *traces =
             scheduler_state_at<SchedulerTaskTrace>(scheduler_state_base, scheduler->trace_cells_offset);
@@ -1064,10 +1031,11 @@ inline __aicore__ bool scheduler_fill_dispatch_slot(
         trace->task_id = static_cast<uint64_t>(ready_claim.task_id);
         if (phase_timing_enabled) {
             trace->ready_source = static_cast<uint64_t>(ready_claim.source);
-            trace->claim_worker_id = scheduler->worker_index;
-            trace->claim_start_cycles = ready_claim.claim_start_cycles;
-            trace->claim_end_cycles = ready_claim.claim_end_cycles;
-            trace->claim_loop_iter = scheduler->profiling_loop_iter;
+            trace->publication_mode = static_cast<uint64_t>(ready_claim.publication_mode);
+            trace->state_probe_scheduler_worker_id = scheduler->worker_index;
+            trace->state_probe_start_cycles = ready_claim.state_probe_start_cycles;
+            trace->state_probe_end_cycles =
+                ready_claim.state_probe_end_cycles == 0 ? dispatch_start_cycles : ready_claim.state_probe_end_cycles;
             trace->dispatch_start_cycles = dispatch_start_cycles;
             trace->dispatch_scheduler_worker_id = scheduler->worker_index;
             trace->dispatch_loop_iter = scheduler->profiling_loop_iter;
@@ -1086,8 +1054,7 @@ inline __aicore__ bool scheduler_resolve_completion(
     const SchedulerGraphView &graph, __gm__ void *scheduler_state_base, __gm__ SchedulerWorkerContext *context,
     __gm__ SchedulerRunControl *run_control, int64_t task_id, SchedulerWakeStats *wake_stats,
     SchedulerReadyStats *ready_stats, SchedulerCompletionStats *completion_stats,
-    __gm__ SchedulerReadyOwnerState *owner_state, uint64_t profiling_level = 0, bool validate_done_state = true,
-    uint64_t *ready_publish_cycles = nullptr
+    __gm__ SchedulerReadyOwnerState *owner_state, uint64_t profiling_level = 0, bool validate_done_state = true
 ) {
     if (owner_state == nullptr) return false;
     __gm__ SchedulerTaskControl *control = scheduler_task_control_at(scheduler_state_base, context, task_id);
@@ -1167,7 +1134,6 @@ inline __aicore__ bool scheduler_resolve_completion(
         }
         waiter = next;
     }
-    uint64_t ready_publish_start = ready_publish_cycles == nullptr ? 0 : scheduler_cycles();
     for (uint32_t type = 0; type < SCHEDULER_CORE_TYPE_COUNT; ++type) {
         if (!scheduler_ready_batch_push(
                 scheduler_state_base, context, type, context->inbox_index, &batches[type], ready_stats, owner_state
@@ -1179,7 +1145,6 @@ inline __aicore__ bool scheduler_resolve_completion(
             return false;
         }
     }
-    if (ready_publish_cycles != nullptr) *ready_publish_cycles += scheduler_cycles() - ready_publish_start;
     if (phase_timing_enabled) {
         control->completion_resolve_end_cycles = scheduler_cycles();
         scheduler_publish_cache_line(&control->next_waiter);

--- a/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/host_build_graph/runtime/scheduler/scheduler_types.h
@@ -668,6 +668,11 @@ enum class SchedulerReadySource : uint8_t {
     STOLEN = 1,
 };
 
+enum class SchedulerPublicationMode : uint8_t {
+    DISPATCH = 0,
+    REFILL = 1,
+};
+
 struct SchedulerIdleRecord {
     uint64_t start_time;
     uint64_t end_time;
@@ -916,14 +921,11 @@ struct alignas(128) SchedulerExecutorTaskTrace {
 // publication in the second line and owns the trailing trace payload.
 struct alignas(128) SchedulerDispatchSlot {
     int64_t task_id;
-    uint64_t ready_inbox_index;
-    uint64_t claim_start_cycles;
-    uint64_t claim_end_cycles;
-    uint64_t claim_worker_id;
+    uint64_t scheduler_metadata_reserved[4];
     uint16_t kernel_id;
     uint8_t subtask_slot;
     uint8_t has_fanin;
-    uint8_t ready_source;
+    uint8_t scheduler_metadata_byte_reserved;
     uint8_t pending_slot;
     uint16_t block_num;
     uint32_t generation;
@@ -1030,42 +1032,23 @@ struct alignas(128) SchedulerRunControl {
     uint64_t error_reserved[6];
 };
 
-struct alignas(128) AicpuCoreLifecycleTrace {
-    uint64_t worker_id;
+struct alignas(128) AicpuThreadLifecycleTrace {
     uint64_t aicpu_thread_id;
-    uint64_t core_type;
-    uint64_t physical_core_id;
-    uint64_t handshake_observed_cycles;
-    uint64_t handshake_partition_complete_cycles;
+    uint64_t handshake_start_cycles;
+    uint64_t handshake_complete_cycles;
     uint64_t config_start_cycles;
     uint64_t topology_complete_cycles;
+    uint64_t context_publish_start_cycles;
     uint64_t context_publish_complete_cycles;
     uint64_t bootstrap_wait_start_cycles;
     uint64_t bootstrap_complete_cycles;
-    uint64_t register_release_cycles;
-    uint64_t exit_signal_cycles;
-    uint64_t exit_ack_cycles;
-    uint64_t reserved[2];
-};
-
-struct alignas(128) SchedulerTailTrace {
-    volatile uint64_t valid;
-    uint64_t start_cycles;
-    uint64_t end_cycles;
-    uint64_t completion_scan_cycles;
-    uint64_t completion_consume_cycles;
-    uint64_t completion_resolve_cycles;
-    uint64_t completion_ready_publish_cycles;
-    uint64_t completion_refill_cycles;
-    uint64_t completion_finalize_cycles;
-    uint64_t gang_service_cycles;
-    uint64_t dispatch_probe_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t dispatch_claim_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t dispatch_prepare_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t dispatch_materialize_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t dispatch_publish_cycles[SCHEDULER_CORE_TYPE_COUNT];
-    uint64_t ready_poll_cycles;
-    uint64_t backoff_cycles;
+    uint64_t register_release_start_cycles;
+    uint64_t register_release_end_cycles;
+    uint64_t exit_signal_start_cycles;
+    uint64_t exit_signal_end_cycles;
+    uint64_t exit_wait_start_cycles;
+    uint64_t exit_wait_end_cycles;
+    uint64_t reserved;
 };
 
 struct alignas(128) SchedulerWorkerContext {
@@ -1107,8 +1090,7 @@ struct alignas(128) SchedulerWorkerContext {
     uint64_t target_bootstrap_end_cycles;
     uint64_t bootstrap_target_aic_cycles;
     uint64_t bootstrap_target_aiv_cycles;
-    uint64_t bootstrap_ready_claim_aic_cycles;
-    uint64_t bootstrap_ready_claim_aiv_cycles;
+    uint64_t bootstrap_timing_reserved[2];
 
     volatile uint64_t gang_coordinator_offset;
     volatile uint64_t gang_cohorts_offset;
@@ -1157,7 +1139,7 @@ struct alignas(128) SchedulerWorkerContext {
 
     uint64_t completion_enqueue_cycles;
     uint64_t bootstrap_start_cycles;
-    uint64_t bootstrap_end_cycles;
+    uint64_t bootstrap_end_reserved;
     uint64_t drain_start_cycles;
     uint64_t drain_end_cycles;
     uint64_t exit_wait_start_cycles;
@@ -1169,20 +1151,21 @@ struct alignas(128) SchedulerWorkerContext {
     uint64_t bootstrap_slot_fill_aiv_cycles;
     uint64_t termination_reserved[4];
 
-    SchedulerTailTrace scheduler_tail_trace;
+    // Preserve the shared wire layout after retiring the unconsumed
+    // Scheduler-tail profiling payload.
+    uint64_t scheduler_tail_reserved[32];
 };
 
 struct alignas(128) SchedulerTaskTrace {
     // Dispatch publishes this line before READY; completion publishes valid.
-    // Bootstrap owns only the fanin line and must not dirty this cache line.
     volatile uint64_t valid;
     uint64_t ready_source;
     uint64_t worker_id;
     uint64_t task_id;
-    uint64_t claim_worker_id;
-    uint64_t claim_start_cycles;
-    uint64_t claim_end_cycles;
-    uint64_t claim_loop_iter;
+    uint64_t state_probe_scheduler_worker_id;
+    uint64_t state_probe_start_cycles;
+    uint64_t state_probe_end_cycles;
+    uint64_t publication_mode;
 
     uint64_t kernel_start_cycles;
     uint64_t kernel_end_cycles;
@@ -1194,10 +1177,7 @@ struct alignas(128) SchedulerTaskTrace {
     uint64_t completion_inbox_index;
 
     uint64_t ready_transition_cycles;
-    uint64_t fanin_start_cycles;
-    uint64_t fanin_end_cycles;
-    uint64_t fanin_scheduler_worker_id;
-    uint64_t fanin_loop_iter;
+    uint64_t fanin_timing_reserved[4];
     uint64_t aicore_entry_cycles;
     uint64_t handshake_publish_cycles;
     uint64_t register_release_cycles;
@@ -1291,8 +1271,7 @@ static_assert(alignof(SchedulerRunControl) == 128, "run control alignment change
 static_assert(offsetof(SchedulerRunControl, executed_task_count) == 128, "lifecycle atomics need their own line");
 static_assert(offsetof(SchedulerRunControl, error_claimed) == 256, "error state needs its own line");
 static_assert(offsetof(SchedulerRunControl, error_site) == 328, "error site ABI changed");
-static_assert(sizeof(AicpuCoreLifecycleTrace) == 128, "AICPU lifecycle trace layout changed");
-static_assert(sizeof(SchedulerTailTrace) == 256, "scheduler tail trace layout changed");
+static_assert(sizeof(AicpuThreadLifecycleTrace) == 128, "AICPU lifecycle trace layout changed");
 static_assert(sizeof(SchedulerWorkerContext) == 1024, "worker context layout changed");
 static_assert(alignof(SchedulerWorkerContext) == 128, "worker context alignment changed");
 static_assert(offsetof(SchedulerWorkerContext, task_metadata_offset) == 128, "runtime offsets changed");
@@ -1300,7 +1279,7 @@ static_assert(offsetof(SchedulerWorkerContext, gang_coordinator_offset) == 256, 
 static_assert(offsetof(SchedulerWorkerContext, bootstrap_task_count) == 384, "worker stats offset changed");
 static_assert(offsetof(SchedulerWorkerContext, wake_cas_retry_count) == 512, "wake stats offset changed");
 static_assert(offsetof(SchedulerWorkerContext, completion_enqueue_cycles) == 640, "termination stats offset changed");
-static_assert(offsetof(SchedulerWorkerContext, scheduler_tail_trace) == 768, "scheduler tail trace offset changed");
+static_assert(offsetof(SchedulerWorkerContext, scheduler_tail_reserved) == 768, "worker reserved tail offset changed");
 static_assert(sizeof(SchedulerTaskTrace) == 384, "task trace layout changed");
 static_assert(
     offsetof(SchedulerTaskTrace, dispatch_start_cycles) % 64 == 0,
@@ -1354,9 +1333,11 @@ static_assert(
 static_assert(std::is_standard_layout_v<SchedulerDispatchSlot> && std::is_trivially_copyable_v<SchedulerDispatchSlot>);
 static_assert(std::is_standard_layout_v<SchedulerRunControl> && std::is_trivially_copyable_v<SchedulerRunControl>);
 static_assert(
+    std::is_standard_layout_v<AicpuThreadLifecycleTrace> && std::is_trivially_copyable_v<AicpuThreadLifecycleTrace>
+);
+static_assert(
     std::is_standard_layout_v<SchedulerWorkerContext> && std::is_trivially_copyable_v<SchedulerWorkerContext>
 );
-static_assert(std::is_standard_layout_v<SchedulerTailTrace> && std::is_trivially_copyable_v<SchedulerTailTrace>);
 static_assert(std::is_standard_layout_v<SchedulerTaskTrace> && std::is_trivially_copyable_v<SchedulerTaskTrace>);
 
 inline bool scheduler_layout_checked_add(uint64_t lhs, uint64_t rhs, uint64_t *out) {
@@ -1407,7 +1388,9 @@ inline bool scheduler_plan_layout(
     if (!scheduler_layout_reserve(
             &cursor, sizeof(SchedulerRunControl), alignof(SchedulerRunControl), &next.run_control_offset
         ) ||
-        !SCHEDULER_RESERVE_ARRAY(SCHEDULER_WORKER_CAPACITY, AicpuCoreLifecycleTrace, aicpu_lifecycle_traces_offset) ||
+        !SCHEDULER_RESERVE_ARRAY(
+            PLATFORM_MAX_AICPU_THREADS, AicpuThreadLifecycleTrace, aicpu_lifecycle_traces_offset
+        ) ||
         !SCHEDULER_RESERVE_ARRAY(SCHEDULER_WORKER_CAPACITY, SchedulerWorkerContext, worker_contexts_offset) ||
         !SCHEDULER_RESERVE_ARRAY(
             SCHEDULER_WORKER_CAPACITY * SCHEDULER_PENDING_SLOT_COUNT, DispatchPayload, dispatch_payloads_offset

--- a/tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
+++ b/tests/st/a5/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import json
+from collections import Counter
 
 import torch
 from simpler.task_interface import ArgDirection as D
@@ -100,7 +101,24 @@ class TestSchedulerPhases(SceneTestCase):
                 for core_id, reg_task_id, dispatch_cycles, finish_cycles in scheduler_rows:
                     aicore_row = aicore_by_key[(int(core_id), int(reg_task_id))]
                     assert 0 < dispatch_cycles <= aicore_row[3] <= aicore_row[4] <= finish_cycles
-                assert raw["aicpu_lifecycle_records"], "AICPU lifecycle records are missing"
+                lifecycle_records = raw["aicpu_lifecycle_records"]
+                assert lifecycle_records, "AICPU lifecycle records are missing"
+                thread_ids = [int(record["aicpu_thread_id"]) for record in lifecycle_records]
+                assert thread_ids == list(range(len(thread_ids)))
+                assert all("worker_id" not in record for record in lifecycle_records)
+                for record in lifecycle_records:
+                    assert 0 < record["handshake_start_cycles"] <= record["handshake_complete_cycles"]
+                    assert 0 < record["context_publish_start_cycles"] <= record["context_publish_complete_cycles"]
+                    assert 0 < record["bootstrap_wait_start_cycles"] <= record["bootstrap_complete_cycles"]
+                    assert 0 < record["register_release_start_cycles"] <= record["register_release_end_cycles"]
+                    assert 0 < record["exit_signal_start_cycles"] <= record["exit_signal_end_cycles"]
+                    assert 0 < record["exit_wait_start_cycles"] <= record["exit_wait_end_cycles"]
+                leader = lifecycle_records[0]
+                assert 0 < leader["config_start_cycles"] <= leader["topology_complete_cycles"]
+                assert all(
+                    record["config_start_cycles"] == record["topology_complete_cycles"] == 0
+                    for record in lifecycle_records[1:]
+                )
             else:
                 assert "scheduler_tasks" not in raw
                 assert "aicpu_lifecycle_records" not in raw
@@ -111,9 +129,48 @@ class TestSchedulerPhases(SceneTestCase):
                 assert all(stream["producer"] == "aicore" for stream in streams)
                 assert all(stream["capture"]["dropped"] == 0 for stream in streams)
                 emitted_kinds = {record["kind"] for stream in streams for record in stream["records"]}
-                required_kinds = {"bootstrap", "fanin", "dispatch", "complete", "resolve", "idle"}
+                required_kinds = {"bootstrap", "state_probe", "dispatch", "complete", "resolve", "refill", "idle"}
                 assert required_kinds <= emitted_kinds, (
                     f"missing Scheduler kinds: {sorted(required_kinds - emitted_kinds)}"
+                )
+                assert not ({"fanin", "ready_claim", "ready_steal", "direct_refill"} & emitted_kinds)
+                records = [record for stream in streams for record in stream["records"]]
+                launch_kinds = {"dispatch", "worksteal", "refill"}
+                launches_by_task = Counter(
+                    int(record["task_id"])
+                    for record in records
+                    if record["kind"] in launch_kinds and record["task_id"] is not None
+                )
+                assert set(launches_by_task) == {int(row[1]) for row in aicore_rows}
+                assert set(launches_by_task.values()) == {1}
+                probes_by_task = Counter(
+                    int(record["task_id"])
+                    for record in records
+                    if record["kind"] == "state_probe" and record["task_id"] is not None
+                )
+                assert probes_by_task == launches_by_task
+                for stream in streams:
+                    ordered = sorted(
+                        stream["records"],
+                        key=lambda record: (record["start_cycles"], record["end_cycles"]),
+                    )
+                    assert all(
+                        previous["end_cycles"] <= current["start_cycles"]
+                        for previous, current in zip(ordered, ordered[1:])
+                    )
+                probe_by_task = {
+                    int(record["task_id"]): record
+                    for record in records
+                    if record["kind"] == "state_probe" and record["task_id"] is not None
+                }
+                launch_by_task = {
+                    int(record["task_id"]): record
+                    for record in records
+                    if record["kind"] in launch_kinds and record["task_id"] is not None
+                }
+                assert all(
+                    probe_by_task[task_id]["end_cycles"] <= launch["start_cycles"]
+                    for task_id, launch in launch_by_task.items()
                 )
             else:
                 assert "scheduler_records" not in raw

--- a/tests/st/a5/host_build_graph/single_core_dag/test_single_core_dag.py
+++ b/tests/st/a5/host_build_graph/single_core_dag/test_single_core_dag.py
@@ -11,6 +11,7 @@
 
 import ctypes
 import json
+from collections import Counter
 
 import torch
 from simpler.task_interface import ArgDirection as D
@@ -132,13 +133,23 @@ class TestHbgSingleCoreDag(SceneTestCase):
             records = [record for stream in streams for record in stream["records"]]
             assert all(set(record) == record_fields for record in records)
             assert all(0 < record["start_cycles"] <= record["end_cycles"] for record in records)
-            required_kinds = {"bootstrap", "dispatch", "complete", "resolve", "idle"}
-            if case["params"]["graph_case"] != GRAPH_CASES["multi_root_64"][0]:
-                required_kinds.add("fanin")
+            required_kinds = {"bootstrap", "state_probe", "complete", "resolve", "idle"}
             emitted_kinds = {record["kind"] for record in records}
             assert required_kinds <= emitted_kinds, f"missing Scheduler kinds: {sorted(required_kinds - emitted_kinds)}"
             profiled_task_ids = {int(row[1]) for row in raw["aicore_tasks"]}
-            for kind in ("dispatch", "complete"):
+            launch_kinds = {"dispatch", "worksteal", "refill"}
+            launches_by_task = Counter(
+                int(record["task_id"])
+                for record in records
+                if record["kind"] in launch_kinds and record["task_id"] is not None
+            )
+            assert set(launches_by_task) == profiled_task_ids, (
+                "launch records do not cover every profiled task: "
+                f"missing={sorted(profiled_task_ids - set(launches_by_task))} "
+                f"unexpected={sorted(set(launches_by_task) - profiled_task_ids)}"
+            )
+            assert set(launches_by_task.values()) == {1}
+            for kind in ("state_probe", "complete"):
                 recorded_task_ids = {int(record["task_id"]) for record in records if record["kind"] == kind}
                 assert recorded_task_ids == profiled_task_ids, (
                     f"{kind} records do not cover every profiled task: "

--- a/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_contracts.cpp
@@ -172,6 +172,10 @@ TEST(SchedulerState, PlansAndInitializesReadyState) {
     EXPECT_EQ(layout.ready_owner_states_offset % alignof(SchedulerReadyOwnerState), 0u);
     EXPECT_EQ(layout.ready_directory_offset % alignof(SchedulerReadyDirectory), 0u);
     EXPECT_EQ(layout.completion_inboxes_offset % alignof(SchedulerCompletionInbox), 0u);
+    EXPECT_EQ(
+        layout.worker_contexts_offset - layout.aicpu_lifecycle_traces_offset,
+        static_cast<uint64_t>(PLATFORM_MAX_AICPU_THREADS) * sizeof(AicpuThreadLifecycleTrace)
+    );
 
     SchedulerStateBuffer storage(layout);
     auto *controls = scheduler_state_at<SchedulerTaskControl>(storage.base(), layout.task_controls_offset);

--- a/tests/ut/cpp/a5/test_hbg_scheduler_dispatch.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_dispatch.cpp
@@ -284,7 +284,7 @@ TEST(SchedulerClusterCompletion, SpscGenerationCompletesNormalTask) {
     SchedulerCompletionStats completion_stats{};
     ASSERT_TRUE(scheduler_service_cluster_completions(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &wake_stats, &ready_stats,
-        &completion_stats, nullptr, false, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index]
+        &completion_stats, nullptr, false, nullptr, &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(completion_line->completed_generations[0], 0u);
     EXPECT_EQ(scheduler_dispatch_state(slot->publication), SchedulerDispatchSlotState::FREE);
@@ -317,7 +317,7 @@ TEST(SchedulerClusterCompletion, RejectsStaleCompletionGenerationAtNamedSite) {
     SchedulerCompletionStats completion_stats{};
     EXPECT_FALSE(scheduler_service_cluster_completion_slot(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation + 1,
-        &wake_stats, &ready_stats, &completion_stats, nullptr, false, nullptr, nullptr, nullptr,
+        &wake_stats, &ready_stats, &completion_stats, nullptr, false, nullptr, nullptr,
         &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(
@@ -345,7 +345,7 @@ TEST(SchedulerClusterCompletion, RejectsUnexpectedGangSlotAtNamedSite) {
     SchedulerCompletionStats completion_stats{};
     EXPECT_FALSE(scheduler_service_cluster_completion_slot(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
-        &wake_stats, &ready_stats, &completion_stats, nullptr, false, nullptr, nullptr, nullptr,
+        &wake_stats, &ready_stats, &completion_stats, nullptr, false, nullptr, nullptr,
         &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(
@@ -362,7 +362,7 @@ TEST(SchedulerClusterCompletion, AccountsCompletedTaskWhenResolveFails) {
 
     EXPECT_FALSE(scheduler_service_cluster_completion_slot(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
-        nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr, nullptr, nullptr
+        nullptr, nullptr, nullptr, nullptr, 0, nullptr, nullptr, nullptr
     ));
     EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
     EXPECT_NE(storage.run_control->scheduler_error, 0u);
@@ -381,7 +381,7 @@ TEST(SchedulerClusterCompletion, AccountsCompletedTaskWhenRefillClaimFails) {
 
     EXPECT_FALSE(scheduler_service_cluster_completion_slot(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
-        nullptr, nullptr, nullptr, ready_victim_cursors, 0, nullptr, nullptr, nullptr, &owner_state
+        nullptr, nullptr, nullptr, ready_victim_cursors, 0, nullptr, nullptr, &owner_state
     ));
     EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
     EXPECT_NE(storage.run_control->scheduler_error, 0u);
@@ -401,8 +401,7 @@ TEST(SchedulerClusterCompletion, AccountsCompletedTaskWhenRefillDispatchFails) {
 
     EXPECT_FALSE(scheduler_service_cluster_completion_slot(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
-        nullptr, nullptr, nullptr, nullptr, 0, &replacement, nullptr, nullptr,
-        &storage.owner_states[scheduler.inbox_index]
+        nullptr, nullptr, nullptr, nullptr, 0, &replacement, nullptr, &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
     EXPECT_NE(storage.run_control->scheduler_error, 0u);
@@ -454,7 +453,7 @@ TEST(SchedulerClusterCompletion, PropagatesTraceToCompletionAndWokenTask) {
     SchedulerCompletionStats completion_stats{};
     ASSERT_TRUE(scheduler_service_cluster_completions(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &wake_stats, &ready_stats,
-        &completion_stats, nullptr, SCHEDULER_PROFILING_SCHED_PHASES_LEVEL, nullptr, nullptr,
+        &completion_stats, nullptr, SCHEDULER_PROFILING_SCHED_PHASES_LEVEL, nullptr,
         &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(producer->completion_resolve_start_cycles, 0u);
@@ -499,6 +498,7 @@ TEST(SchedulerClusterCompletion, DirectlyRefillsCompletedSlotWhenReadyTaskExists
     slot->task_id = 0;
     slot->subtask_slot = 0;
     slot->gang = 0;
+    slot->executor_trace.generation = completed_generation;
     scheduler_gm_store(
         slot->publication, scheduler_dispatch_publication(completed_generation, SchedulerDispatchSlotState::READY)
     );
@@ -522,7 +522,7 @@ TEST(SchedulerClusterCompletion, DirectlyRefillsCompletedSlotWhenReadyTaskExists
     uint64_t direct_refilled_slot_mask = 0;
     ASSERT_TRUE(scheduler_service_cluster_completions(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &wake_stats, &ready_stats,
-        &completion_stats, ready_victim_cursors, false, &direct_refilled_slot_mask, nullptr,
+        &completion_stats, ready_victim_cursors, SCHEDULER_PROFILING_SCHED_PHASES_LEVEL, &direct_refilled_slot_mask,
         &storage.owner_states[scheduler.inbox_index]
     ));
 
@@ -533,6 +533,47 @@ TEST(SchedulerClusterCompletion, DirectlyRefillsCompletedSlotWhenReadyTaskExists
     EXPECT_EQ(completed_control->state, static_cast<int64_t>(SchedulerTaskState::DONE));
     EXPECT_EQ(storage.run_control->resolved_task_count, 1u);
     EXPECT_EQ(direct_refilled_slot_mask, 1u);
+    auto *traces =
+        scheduler_state_at<SchedulerTaskTrace>(storage.scheduler_state->base(), storage.layout.trace_cells_offset);
+    EXPECT_EQ(traces[1].ready_source, static_cast<uint64_t>(SchedulerReadySource::LOCAL));
+    EXPECT_EQ(traces[1].publication_mode, static_cast<uint64_t>(SchedulerPublicationMode::REFILL));
+    EXPECT_LE(traces[1].state_probe_start_cycles, traces[1].state_probe_end_cycles);
+    EXPECT_EQ(traces[1].state_probe_end_cycles, traces[0].refill_start_cycles);
+}
+
+TEST(SchedulerClusterCompletion, DeferredRefillPreservesOriginalStateProbeAndReadySource) {
+    FixtureStorage storage(2, 3);
+    GraphBuffer graph(2);
+    graph.executable(0, 0);
+    graph.executable(1, 0);
+    storage.contexts[0].core_type = static_cast<int32_t>(CoreType::AIC);
+    SchedulerWorkerContext &scheduler = storage.contexts[1];
+    SchedulerDispatchSlot *slot = prepare_completed_normal_slot(storage, scheduler);
+    slot->executor_trace.generation = slot->generation;
+    auto *callables =
+        scheduler_state_at<uint64_t>(storage.scheduler_state->base(), storage.layout.callable_addresses_offset);
+    callables[1] = 0x1000;
+
+    SchedulerReadyClaim replacement{};
+    replacement.task_id = 1;
+    replacement.source = SchedulerReadySource::STOLEN;
+    replacement.state_probe_start_cycles = 123;
+    replacement.state_probe_end_cycles = 456;
+    bool refilled = false;
+
+    ASSERT_TRUE(scheduler_service_cluster_completion_slot(
+        graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, 0, 0, slot->generation,
+        nullptr, nullptr, nullptr, nullptr, SCHEDULER_PROFILING_SCHED_PHASES_LEVEL, &replacement, &refilled,
+        &storage.owner_states[scheduler.inbox_index]
+    ));
+
+    EXPECT_TRUE(refilled);
+    auto *traces =
+        scheduler_state_at<SchedulerTaskTrace>(storage.scheduler_state->base(), storage.layout.trace_cells_offset);
+    EXPECT_EQ(traces[1].ready_source, static_cast<uint64_t>(SchedulerReadySource::STOLEN));
+    EXPECT_EQ(traces[1].publication_mode, static_cast<uint64_t>(SchedulerPublicationMode::REFILL));
+    EXPECT_EQ(traces[1].state_probe_start_cycles, 123u);
+    EXPECT_EQ(traces[1].state_probe_end_cycles, 456u);
 }
 
 TEST(SchedulerNormalDispatch, FillsFreshAicSlot) {
@@ -565,7 +606,7 @@ TEST(SchedulerNormalDispatch, FillsFreshAicSlot) {
     uint64_t victim_cursors[SCHEDULER_CORE_TYPE_COUNT]{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index]
+        false, 0, nullptr, &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(slot->task_id, 0);
     EXPECT_EQ(scheduler_dispatch_state(slot->publication), SchedulerDispatchSlotState::READY);
@@ -610,7 +651,7 @@ TEST(SchedulerNormalDispatch, PreservesProgressWhenALaterFillFails) {
     bool failed = false;
     EXPECT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index], &failed
+        false, 0, nullptr, &storage.owner_states[scheduler.inbox_index], &failed
     ));
     EXPECT_TRUE(failed);
     auto *first_slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &scheduler, 0, 0);
@@ -638,7 +679,7 @@ TEST(SchedulerNormalDispatch, RejectsExcessAivWorkersAtNamedSite) {
     bool failed = false;
     EXPECT_FALSE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index], &failed
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index], &failed
     ));
     EXPECT_TRUE(failed);
     EXPECT_EQ(
@@ -659,7 +700,7 @@ TEST(SchedulerNormalDispatch, PublishesOrdinaryAivToPeerBeforeScheduler) {
     SchedulerDeferredAivQueue deferred{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index]
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index]
     ));
     auto *peer_slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &scheduler, 2, 0);
     EXPECT_EQ(peer_slot->task_id, 0);
@@ -683,7 +724,7 @@ TEST(SchedulerDeferredAiv, ReservesOnlyAvailableSchedulerSlotsBeforeClaiming) {
     SchedulerDeferredAivQueue deferred{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index]
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index]
     ));
 
     ASSERT_EQ(deferred.count, SCHEDULER_PENDING_SLOT_COUNT);
@@ -795,7 +836,7 @@ TEST(SchedulerDeferredAiv, DoesNotClaimWithoutSchedulerReservation) {
     bool failed = true;
     EXPECT_FALSE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index], &failed
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index], &failed
     ));
     EXPECT_FALSE(failed);
     EXPECT_EQ(deferred.count, 0u);
@@ -817,7 +858,7 @@ TEST(SchedulerDeferredAiv, KeepsReservationForSchedulerWhenNoPeerIsActive) {
     SchedulerDeferredAivQueue deferred{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index]
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index]
     ));
     ASSERT_EQ(deferred.count, 1u);
 
@@ -825,7 +866,7 @@ TEST(SchedulerDeferredAiv, KeepsReservationForSchedulerWhenNoPeerIsActive) {
     SchedulerCompletionStats completion_stats{};
     EXPECT_TRUE(scheduler_drain_deferred_aiv_to_peer(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &deferred, &wake_stats,
-        &ready_stats, &completion_stats, false, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index]
+        &ready_stats, &completion_stats, false, &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(deferred.count, 1u);
 
@@ -852,7 +893,7 @@ TEST(SchedulerDeferredAiv, PrefersNewPeerCapacityAndSelfPublishesOnlyOne) {
     SchedulerDeferredAivQueue deferred{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index]
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index]
     ));
     ASSERT_EQ(deferred.count, 2u);
     const SchedulerFreeSlotClaim first_reservation = deferred.entries[0].reserved_slot;
@@ -866,7 +907,7 @@ TEST(SchedulerDeferredAiv, PrefersNewPeerCapacityAndSelfPublishesOnlyOne) {
     SchedulerCompletionStats completion_stats{};
     ASSERT_TRUE(scheduler_drain_deferred_aiv_to_peer(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &deferred, &wake_stats,
-        &ready_stats, &completion_stats, false, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index]
+        &ready_stats, &completion_stats, false, &storage.owner_states[scheduler.inbox_index]
     ));
     ASSERT_EQ(deferred.count, 1u);
     EXPECT_EQ(scheduler_dispatch_state(peer_slot->publication), SchedulerDispatchSlotState::READY);
@@ -900,7 +941,7 @@ TEST(SchedulerDeferredAiv, KeepsSecondReservationAfterOneSelfPublish) {
     SchedulerDeferredAivQueue deferred{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index]
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index]
     ));
     ASSERT_EQ(deferred.count, 2u);
 
@@ -938,7 +979,7 @@ TEST(SchedulerDeferredAiv, RetiresCompletedPeerAndRefillsWithoutFreeDecision) {
     SchedulerDeferredAivQueue deferred{};
     ASSERT_TRUE(scheduler_fill_cluster_normal_slots(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, victim_cursors, &ready_stats,
-        false, 0, nullptr, &deferred, &storage.owner_states[scheduler.inbox_index]
+        false, 0, &deferred, &storage.owner_states[scheduler.inbox_index]
     ));
     ASSERT_EQ(deferred.count, 1u);
     auto *peer_slot = scheduler_dispatch_slot_at(storage.scheduler_state->base(), &scheduler, 2, 0);
@@ -950,7 +991,7 @@ TEST(SchedulerDeferredAiv, RetiresCompletedPeerAndRefillsWithoutFreeDecision) {
     SchedulerCompletionStats completion_stats{};
     ASSERT_TRUE(scheduler_drain_deferred_aiv_to_peer(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &deferred, &wake_stats,
-        &ready_stats, &completion_stats, false, nullptr, nullptr, &storage.owner_states[scheduler.inbox_index]
+        &ready_stats, &completion_stats, false, &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(deferred.count, 0u);
     EXPECT_EQ(completion_line->completed_generations[0], 0u);
@@ -983,7 +1024,7 @@ TEST(SchedulerDeferredAiv, SchedulerCompletionDoesNotDirectRefillItself) {
     uint64_t direct_refilled_slot_mask = 0;
     ASSERT_TRUE(scheduler_service_cluster_completions(
         graph.graph(), storage.scheduler_state->base(), &scheduler, storage.run_control, &wake_stats, &ready_stats,
-        &completion_stats, victim_cursors, false, &direct_refilled_slot_mask, nullptr,
+        &completion_stats, victim_cursors, false, &direct_refilled_slot_mask,
         &storage.owner_states[scheduler.inbox_index]
     ));
     EXPECT_EQ(direct_refilled_slot_mask, 0u);

--- a/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
+++ b/tests/ut/cpp/a5/test_hbg_scheduler_ready.cpp
@@ -228,8 +228,9 @@ TEST(SchedulerProfilingLevel, DispatchWritesTaskIdentityBeforePhaseDetails) {
         storage.contexts[1].core_type = static_cast<int32_t>(CoreType::AIC);
         SchedulerReadyClaim ready_claim{};
         ready_claim.task_id = 0;
-        ready_claim.claim_start_cycles = 123;
-        ready_claim.claim_end_cycles = 456;
+        ready_claim.source = SchedulerReadySource::STOLEN;
+        ready_claim.state_probe_start_cycles = 100;
+        ready_claim.state_probe_end_cycles = 123;
 
         ASSERT_TRUE(scheduler_fill_dispatch_slot(
             graph.graph(), storage.scheduler_state->base(), &storage.contexts[1], storage.run_control,
@@ -239,8 +240,21 @@ TEST(SchedulerProfilingLevel, DispatchWritesTaskIdentityBeforePhaseDetails) {
             scheduler_state_at<SchedulerTaskTrace>(storage.scheduler_state->base(), storage.layout.trace_cells_offset);
         EXPECT_EQ(traces[0].worker_id, level == 0 ? 0u : storage.contexts[1].worker_index);
         EXPECT_EQ(traces[0].task_id, 0u);
-        EXPECT_EQ(traces[0].claim_start_cycles, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? 123u : 0u);
-        EXPECT_EQ(traces[0].claim_end_cycles, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? 456u : 0u);
+        EXPECT_EQ(
+            traces[0].state_probe_scheduler_worker_id,
+            level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? storage.contexts[1].worker_index : 0u
+        );
+        EXPECT_EQ(traces[0].state_probe_start_cycles, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? 100u : 0u);
+        EXPECT_EQ(traces[0].state_probe_end_cycles, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? 123u : 0u);
+        EXPECT_EQ(
+            traces[0].ready_source,
+            level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ? static_cast<uint64_t>(SchedulerReadySource::STOLEN) : 0u
+        );
+        EXPECT_EQ(
+            traces[0].publication_mode, level >= SCHEDULER_PROFILING_SCHED_PHASES_LEVEL ?
+                                            static_cast<uint64_t>(SchedulerPublicationMode::DISPATCH) :
+                                            0u
+        );
     }
 }
 
@@ -1209,7 +1223,7 @@ TEST(SchedulerReadyWake, WakeResolveQueuesBehindOlderPublishedWork) {
     controls[0].state = static_cast<int64_t>(SchedulerTaskState::DONE);
     ASSERT_TRUE(scheduler_resolve_completion(
         graph.graph(), storage.scheduler_state->base(), &storage.contexts[0], storage.run_control, 0, &wake, &ready,
-        &completion, &owner_state, false, true, nullptr
+        &completion, &owner_state, false, true
     ));
     EXPECT_EQ(completion.resolve_count, 1u);
     EXPECT_EQ(scheduler_ready_pending_head(owner_state.queues[0].pending_endpoints), 1);

--- a/tests/ut/py/test_containment.py
+++ b/tests/ut/py/test_containment.py
@@ -299,7 +299,7 @@ def test_the_extent_counts_every_record_the_converter_draws():
     assert with_receive.extent == (1_800, 2_200)
 
     with_lifecycle = containment.capture_windows(
-        _capture(aicpu_lifecycle_records=[{"worker_id": 0, "exit_ack_cycles": 3_400}])
+        _capture(aicpu_lifecycle_records=[{"aicpu_thread_id": 0, "exit_wait_end_cycles": 3_400}])
     )
     assert with_lifecycle.extent == (1_900, 3_400)
 
@@ -307,7 +307,7 @@ def test_the_extent_counts_every_record_the_converter_draws():
 def test_a_record_outside_the_run_wall_is_caught_rather_than_drawn_outside_it():
     """The join is what enforces containment, so the extent has to feed it."""
     capture = containment.capture_windows(
-        _capture(aicpu_lifecycle_records=[{"worker_id": 0, "exit_ack_cycles": 9_000}])
+        _capture(aicpu_lifecycle_records=[{"aicpu_thread_id": 0, "exit_wait_end_cycles": 9_000}])
     )
 
     with pytest.raises(containment.ContainmentError, match="do not overlap"):

--- a/tests/ut/py/test_sched_overhead_analysis.py
+++ b/tests/ut/py/test_sched_overhead_analysis.py
@@ -349,6 +349,38 @@ def test_parse_scheduler_classifies_release_as_scheduler_work():
     assert threads[0]["phases_seen"] == {"release", "resolve"}
 
 
+def test_parse_scheduler_counts_aicore_flat_dispatch_phases():
+    data = {
+        "aicpu_scheduler_phases": [
+            [
+                {"phase": "complete", "start_time_us": 1.0, "end_time_us": 2.0, "loop_iter": 1},
+                {"phase": "resolve", "start_time_us": 2.0, "end_time_us": 3.0, "loop_iter": 1},
+                {"phase": "state_probe", "start_time_us": 3.0, "end_time_us": 4.0, "loop_iter": 1},
+                {"phase": "dispatch", "start_time_us": 4.0, "end_time_us": 5.0, "loop_iter": 1},
+                {"phase": "worksteal", "start_time_us": 5.0, "end_time_us": 6.0, "loop_iter": 1},
+                {"phase": "refill", "start_time_us": 6.0, "end_time_us": 7.0, "loop_iter": 1},
+            ]
+        ]
+    }
+
+    threads = parse_scheduler_from_json_phases(data)
+
+    assert threads[0]["role"] == "scheduler"
+    assert threads[0]["state_probe_us"] == 1.0
+    assert threads[0]["dispatch_us"] == 1.0
+    assert threads[0]["worksteal_us"] == 1.0
+    assert threads[0]["refill_us"] == 1.0
+    assert threads[0]["total_us"] == 6.0
+    assert threads[0]["phases_seen"] == {
+        "complete",
+        "resolve",
+        "state_probe",
+        "dispatch",
+        "worksteal",
+        "refill",
+    }
+
+
 def test_parse_scheduler_uses_explicit_hbg_resolve_discriminator_at_parent_boundary():
     data = {
         "aicpu_scheduler_phases": [

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -401,11 +401,9 @@ def test_l3_directory_merge_keeps_scheduler_streams_and_lifecycle_records(tmp_pa
         }
         records["aicpu_lifecycle_records"] = [
             {
-                "worker_id": rank + 4,
                 "aicpu_thread_id": rank,
-                "core_type": "aiv",
-                "physical_core_id": rank,
-                "register_release_cycles": device_base + 600,
+                "register_release_start_cycles": device_base + 600,
+                "register_release_end_cycles": device_base + 650,
             }
         ]
         records_path.write_text(json.dumps(records))
@@ -817,20 +815,21 @@ def test_aicore_scheduler_records_keep_common_shape_and_stream_metadata(tmp_path
                 },
                 "aicpu_lifecycle_records": [
                     {
-                        "worker_id": 6,
                         "aicpu_thread_id": 1,
-                        "core_type": "aiv",
-                        "physical_core_id": 9,
-                        "handshake_observed_cycles": 90,
-                        "handshake_partition_complete_cycles": 91,
+                        "handshake_start_cycles": 90,
+                        "handshake_complete_cycles": 91,
                         "config_start_cycles": 92,
                         "topology_complete_cycles": 93,
+                        "context_publish_start_cycles": 93,
                         "context_publish_complete_cycles": 94,
                         "bootstrap_wait_start_cycles": 95,
                         "bootstrap_complete_cycles": 96,
-                        "register_release_cycles": 97,
-                        "exit_signal_cycles": 181,
-                        "exit_ack_cycles": 182,
+                        "register_release_start_cycles": 97,
+                        "register_release_end_cycles": 98,
+                        "exit_signal_start_cycles": 181,
+                        "exit_signal_end_cycles": 182,
+                        "exit_wait_start_cycles": 183,
+                        "exit_wait_end_cycles": 184,
                     }
                 ],
                 "scheduler_records": {
@@ -880,7 +879,7 @@ def test_aicore_scheduler_records_keep_common_shape_and_stream_metadata(tmp_path
     assert data["scheduler_streams"][0]["producer"] == "aicore"
     assert data["scheduler_records"][0][0]["claim_retries"] == 2
     assert data["scheduler_records"][0][1]["task_id"] is None
-    assert data["aicpu_lifecycle_records"][0]["register_release_time_us"] == pytest.approx(0.007)
+    assert data["aicpu_lifecycle_records"][0]["register_release_start_time_us"] == pytest.approx(0.007)
 
     trace_path = tmp_path / "merged_swimlane.json"
     sc.generate_chrome_trace_json(
@@ -895,10 +894,13 @@ def test_aicore_scheduler_records_keep_common_shape_and_stream_metadata(tmp_path
         event.get("name") == "process_name" and event.get("args", {}).get("name") == "AICore Scheduler"
         for event in events
     )
-    assert any(event.get("cat") == "scheduler" and event.get("name") == "idle(0)" for event in events)
+    assert any(event.get("cat") == "scheduler" and event.get("name") == "idle" for event in events)
     assert any(
         event.get("name") == "process_name" and event.get("args", {}).get("name") == "AICPU Lifecycle"
         for event in events
+    )
+    assert any(
+        event.get("name") == "thread_name" and event.get("args", {}).get("name") == "AICPU Thread 1" for event in events
     )
     assert any(event.get("cat") == "aicpu_lifecycle" and event.get("name") == "bootstrap_wait" for event in events)
 
@@ -1145,10 +1147,9 @@ def test_lifecycle_interval_can_start_at_relative_time_origin(tmp_path):
         str(trace_path),
         aicpu_lifecycle_records=[
             {
-                "worker_id": 0,
                 "aicpu_thread_id": 1,
-                "handshake_observed_time_us": 0.0,
-                "handshake_partition_complete_time_us": 2.0,
+                "handshake_start_time_us": 0.0,
+                "handshake_complete_time_us": 2.0,
             }
         ],
     )
@@ -1167,13 +1168,19 @@ def test_lifecycle_register_release_can_be_at_relative_time_origin(tmp_path):
                 "chip_swimlane_level": 1,
                 "metadata": {"clock_freq_hz": 1_000_000_000, "num_cores": 1, "core_types": ["aiv"]},
                 "aicore_tasks": [[0, 7, 7, 120, 180, 10]],
-                "aicpu_lifecycle_records": [{"worker_id": 0, "register_release_cycles": 90}],
+                "aicpu_lifecycle_records": [
+                    {
+                        "aicpu_thread_id": 0,
+                        "register_release_start_cycles": 90,
+                        "register_release_end_cycles": 91,
+                    }
+                ],
             }
         )
     )
 
     data = sc.read_perf_data(raw)
-    assert data["aicpu_lifecycle_records"][0]["register_release_time_us"] == 0.0
+    assert data["aicpu_lifecycle_records"][0]["register_release_start_time_us"] == 0.0
 
     trace_path = tmp_path / "merged_swimlane.json"
     sc.generate_chrome_trace_json(
@@ -1192,7 +1199,7 @@ def test_lifecycle_omits_missing_register_release(tmp_path):
     sc.generate_chrome_trace_json(
         [],
         str(trace_path),
-        aicpu_lifecycle_records=[{"worker_id": 0}],
+        aicpu_lifecycle_records=[{"aicpu_thread_id": 0}],
     )
 
     events = json.loads(trace_path.read_text())["traceEvents"]
@@ -1791,6 +1798,91 @@ def test_tmr_nested_resolve_stays_on_scheduler_sublane(tmp_path):
     resolve = next(event for event in events if event.get("name") == "resolve(0)")
     assert complete["tid"] == 30000
     assert resolve["tid"] == 30001
+
+
+def test_aicore_scheduler_uses_one_lane_and_display_names(tmp_path):
+    out = tmp_path / "trace.json"
+    scheduler_phases = [
+        [
+            {
+                "phase": "complete",
+                "start_time_us": 1.0,
+                "end_time_us": 4.0,
+                "tasks_processed": 1,
+                "task_id": 23,
+            },
+            {
+                "phase": "resolve",
+                "start_time_us": 2.0,
+                "end_time_us": 3.0,
+                "tasks_processed": 1,
+                "task_id": 23,
+            },
+            {
+                "phase": "state_probe",
+                "start_time_us": 4.0,
+                "end_time_us": 5.0,
+                "tasks_processed": 1,
+                "task_id": 5,
+            },
+            {
+                "phase": "dispatch",
+                "start_time_us": 5.0,
+                "end_time_us": 6.0,
+                "tasks_processed": 1,
+                "task_id": 5,
+            },
+            {
+                "phase": "worksteal",
+                "start_time_us": 6.0,
+                "end_time_us": 7.0,
+                "tasks_processed": 1,
+                "task_id": 7,
+            },
+            {
+                "phase": "refill",
+                "start_time_us": 7.0,
+                "end_time_us": 8.0,
+                "tasks_processed": 1,
+                "task_id": 9,
+            },
+        ]
+    ]
+    scheduler_streams = [
+        {
+            "producer": "aicore",
+            "scheduler_id": 4,
+            "worker_id": 36,
+            "core_type": "aiv",
+            "physical_core_id": 26,
+        }
+    ]
+
+    sc.generate_chrome_trace_json(
+        [], str(out), scheduler_phases=scheduler_phases, scheduler_streams=scheduler_streams, core_to_thread=[0]
+    )
+
+    events = json.loads(out.read_text())["traceEvents"]
+    scheduler_metadata = [
+        event
+        for event in events
+        if event.get("ph") == "M"
+        and event.get("pid") == 2
+        and event.get("name") == "thread_name"
+        and event.get("tid") != 3999
+    ]
+    assert [(event["tid"], event["args"]["name"]) for event in scheduler_metadata] == [(30000, "Scheduler_26")]
+    phases = [event for event in events if event.get("cat") == "scheduler"]
+    assert {event["tid"] for event in phases} == {30000}
+    assert [event["name"] for event in phases] == [
+        "Completion(t23)",
+        "Resolve(t23)",
+        "StateProbe(t5)",
+        "Dispatch(t5)",
+        "Worksteal(t7)",
+        "Refill(t9)",
+    ]
+    assert [event["args"]["task_id"] for event in phases] == [23, 23, 5, 5, 7, 9]
 
 
 def test_complete_flow_worker_view_only_without_scheduler_phases(tmp_path):


### PR DESCRIPTION
## Problem

The A5 host-build-graph profiling schema still reflected implementation-detail claim timing and per-worker AICPU lifecycle records. This made deferred Scheduler work hard to interpret, produced misleading lane identities, and did not match the final flat swimlane model.

## The change

- Emit flat, non-overlapping per-task Scheduler phases: Completion, Resolve, StateProbe, and one publication phase: Dispatch, Worksteal, or Refill.
- Preserve the original StateProbe start for deferred tasks. StateProbe covers local Ready selection or stealing and ends before deferred waiting; the later publication is recorded independently.
- Label Scheduler lanes with the physical AIV ID, for example Scheduler 26, and label task phases with the actual task ID, for example StateProbe(t23).
- Collect AICPU Lifecycle directly per AICPU thread instead of duplicating it per Scheduler worker. The merged swimlane now shows AICPU Thread 0 through AICPU Thread 4.
- Remove obsolete claim timestamps plus unconsumed fanin, bootstrap-end, and Scheduler-tail profiling data and its aggregation work. Reserved fields retain the existing shared cache-line and structure layout where required.
- Use `PLATFORM_MAX_AICPU_THREADS` consistently for the new lifecycle buffer layout, invalidation, collection, and tests.
- Keep `fanin` and the former claim phases accepted only for old captures, and document that a stolen task published through a completed Slot remains Refill.
- Add A5 Bootstrap to the public phase taxonomy and update shared DFX consumers, documentation, and tests for the new schema.

## Semantics

For a deferred task, StateProbe begins at the original scheduling decision and ends after Ready selection or stealing, before the task waits for publication capacity. Dispatch, Worksteal, or Refill starts only when the task is actually published. Completion and Resolve remain separate phases. A refill is classified by completed-Slot reuse, so a task with a stolen Ready source is still displayed as Refill when published through that path.

## Correctness and scope

- Runtime changes are limited to A5 host-build-graph profiling.
- A2/A3 and TMR runtime behavior is unchanged.
- Shared DFX changes recognize and render the A5 records without changing TMR lane behavior.
- Scheduler shared structure sizes, alignment, and critical offsets remain guarded by compile-time tests.
- Test code remains compatible with the projects declared Python 3.9 baseline.

## Reviewer guide

- Check StateProbe and deferred publication boundaries in scheduler_ready.h, scheduler_dispatch.h, and scheduler_completion.h.
- Check task and lifecycle serialization in runtime_maker.cpp.
- Check physical AIV lane naming, task labels, and AICPU thread lanes in swimlane_converter.py.
- Check reserved layout substitutions and retired profiling storage in scheduler_types.h.

## Testing

Post-review cleanup validation on the current head:

- [x] Focused A5 HBG Scheduler C++ unit tests: 3 passed
- [x] Swimlane converter Python unit tests: 72 passed
- [x] Clang-format, Ruff formatting/lint, and git diff --check: passed
- [ ] CI rerun: in progress

Original PR validation before the review cleanup:

- [x] Editable package rebuild: pip install --no-build-isolation -e .
- [x] Python DFX unit tests: 119 passed
- [x] Full C++ non-hardware unit suite: 140 passed
- [x] A5 simulator Level 4 scheduler-phase test: passed
- [x] A5 hardware Level 4 scheduler-phase test on Ascend 950: passed
- [x] Hardware trace audit: 5 AICPU thread records, physical Scheduler lane IDs, task-ID phase labels, zero dropped Scheduler records, and zero Scheduler/Lifecycle lane overlaps
