### PR TITLE
Refactor: make host_build_graph AICPU threads symmetric

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -338,11 +338,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             LOG_ERROR("Thread %d: rt is null after a failed boot, skipping dispatch", thread_idx);
         } else {
             sched_ctx_.bind_runtime(rt);
-            // 3S+1P: the last thread is the core-less resolution (P) thread; the
-            // rest are core-owning schedulers (S).
-            int32_t completed = (thread_idx == sched_ctx_.p_thread_idx()) ?
-                                    sched_ctx_.run_resolution_thread(runtime, thread_idx) :
-                                    sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
+            int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
             if (completed < 0) {
                 LOG_ERROR("Thread %d: Scheduler failed with rc=%d", thread_idx, completed);
                 run_rc = completed;

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -137,7 +137,7 @@ read. `RuntimeContext` therefore holds a *pointer* to it, wired from
 region arrives holding the pooled allocation's previous generation, so every
 field the dispatch loop reads before anything writes it needs a value from
 `init_data_from_layout`: the queue headers, and `AsyncWaitList`'s `busy` and
-`count`. A residual `count` is the length the resolution thread's poll walks
+`count`. A residual `count` is the length a polling thread walks
 `entries` by, so it reads past the region and faults on an address that belongs
 to no mapping (issue #2121); a residual `busy` is the same miss inverted, making
 every drain a no-op and stranding deferred completions.

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_cold_path.cpp
@@ -729,20 +729,20 @@ bool SchedulerContext::assign_cores_to_threads() {
     // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
     // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
     //
-    // 3S+1P: the last AICPU thread is the core-less resolution thread (P); cores
-    // partition across the remaining (aicpu_thread_num_ - 1) scheduler threads
-    // only, so P never owns a cluster and never polls a COND register. P is
-    // mandatory — like tmr's scheduler + orchestrator split, host_build_graph
-    // needs at least two AICPU threads (one S + one P); one thread cannot own
-    // cores and resolve on a dedicated thread at once.
-    if (aicpu_thread_num_ < 2) {
-        LOG_ERROR(
-            "host_build_graph requires aicpu_thread_num >= 2 (1 scheduler + 1 resolution); got %d", aicpu_thread_num_
-        );
+    // Symmetric threads: every AICPU thread owns clusters, polls their COND
+    // registers and resolves the completions it observes. Cores therefore
+    // partition across all of them, and one thread is a valid configuration —
+    // there is no core-less resolution thread to reserve.
+    //
+    // Polling a core's COND is a Device-nGnRE load that cannot pipeline against
+    // another (~95 ns each, serialised by the nR attribute), so a thread's
+    // FIN-detection round costs clusters_owned x lanes x ~95 ns. Spreading the
+    // same clusters over more threads is the only way to shorten that round.
+    if (aicpu_thread_num_ < 1) {
+        LOG_ERROR("host_build_graph requires aicpu_thread_num >= 1; got %d", aicpu_thread_num_);
         return false;
     }
-    p_thread_idx_ = aicpu_thread_num_ - 1;
-    active_sched_threads_ = aicpu_thread_num_ - 1;
+    active_sched_threads_ = aicpu_thread_num_;
     int32_t cluster_count = aic_count_;
 
     // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
@@ -1058,22 +1058,8 @@ void SchedulerContext::bind_runtime(RuntimeContext *rt) {
 void SchedulerContext::on_graph_attached(RuntimeContext *rt, [[maybe_unused]] int32_t thread_idx, int32_t total_tasks) {
     total_tasks_ = total_tasks;
 
-    // Allocate the per-S CompletedTaskQueues here on the boot leader, before it
-    // releases runtime_init_ready_ — no scheduler thread can push until then.
-    // Completed-but-unresolved tasks in flight are bounded by the run's task count
-    // (a task must have been submitted to run and complete), so size to that,
-    // rounded up to a power of two and floored at 256. That bound is exact, so
-    // there is no artificial ceiling and a producer never has to spin on a full
-    // queue.
-    uint64_t sp_bound = static_cast<uint64_t>(total_tasks);
-    uint64_t sp_cap = 256;
-    while (sp_cap < sp_bound) {
-        sp_cap <<= 1;
-    }
-    for (int32_t t = 0; t < active_sched_threads_; t++) {
-        sp_queues_[t].destroy();  // free a prior run's buffer before re-alloc
-        sp_queues_[t].init(sp_cap);
-    }
+    // No S->P completion transport: the thread that observes a FIN resolves it,
+    // so there is nothing to hand off and nothing to size here.
 
     // Fold tasks completed inline during orchestration
     int32_t inline_completed = static_cast<int32_t>(rt->inline_completed_tasks);

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_completion.cpp
@@ -80,7 +80,7 @@ SlotTransition SchedulerContext::decide_slot_transition(
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
     ChipTaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] SubtaskSlot subslot,
-    int32_t thread_idx, int32_t core_id, Handshake *hank, [[maybe_unused]] int32_t &completed_this_turn
+    [[maybe_unused]] int32_t thread_idx, int32_t core_id, Handshake *hank, int32_t &completed_this_turn
 #if SIMPLER_DFX
     ,
     uint64_t dispatch_ts, uint64_t finish_ts
@@ -188,12 +188,31 @@ void SchedulerContext::complete_slot_task(
             );
         }
 #endif
-        // 3S+1P: hand the finished task to the dedicated resolution (P) thread.
-        // P publishes task_states and drains the wake list — and owns
-        // completed_tasks_, so this scheduler thread neither
-        // resolves nor bumps completed_this_turn. (The Resolve swimlane bar is
-        // emitted by P, not here.)
-        sp_queues_[thread_idx].push(&slot_state);
+        // The thread that observed the FIN resolves it, here, inline: publish
+        // the completion flag and drain the wake list. There is no hand-off hop
+        // and no dedicated resolver, so completed_this_turn is bumped on this
+        // thread and feeds the caller's completed_tasks_ accounting.
+        //
+        // Concurrent resolvers are safe by construction: the wake-list detach is
+        // an exchange onto a terminal sentinel (exactly one thread walks a given
+        // producer's list), register_wake is a CAS loop that re-classifies when
+        // it loses to that sentinel, and the ready queues are MPMC.
+#if SIMPLER_SCHED_PROFILING
+        SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(slot_state, thread_idx);
+#else
+        SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(slot_state);
+#endif
+        if (outcome.error_code != SIMPLER_ERROR_NONE) {
+            // No Runtime* reaches this far, so latch the code the way the slab
+            // errors above do; the dispatch loop raises it on its next turn.
+            int32_t expected = SIMPLER_ERROR_NONE;
+            sched_->sm_header->sched_error_code.compare_exchange_strong(
+                expected, outcome.error_code, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+            completed_.store(true, std::memory_order_release);
+            return;
+        }
+        completed_this_turn += outcome.stream_tasks_completed;
 #if SIMPLER_DFX
         chip_swimlane.phase_complete_count++;
 #endif

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_context.h
@@ -38,58 +38,6 @@ class Runtime;
 struct Handshake;
 struct RuntimeContext;
 
-// SPSC ring carrying completed-but-unresolved task slots from one scheduler (S)
-// thread to the dedicated resolution (P) thread. Whole-graph-resident hbg never
-// reclaims a slot, so the queued ChipTaskSlotState* stays valid until P reads it.
-// Single producer (the owning S thread) / single consumer (P): plain
-// acquire/release on head/tail, no CAS. Capacity is a power of two sized to the
-// run's task count, which bounds the completed-but-unresolved tasks in flight
-// exactly, so a producer does not spin on a full queue in practice; the spin is a
-// correctness backstop only
-// (P drains independently, so it always makes progress). The std::atomic cursors
-// make this type non-copyable / non-movable, so `buf` cannot be double-freed
-// through an accidental copy.
-struct CompletedTaskQueue {
-    ChipTaskSlotState **buf{nullptr};
-    uint64_t cap{0};
-    uint64_t mask{0};
-    alignas(64) std::atomic<uint64_t> head{0};  // consumer (P) cursor
-    alignas(64) std::atomic<uint64_t> tail{0};  // producer (S) cursor
-
-    void init(uint64_t capacity_pow2) {
-        debug_assert(capacity_pow2 != 0 && (capacity_pow2 & (capacity_pow2 - 1)) == 0);
-        cap = capacity_pow2;
-        mask = capacity_pow2 - 1;
-        buf = new ChipTaskSlotState *[capacity_pow2];
-        head.store(0, std::memory_order_relaxed);
-        tail.store(0, std::memory_order_relaxed);
-    }
-    void destroy() {
-        delete[] buf;
-        buf = nullptr;
-    }
-    // Producer (S). Spins only if the ring is full — sized so this never fires.
-    void push(ChipTaskSlotState *s) {
-        uint64_t t = tail.load(std::memory_order_relaxed);
-        while (t - head.load(std::memory_order_acquire) >= cap) {
-            SPIN_WAIT_HINT();
-        }
-        buf[t & mask] = s;
-        tail.store(t + 1, std::memory_order_release);
-    }
-    // Consumer (P). Returns nullptr when empty.
-    ChipTaskSlotState *pop() {
-        uint64_t h = head.load(std::memory_order_relaxed);
-        if (h == tail.load(std::memory_order_acquire)) {
-            return nullptr;
-        }
-        ChipTaskSlotState *s = buf[h & mask];
-        head.store(h + 1, std::memory_order_release);
-        return s;
-    }
-    uint64_t size() const { return tail.load(std::memory_order_acquire) - head.load(std::memory_order_acquire); }
-};
-
 class SchedulerContextTestPeer;
 
 /**
@@ -139,16 +87,6 @@ public:
 
     // Main scheduler thread entry: poll completion + dispatch ready tasks.
     int32_t resolve_and_dispatch(Runtime *runtime, int32_t thread_idx);
-
-    // Dedicated resolution (P) thread entry (3S+1P). Owns no cores: drains the
-    // per-S CompletedTaskQueues and runs on_task_complete for each finished task
-    // (task_states publish + wake-list drain), making P
-    // the sole producer of the ready queues. Owns completed_tasks_ / termination.
-    int32_t run_resolution_thread(Runtime *runtime, int32_t thread_idx);
-
-    // Index of the dedicated resolution (P) thread — the last AICPU thread.
-    // host_build_graph always reserves it (aicpu_thread_num >= 2 is required).
-    int32_t p_thread_idx() const { return p_thread_idx_; }
 
     // Retire the cores this thread owns, on its way out of resolve_and_dispatch.
     // Threads that own none no-op. Runs before the completion latch, so no
@@ -234,15 +172,6 @@ private:
     int32_t active_sched_threads_{0};
     int32_t aicpu_thread_num_{0};
     int32_t cores_total_num_{0};
-
-    // --- 3S+1P dedicated resolution thread ---
-    // The AICPU threads split into (aicpu_thread_num_ - 1) core-owning schedulers
-    // (S) plus one core-less resolution thread (P) at index p_thread_idx_ =
-    // aicpu_thread_num_ - 1. host_build_graph requires aicpu_thread_num_ >= 2 (one
-    // S + one P). Each S thread hands its finished tasks to P through
-    // sp_queues_[its_thread_idx].
-    int32_t p_thread_idx_{-1};
-    CompletedTaskQueue sp_queues_[MAX_AICPU_THREADS];
 
     // Cluster-ordered worker_id lists, populated by post_handshake_init().
     int32_t aic_worker_ids_[RUNTIME_MAX_WORKER]{};

--- a/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/scheduler/scheduler_dispatch.cpp
@@ -940,278 +940,6 @@ int32_t SchedulerContext::try_early_dispatch(
 }
 
 // =============================================================================
-// Dedicated resolution (P) thread — 3S+1P
-// =============================================================================
-
-// P owns no AICore cores. It drains the per-S CompletedTaskQueues and runs
-// on_task_complete for every finished task: publish task_states, drain the
-// wake list (route/re-register waiters into the ready queues). As the sole
-// producer of the ready queues its enqueues never contend. P owns
-// completed_tasks_ and the terminal completed_ flip, so the S threads keep
-// dispatching until P has resolved the whole graph.
-int32_t SchedulerContext::run_resolution_thread(Runtime *runtime, int32_t thread_idx) {
-    always_assert(sched_ != nullptr);
-    SharedMemoryHeader *header = sched_->sm_header;
-    if (!header) {
-        LOG_ERROR("resolution: header is null");
-        return -1;
-    }
-    LOG_INFO("Thread %d: resolution (P) thread starting, serving %d schedulers", thread_idx, active_sched_threads_);
-
-#if SIMPLER_DFX
-    auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
-    chip_swimlane.reset();
-    chip_swimlane.chip_swimlane_enabled = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
-
-    const bool record_sched_phases = chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES;
-    auto record_p_phase = [&](ChipSwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time,
-                              uint32_t tasks_processed, const int16_t shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
-        int16_t shared_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];
-        capture_shared_ready_depth(sched_, shared_at_end);
-        chip_swimlane_aicpu_record_sched_phase(
-            thread_idx, kind, start_time, end_time, chip_swimlane.sched_loop_count, tasks_processed,
-            /*pop_hit=*/0, /*pop_miss=*/0, shared_at_start, shared_at_end
-        );
-    };
-    simpler::hbg::AsyncPollPhaseAccumulator async_poll_phase;
-    int16_t async_poll_shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES] = {0};
-    auto flush_async_poll = [&](uint64_t end_time) {
-        if (!async_poll_phase.active()) return;
-        // Consecutive empty polls are compacted into one bar whose duration is
-        // their exact summed CPU time. Anchoring the compact bar at the flush
-        // point preserves phase accounting without exporting one record per
-        // spin iteration.
-        const simpler::hbg::AsyncPollPhaseSummary summary = async_poll_phase.flush(end_time);
-        record_p_phase(
-            ChipSwimlaneSchedPhaseKind::AsyncPoll, summary.start_time, summary.end_time, summary.resolved,
-            async_poll_shared_at_start
-        );
-    };
-#endif
-
-    uint64_t last_progress_ts = get_sys_cnt_aicpu();
-    uint64_t scheduler_timeout_cycles = SCHEDULER_TIMEOUT_CYCLES;
-    const int32_t scheduler_timeout_ms_override = get_scheduler_timeout_ms();
-    if (scheduler_timeout_ms_override > 0) {
-        scheduler_timeout_cycles =
-            static_cast<uint64_t>(scheduler_timeout_ms_override) * PLATFORM_PROF_SYS_CNT_FREQ / 1000;
-    }
-
-    while (true) {
-        if (completed_.load(std::memory_order_acquire)) break;
-
-#if SIMPLER_DFX
-        chip_swimlane.sched_loop_count++;
-#endif
-
-        int32_t published_task_count = 0;
-        if (check_exit_conditions(thread_idx, header, runtime, published_task_count) == LoopAction::BREAK_LOOP) break;
-
-        int32_t resolved_this_pass = 0;
-        bool resolved_any = false;
-#if SIMPLER_DFX
-        uint64_t resolve_t0 = 0;
-        int16_t resolve_shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES] = {0};
-        uint32_t resolve_count = 0;
-#endif
-        for (int32_t s = 0; s < active_sched_threads_ && !completed_.load(std::memory_order_acquire); s++) {
-            ChipTaskSlotState *slot;
-            while ((slot = sp_queues_[s].pop()) != nullptr) {
-#if SIMPLER_DFX
-                if (record_sched_phases && resolve_t0 == 0) {
-                    resolve_t0 = get_sys_cnt_aicpu();
-                    flush_async_poll(resolve_t0);
-                    capture_shared_ready_depth(sched_, resolve_shared_at_start);
-                }
-#endif
-#if SIMPLER_SCHED_PROFILING
-                SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*slot, thread_idx);
-#else
-                SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*slot);
-#endif
-                if (outcome.error_code != SIMPLER_ERROR_NONE) {
-                    fail_scheduler(runtime, thread_idx, outcome.error_code);
-                    break;
-                }
-                resolved_this_pass += outcome.stream_tasks_completed;
-                resolved_any = true;
-#if SIMPLER_DFX
-                resolve_count++;
-#endif
-            }
-        }
-#if SIMPLER_DFX
-        if (resolve_t0 != 0) {
-            record_p_phase(
-                ChipSwimlaneSchedPhaseKind::ResolveStandalone, resolve_t0, get_sys_cnt_aicpu(), resolve_count,
-                resolve_shared_at_start
-            );
-        }
-#endif
-        if (completed_.load(std::memory_order_acquire)) break;
-
-        // Async deferred completions, moved off the scheduler threads. Every
-        // condition that fires resolves via on_task_complete inside
-        // poll_and_complete, so async ready tasks also enter the ready queues
-        // through P alone.
-        if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
-            (sched_->async_wait_list.count > 0 || rt_->aicore_mailbox->has_pending())) {
-#if SIMPLER_DFX
-            uint64_t async_poll_t0 = 0;
-            if (record_sched_phases) {
-                if (!async_poll_phase.active()) {
-                    capture_shared_ready_depth(sched_, async_poll_shared_at_start);
-                    async_poll_phase.begin();
-                }
-                async_poll_t0 = get_sys_cnt_aicpu();
-            }
-#endif
-            AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
-                rt_->aicore_mailbox, sched_
-#if SIMPLER_SCHED_PROFILING
-                ,
-                thread_idx
-#endif
-            );
-#if SIMPLER_DFX
-            if (async_poll_t0 != 0) {
-                const uint64_t async_poll_t1 = get_sys_cnt_aicpu();
-                const bool flush_poll_phase = async_poll_phase.add_poll(
-                    async_poll_t0, async_poll_t1, static_cast<uint32_t>(poll_result.resolved),
-                    poll_result.error_code != SIMPLER_ERROR_NONE
-                );
-                if (flush_poll_phase) {
-                    flush_async_poll(async_poll_t1);
-                }
-            }
-#endif
-            if (poll_result.error_code != SIMPLER_ERROR_NONE) {
-                fail_scheduler(runtime, thread_idx, poll_result.error_code);
-                break;
-            }
-            resolved_this_pass += poll_result.completed;
-            resolved_any = resolved_any || poll_result.resolved > 0;
-        }
-
-        // Dependency-only tasks (empty active_mask, or a predicate that failed)
-        // route to dummy_ready_queue during resolution; P produces and drains it,
-        // so the queue is single-threaded end to end. Loop until empty — a dummy's
-        // resolution can make further dummies ready in the same pass.
-        {
-            constexpr int DUMMY_DRAIN_BATCH = 8;
-            ChipTaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
-            int dummy_got;
-#if SIMPLER_DFX
-            uint64_t dummy_t0 = 0;
-            int16_t dummy_shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES] = {0};
-            uint32_t dummy_count = 0;
-#endif
-            while ((dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH)) > 0) {
-#if SIMPLER_DFX
-                if (record_sched_phases && dummy_t0 == 0) {
-                    dummy_t0 = get_sys_cnt_aicpu();
-                    flush_async_poll(dummy_t0);
-                    capture_shared_ready_depth(sched_, dummy_shared_at_start);
-                }
-#endif
-                for (int di = 0; di < dummy_got; di++) {
-#if SIMPLER_SCHED_PROFILING
-                    SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*dummy_batch[di], thread_idx);
-#else
-                    SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*dummy_batch[di]);
-#endif
-                    if (outcome.error_code != SIMPLER_ERROR_NONE) {
-                        fail_scheduler(runtime, thread_idx, outcome.error_code);
-                        break;
-                    }
-                    resolved_this_pass += outcome.stream_tasks_completed;
-                    resolved_any = true;
-#if SIMPLER_DFX
-                    dummy_count++;
-#endif
-                }
-                if (completed_.load(std::memory_order_acquire)) break;
-            }
-#if SIMPLER_DFX
-            if (dummy_t0 != 0) {
-                record_p_phase(
-                    ChipSwimlaneSchedPhaseKind::Dummy, dummy_t0, get_sys_cnt_aicpu(), dummy_count, dummy_shared_at_start
-                );
-            }
-#endif
-        }
-        if (completed_.load(std::memory_order_acquire)) break;
-
-        if (resolved_any) {
-            if (resolved_this_pass > 0) {
-                completed_tasks_.fetch_add(resolved_this_pass, std::memory_order_relaxed);
-#if SIMPLER_SCHED_PROFILING
-                // P owns the completion accounting, so it owns the profiling mirror too
-                // (the S threads' completed_this_turn no longer feeds it in P mode).
-                sched_->tasks_completed.fetch_add(resolved_this_pass, std::memory_order_relaxed);
-#endif
-            }
-            last_progress_ts = get_sys_cnt_aicpu();
-            continue;  // fast re-drain while work keeps arriving
-        }
-
-        // Idle: nothing to resolve this pass. A task legitimately in flight — some
-        // thread still owns a RUNNING core — means P is merely waiting for that
-        // task to finish, not stalled: refresh the budget and keep spinning
-        // (mirrors resolve_and_dispatch's sibling-owns-running guard, so a task
-        // that runs longer than the timeout does not false-latch here). Only latch
-        // a hang when work is outstanding AND no thread anywhere owns a running
-        // task — a genuine forward-progress stall / pre-dispatch deadlock.
-        uint64_t now = get_sys_cnt_aicpu();
-        if (now - last_progress_ts > scheduler_timeout_cycles) {
-            const int32_t total = total_tasks_;
-            bool outstanding = total > 0 && completed_tasks_.load(std::memory_order_relaxed) < total;
-            if (outstanding && no_thread_owns_running_task()) {
-                LOG_ERROR(
-                    "Thread %d: P resolution stall (%d/%d resolved)", thread_idx,
-                    completed_tasks_.load(std::memory_order_relaxed), total
-                );
-                int32_t expected = SIMPLER_ERROR_NONE;
-                header->sched_error_code.compare_exchange_strong(
-                    expected, SIMPLER_ERROR_SCHEDULER_TIMEOUT, std::memory_order_acq_rel, std::memory_order_acquire
-                );
-                if (!completed_.exchange(true, std::memory_order_acq_rel)) {
-                    emergency_shutdown(runtime);
-                }
-                break;
-            }
-            last_progress_ts = now;  // a task is still running (or none outstanding): not a stall
-        }
-        SPIN_WAIT_HINT();
-    }
-
-#if SIMPLER_DFX
-    flush_async_poll(get_sys_cnt_aicpu());
-    // P owns no cores, so the AICore-keyed flushes below iterate an empty core
-    // list; the sched-phase-buffer flush is the one that matters — it drains any
-    // per-thread records P wrote (e.g. under SCHED_PROFILING) so they are not lost.
-    if (chip_swimlane.chip_swimlane_enabled) {
-        chip_swimlane_aicpu_flush(
-            thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
-        );
-        if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) {
-            chip_swimlane_aicpu_flush_sched_phase_buffer(thread_idx);
-        }
-    }
-    if (is_dump_args_enabled()) {
-        dump_args_flush(thread_idx);
-    }
-    if (is_pmu_enabled()) {
-        pmu_aicpu_flush_buffers(
-            thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
-        );
-    }
-#endif
-
-    return completed_tasks_.load(std::memory_order_relaxed);
-}
-
-// =============================================================================
 // Main scheduler dispatch loop
 // =============================================================================
 
@@ -1239,6 +967,28 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     auto &chip_swimlane = sched_chip_swimlane_[thread_idx];
     chip_swimlane.reset();
     chip_swimlane.chip_swimlane_enabled = (chip_swimlane_level_ != ChipSwimlaneLevel::DISABLED);
+    // Consecutive empty async polls compact into one bar: every thread polls the
+    // wait list now, so one record per spin would swamp the lane.
+    simpler::hbg::AsyncPollPhaseAccumulator async_poll_phase;
+    int16_t async_poll_shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES] = {0};
+    auto record_resolution_phase = [&](ChipSwimlaneSchedPhaseKind kind, uint64_t start_time, uint64_t end_time,
+                                       uint32_t tasks_processed,
+                                       const int16_t shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES]) {
+        int16_t shared_at_end[CHIP_SWIMLANE_NUM_QUEUE_SHAPES];
+        capture_shared_ready_depth(sched_, shared_at_end);
+        chip_swimlane_aicpu_record_sched_phase(
+            thread_idx, kind, start_time, end_time, chip_swimlane.sched_loop_count, tasks_processed,
+            /*pop_hit=*/0, /*pop_miss=*/0, shared_at_start, shared_at_end
+        );
+    };
+    auto flush_async_poll = [&](uint64_t end_time) {
+        if (!async_poll_phase.active()) return;
+        const simpler::hbg::AsyncPollPhaseSummary summary = async_poll_phase.flush(end_time);
+        record_resolution_phase(
+            ChipSwimlaneSchedPhaseKind::AsyncPoll, summary.start_time, summary.end_time, summary.resolved,
+            async_poll_shared_at_start
+        );
+    };
 #endif
 
     // PMU runs require single-issue dispatch — overlapping in-flight tasks
@@ -1378,11 +1128,112 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
         }
 
-        // Async deferred-completion polling and dependency-only (dummy /
-        // predicate-failed) retirement both run on P, which owns every
-        // completion→ready transition — the scheduler threads' loop stays purely
-        // core-local (poll own COND, dispatch own cores) and never touches the
-        // shared mailbox or dummy queue.
+        // Async deferred-completion polling. Every thread may call this: the
+        // wait list is guarded by a try_lock, so a second caller returns empty
+        // rather than contending, and whichever thread wins resolves through the
+        // same on_task_complete as any other completion.
+        if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
+            (sched_->async_wait_list.count > 0 || rt_->aicore_mailbox->has_pending())) {
+#if SIMPLER_DFX
+            uint64_t async_poll_t0 = 0;
+            if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES) {
+                if (!async_poll_phase.active()) {
+                    capture_shared_ready_depth(sched_, async_poll_shared_at_start);
+                    async_poll_phase.begin();
+                }
+                async_poll_t0 = get_sys_cnt_aicpu();
+            }
+#endif
+            AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
+                rt_->aicore_mailbox, sched_
+#if SIMPLER_SCHED_PROFILING
+                ,
+                thread_idx
+#endif
+            );
+#if SIMPLER_DFX
+            if (async_poll_t0 != 0) {
+                const uint64_t async_poll_t1 = get_sys_cnt_aicpu();
+                if (async_poll_phase.add_poll(
+                        async_poll_t0, async_poll_t1, static_cast<uint32_t>(poll_result.resolved),
+                        poll_result.error_code != SIMPLER_ERROR_NONE
+                    )) {
+                    flush_async_poll(async_poll_t1);
+                }
+            }
+#endif
+            if (poll_result.error_code != SIMPLER_ERROR_NONE) {
+                fail_scheduler(runtime, thread_idx, poll_result.error_code);
+                break;
+            }
+            if (poll_result.completed > 0) {
+                completed_tasks_.fetch_add(poll_result.completed, std::memory_order_relaxed);
+                cur_thread_completed += poll_result.completed;
+            }
+            if (poll_result.resolved > 0 || poll_result.completed > 0) made_progress = true;
+        }
+
+        // Dependency-only tasks (empty active_mask, or a predicate that failed)
+        // occupy no core, so no FIN will ever retire them: they are routed to
+        // dummy_ready_queue during resolution and retired here. The queue is
+        // MPMC, so every thread draining its own batch is correct — a dummy
+        // chain simply spreads across threads instead of unwinding on one.
+        {
+            constexpr int DUMMY_DRAIN_BATCH = 8;
+            ChipTaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            int dummy_got;
+            int32_t dummy_completed = 0;
+#if SIMPLER_DFX
+            uint64_t dummy_t0 = 0;
+            int16_t dummy_shared_at_start[CHIP_SWIMLANE_NUM_QUEUE_SHAPES] = {0};
+            uint32_t dummy_retired = 0;
+#endif
+            while ((dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH)) > 0) {
+#if SIMPLER_DFX
+                if (chip_swimlane_level_ >= ChipSwimlaneLevel::SCHED_PHASES && dummy_t0 == 0) {
+                    dummy_t0 = get_sys_cnt_aicpu();
+                    flush_async_poll(dummy_t0);
+                    capture_shared_ready_depth(sched_, dummy_shared_at_start);
+                }
+#endif
+                for (int di = 0; di < dummy_got; di++) {
+#if SIMPLER_SCHED_PROFILING
+                    SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*dummy_batch[di], thread_idx);
+#else
+                    SchedulerState::TaskCompletionOutcome outcome = sched_->complete_task(*dummy_batch[di]);
+#endif
+                    if (outcome.error_code != SIMPLER_ERROR_NONE) {
+                        fail_scheduler(runtime, thread_idx, outcome.error_code);
+                        dummy_got = -1;
+                        break;
+                    }
+                    dummy_completed += outcome.stream_tasks_completed;
+#if SIMPLER_DFX
+                    dummy_retired++;
+#endif
+                }
+                if (dummy_got < 0) break;
+                if (completed_.load(std::memory_order_acquire)) break;
+            }
+#if SIMPLER_DFX
+            if (dummy_t0 != 0) {
+                record_resolution_phase(
+                    ChipSwimlaneSchedPhaseKind::Dummy, dummy_t0, get_sys_cnt_aicpu(), dummy_retired,
+                    dummy_shared_at_start
+                );
+            }
+#endif
+            if (dummy_completed > 0) {
+                completed_tasks_.fetch_add(dummy_completed, std::memory_order_relaxed);
+                cur_thread_completed += dummy_completed;
+                made_progress = true;
+            }
+        }
+        // A dummy completion that failed has already retired every initialized
+        // AICore through fail_scheduler, so the dispatch work further down this
+        // iteration must not run: it would write register windows on cores that
+        // are gone. Also catches a peer thread latching the error concurrently.
+        if (completed_.load(std::memory_order_acquire)) break;
 
 #if SIMPLER_DFX
         if (!try_completed) {
@@ -1502,9 +1353,6 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
             }
         }
-
-        // Phase 3 (dependency-only dummy / predicate-failed retirement) runs on
-        // the resolution thread P, not here — see run_resolution_thread.
 
         // Phase 4: MIX-strict-priority dispatch with phase-split and
         // cross-thread idle gating. See dispatch_ready_tasks for the policy.
@@ -1660,6 +1508,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     // Polling: no deferred producer-release batch to drain at loop exit.
 
 #if SIMPLER_DFX
+    // A trailing run of empty polls is still held in the accumulator at loop
+    // exit; flush it so its compacted bar is not dropped.
+    flush_async_poll(get_sys_cnt_aicpu());
+
     // Final-drain: emit any pop_hit / pop_miss accrued since the last
     // dispatch emit (typically the trailing idle loops while waiting for the
     // last in-flight tasks to complete) as a zero-duration synthetic dispatch record so

--- a/tests/st/a2a3/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
+++ b/tests/st/a2a3/host_build_graph/dfx/chip_swimlane/test_scheduler_phases.py
@@ -72,26 +72,34 @@ class TestSchedulerPhases(SceneTestCase):
             phase_threads = data.get("aicpu_scheduler_phases")
             assert phase_threads, "scheduler phase records are missing"
             assigned_threads = {thread_idx for thread_idx in data.get("core_to_thread", []) if thread_idx >= 0}
-            resolution_threads = [
-                records
-                for thread_idx, records in enumerate(phase_threads)
-                if records and thread_idx not in assigned_threads
-            ]
-            assert len(resolution_threads) == 1, f"expected one core-less P thread, found {len(resolution_threads)}"
-            resolution_thread = resolution_threads[0]
-            required = {"resolve_standalone", "dummy"}
-            emitted = {record.get("phase") for record in resolution_thread}
-            assert required <= emitted, f"missing P-thread phases: {sorted(required - emitted)}"
+            recording = [(thread_idx, records) for thread_idx, records in enumerate(phase_threads) if records]
+            assert recording, "no scheduler thread emitted phase records"
 
-            records = [record for record in resolution_thread if record.get("phase") in required]
-            assert all(record["loop_iter"] > 0 for record in records)
-            assert all(record["end_time_us"] >= record["start_time_us"] for record in records)
-            assert sum(record["tasks_processed"] for record in records if record["phase"] == "resolve_standalone") >= 1
-            assert sum(record["tasks_processed"] for record in records if record["phase"] == "dummy") == 1
-            assert len(resolution_thread) < 64, "P-thread phase aggregation produced excessive records"
+            # Scheduler threads are symmetric: each one owns cores and resolves
+            # the completions it observes, so no thread records phases without
+            # holding a core slice.
+            core_less = [thread_idx for thread_idx, _ in recording if thread_idx not in assigned_threads]
+            assert not core_less, f"scheduler threads own cores; core-less threads recorded phases: {core_less}"
 
-            ordered = sorted(records, key=lambda record: (record["start_time_us"], record["end_time_us"]))
-            assert all(left["end_time_us"] <= right["start_time_us"] for left, right in zip(ordered, ordered[1:]))
+            # The dummy retirement is not one thread's job any more -- whichever
+            # thread wins the queue does it -- but the graph holds exactly one
+            # dummy task, so the chip-wide count is still one.
+            dummy = [record for _, records in recording for record in records if record.get("phase") == "dummy"]
+            assert dummy, "no dummy phase recorded on any scheduler thread"
+            assert sum(record["tasks_processed"] for record in dummy) == 1
+            assert all(record["loop_iter"] > 0 for record in dummy)
+            assert all(record["end_time_us"] >= record["start_time_us"] for record in dummy)
+
+            for thread_idx, records in recording:
+                assert len(records) < 64, f"thread {thread_idx} phase aggregation produced excessive records"
+                # Compare only same-kind bars: the Dummy and AsyncPoll spans sit
+                # inside the same iteration's Complete span, so cross-kind overlap
+                # is expected.
+                ordered = sorted(
+                    (record for record in records if record.get("phase") == "dummy"),
+                    key=lambda record: (record["start_time_us"], record["end_time_us"]),
+                )
+                assert all(left["end_time_us"] <= right["start_time_us"] for left, right in zip(ordered, ordered[1:]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Every AICPU thread now owns AICore clusters, polls their COND registers and resolves
the completions it observes. Previously one thread of the four owned no clusters and
acted as the sole resolver, with the core-owning threads handing their completions to
it over SPSC queues.

- A core's COND register lives in a `Device-nGnRE` mapping, so the `nR` attribute
  serialises the loads: a FIN-detection round costs ~95 ns per cluster and cannot be
  pipelined. Adding a core-owning thread is the only way to shorten it, and the
  resolution thread contributed none. At `aicpu_thread_num=4` the chip's 24 clusters
  were split 3×8 and are now split 4×6; at the reachable minimum of 2 threads, one
  thread polling all 24 becomes two polling 12 each.
- **Concurrent resolution needs no new arbitration.** A producer's wake list is
  detached with a single exchange against a terminal sentinel, so exactly one thread
  drains a given list; `register_wake` is a Treiber-stack CAS loop that re-classifies
  when it loses that race; the ready queues are MPMC; `poll_and_complete` already
  guards itself with a `try_lock`. Boot classification has always run these paths on
  all threads at once.
- The pieces that were single-resolver by construction go away with the split: the
  SPSC completion queues are deleted, `complete_slot_task` resolves inline, and the
  completion count is incremented on the resolving thread so each completion is
  counted exactly once.
- `Dummy` and `AsyncPoll` swimlane bars move with the work that produces them.
  Consecutive empty polls still compact into one bar, which matters more now that
  every thread polls the wait list.
- Net: **+195 / −412 lines** — the runtime change itself is +98 / −392; the rest is
  the rewritten chip-swimlane test and the `Dummy` / `AsyncPoll` phase instrumentation
  moved onto the threads that now do that work.

## Measurements

a2a3, both sides clean-built at the pinned ISA from an empty build tree (both carrying
#2164 so `paged_attention` Case1/Case2 can run at all), `--rounds 4`
with the first round dropped, against main at `a1aa7fdd`:

| case | 3S+1P (ms) | symmetric (ms) | ratio |
| --- | ---: | ---: | ---: |
| `paged_attention/Case2` | 11.806 | 10.491 | **0.889** |
| `paged_attention/Case1` | 22.669 | 20.685 | **0.912** |
| `deepseek_v4_flash_decode` | 37.165 | 35.251 | **0.948** |
| `qwen3_14b_decode` | 38.884 | 37.836 | **0.973** |
| `batch_pa/Case1` | 2.765 | 2.720 | 0.984 |
| `batch_pa/Case2` | 4.723 | 4.688 | 0.993 |
| `batch_pa/Case3` | 7.051 | 7.001 | 0.993 |
| `pa_unroll/Case1` | 1.211 | 1.203 | 0.993 |
| `spmd_pa/Case1` | 2.148 | 2.145 | 0.999 |
| `chained_early_dispatch` † | 46.424 | 46.419 | 1.000 |
| `spmd_sync_start_ed` † | 136.576 | 137.686 | 1.008 |

† `--rounds 1`, so these include the cold round — they act as controls: two
independently built trees landing within 0.03 ms on a 46 ms workload says the legs
carry no systematic offset.

A full 41-case sweep found no regression outside the sub-100 µs measurement floor.

## The symmetric side is also the stable one

Across three successive mains, `paged_attention/Case1`:

| main | 3S+1P | symmetric |
| --- | ---: | ---: |
| `d79c88cd` | 20.76 | 20.83 |
| `e750ccf4` | 25.63 | 20.53 |
| `a1aa7fdd` | 22.67 | 20.69 |

The symmetric side stays flat within 1.5%; the single-resolver side swung 23% over
the same span. Routing every completion through one thread makes the runtime
sensitive to graph-execution changes that the symmetric layout absorbs.

## Testing

- [x] Simulation tests pass (`st-sim-a2a3`, both runners)
- [x] Hardware tests pass (`st-onboard-a2a3`, `st-deepseek-onboard-a2a3`,
      `st-network1-onboard-a2a3`)
- [x] All six profiling flag combos build (`profiling-flags-smoke`)
- [x] 41-case hardware sweep, both legs, clean-built at the pinned ISA
- [x] `dfx/chip_swimlane/test_scheduler_phases` verified on hardware at
      `--enable-chip-swimlane 3`

## Depends on #2164

`paged_attention` Case1 and Case2 build ~65,792 and ~32,832 resident tasks against the
16384-task default window, so on plain `main` they fail at bind with `-1000` before any
kernel runs. #2164 sizes them per case via `runtime_env.ring_task_window`; it is an
orthogonal test-config fix that stands on its own.

Both legs of the measurements above carried #2164, so it cancels out of the comparison —
`git diff` between the two benchmark branches was exactly the six runtime files changed
here. But the two `paged_attention` rows are **not reproducible from this branch alone**:
check out #2164 as well to run those cases.


