### PR TITLE
Add: TMR kernel invocation snapshots and native transport adapter（K4）

### DIFF
--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -304,7 +304,9 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
            simpler_unregister_callable, get_pipeline_contract,
            supports_concurrent_native_prepare_ctx,
            get_arena_bank_gm_heap_base_ctx, get_retained_temp_addr_ctx,
-           finalize_device
+           finalize_device, simpler_kernel_mode_supported,
+           simpler_kernel_mode_init, simpler_kernel_mode_prepare_callable,
+           simpler_kernel_mode_launch
     create_device_context() → DeviceContextHandle
     allocate zeroed, aligned, stable native-run storage per pipeline slot
     simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size, ...)

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -107,12 +107,17 @@ ChipCallable.build(
     func_name="my_orchestration",     # the exported orchestration symbol
     binary=orch_bytes,
     children=[(func_id, core_callable), ...],
+    scalar_count=0,                   # scalar arguments the orchestration expects
 )
 ```
 
 `ArgDirection` is `SCALAR`, `IN`, `OUT`, or `INOUT`. The signature list is
 positional and defines the task-arg order. `func_id` must match the id the
-orchestration submits. `ChipCallable` exposes `binary_size`.
+orchestration submits. `ChipCallable` exposes `binary_size` and
+`scalar_count`. `scalar_count` is a cached derivation of the signature: a
+nonzero value must equal the signature's `SCALAR` entry count or `build`
+raises, while 0 also means "not recorded" — an artifact built before the
+count existed or an orchestration that takes no scalars.
 
 Public `Worker` calls use `TaskArgs` containing address-free `Tensor` views at
 every level. The L2 leaf resolves those views into the internal

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2690,7 +2690,8 @@ NB_MODULE(_task_interface, m) {
         .def_static(
             "build",
             [](std::vector<ArgDirection> signature, std::string func_name, nb::bytes binary,
-               std::vector<std::tuple<int32_t, PyCoreCallable>> children, std::string config_name) -> PyChipCallable {
+               std::vector<std::tuple<int32_t, PyCoreCallable>> children, std::string config_name,
+               int32_t scalar_count) -> PyChipCallable {
                 auto bin_ptr = reinterpret_cast<const void *>(binary.c_str());
                 auto bin_size = static_cast<uint32_t>(binary.size());
                 auto child_count = static_cast<int32_t>(children.size());
@@ -2703,14 +2704,16 @@ NB_MODULE(_task_interface, m) {
                 }
 
                 auto buf = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-                    signature.data(), static_cast<int32_t>(signature.size()), func_name.c_str(), bin_ptr, bin_size,
-                    func_ids.data(), child_bufs.data(), child_count, config_name.c_str()
+                    signature.data(), static_cast<int32_t>(signature.size()), scalar_count, func_name.c_str(), bin_ptr,
+                    bin_size, func_ids.data(), child_bufs.data(), child_count, config_name.c_str()
                 );
                 return PyChipCallable{std::move(buf)};
             },
             nb::arg("signature"), nb::arg("func_name"), nb::arg("binary"), nb::arg("children"),
-            nb::arg("config_name") = "",
-            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children."
+            nb::arg("config_name") = "", nb::arg("scalar_count") = 0,
+            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children. "
+            "scalar_count caches the signature's SCALAR entry count; a nonzero value that disagrees with the "
+            "signature raises, and 0 also means the count is not recorded."
         )
 
         .def_static(
@@ -2776,6 +2779,15 @@ NB_MODULE(_task_interface, m) {
                 return std::string(c.config_name(), c.config_name_len());
             },
             "The optional orchestration config function name."
+        )
+
+        .def_prop_ro(
+            "scalar_count",
+            [](const PyChipCallable &self) -> int32_t {
+                return self.get().scalar_count();
+            },
+            "Number of scalar arguments the orchestration expects. 0 also for "
+            "legacy artifacts built before the count was recorded."
         )
 
         .def_prop_ro(

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1457,12 +1457,17 @@ class ChipWorker:
                 raise RuntimeError("ChipWorker.finalize() cannot run while ChipWorker.init() is in progress")
         try:
             self._impl.finalize()
-        finally:
+        except BaseException:
+            # The registries name what the native side still holds. A teardown
+            # that did not complete leaves those resources alive, so dropping
+            # the registries would hide them from a retry and from the caller.
             _flush_host_log_or_warn("ChipWorker.finalize()")
-            with self._registry_lock:
-                self._callable_registry.clear()
-                self._identity_registry.clear()
-                self._live_handles.clear()
+            raise
+        _flush_host_log_or_warn("ChipWorker.finalize()")
+        with self._registry_lock:
+            self._callable_registry.clear()
+            self._identity_registry.clear()
+            self._live_handles.clear()
 
     def _allocate_slot_locked(self) -> int:
         for slot_id in range(MAX_REGISTERED_CALLABLE_IDS):

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -64,6 +64,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -79,6 +79,9 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_platform_ops.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_persistent_args.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/tmr_kernel_invocation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -148,6 +148,20 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // A kernel-mode context borrows the caller's device and ACL context, so
+    // the ACL lifecycle (aclInit / aclrtSetDevice / aclrtResetDevice[Force] /
+    // aclFinalize) belongs to the caller. Every call site of those APIs falls
+    // into one of three classes: (a) the aclInit / aclrtSetDevice below this
+    // guard, (b) calls inside force_reset_device(), behind its own
+    // kernel-mode guard, or (c) calls gated on acl_ready_, which only the
+    // path below this guard sets. finalize()'s rt-layer device reset on the
+    // acl_ready_ == false path is intercepted by the kernel-mode branch
+    // inside finalize(). Together these keep the caller's device and ACL
+    // state unreachable in kernel mode.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("ensure_acl_ready: refused — a kernel-mode context does not own the caller's ACL lifecycle");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
 
     // aclInit is process-wide; CANN returns ACL_ERROR_REPEAT_INITIALIZE if it
     // has already been initialized (possibly by another owner), which we
@@ -857,6 +871,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -1071,10 +1093,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup performance profiling (including a2a3's dep_gen). Normally
@@ -1121,6 +1148,10 @@ int DeviceRunner::finalize() {
                 if (rc == 0) rc = finalize_rc;
             }
             acl_ready_ = false;
+        } else if (execution_mode_latch().is_kernel()) {
+            // A kernel-mode context borrows the caller's device; the device
+            // reset belongs to the caller, so the healthy close path releases
+            // only context-owned resources.
         } else {
             int reset_rc = rtDeviceReset(device_id_);
             if (reset_rc != 0) {

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -136,6 +136,27 @@ int kernel_args_init_ffts_base_addr(KernelArgsHelper &helper) {
 // DeviceRunner Implementation
 // =============================================================================
 
+int DeviceRunner::fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) {
+    if (args == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    int rc = init_aicore_register_addresses(&args->regs, device_id, mem_alloc_, AicoreRegKind::Ctrl);
+    if (rc != 0) {
+        LOG_ERROR("fill_persistent_arch_fields: init_aicore_register_addresses(Ctrl) failed: %d", rc);
+        return rc;
+    }
+
+    uint32_t ffts_len = 0;
+    rc = rtGetC2cCtrlAddr(&args->ffts_base_addr, &ffts_len);
+    if (rc != 0) {
+        LOG_ERROR("fill_persistent_arch_fields: rtGetC2cCtrlAddr failed: %d", rc);
+        (void)mem_alloc_.free(reinterpret_cast<void *>(args->regs));
+        args->regs = 0;
+        args->ffts_base_addr = 0;
+        return rc;
+    }
+    return 0;
+}
+
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 // `setup_static_arena`, `create_thread`, `attach_current_thread`,
@@ -1050,13 +1071,20 @@ int DeviceRunner::finalize() {
         // (verified on a2a3). An SDMA-provisioned card gets a single attempt:
         // there a non-confirming reset already blocks on the driver's
         // remote-event timeout, which a retry only multiplies.
+        // A kernel-mode context owns neither the device nor its ACL state, so
+        // force_reset_device() refuses. Asking anyway would log that refusal
+        // once per attempt and then report a reset that "did not confirm
+        // clean", which reads as a failed reset rather than the designed
+        // refusal it is.
+        const bool owns_device_reset = !execution_mode_latch().is_kernel();
         constexpr int kFatalResetAttempts = 3;
-        int reset_rc = attempt_fatal_reset(
-            [this]() {
-                return force_reset_device();
-            },
-            sdma_provisioned ? 1 : kFatalResetAttempts
-        );
+        int reset_rc = owns_device_reset ? attempt_fatal_reset(
+                                               [this]() {
+                                                   return force_reset_device();
+                                               },
+                                               sdma_provisioned ? 1 : kFatalResetAttempts
+                                           ) :
+                                           0;
         const bool reset_confirmed = reset_rc == 0;
         if (!reset_confirmed) {
             LOG_ERROR(
@@ -1119,6 +1147,7 @@ int DeviceRunner::finalize() {
     // mem_alloc_.finalize(), and cached arena sizes.
     rc = finalize_common();
     if (rc == 0) rc = stream_rc;
+    if (rc != 0 && execution_mode_latch().is_kernel()) return rc;
 
     // Reset device AFTER all device memory is freed. Two paths:
     //

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -135,6 +135,13 @@ public:
      */
     int finalize() override;
 
+    /**
+     * a2a3 fills the AIC_CTRL per-core register table and the FFTS base
+     * address. The register table is allocated on `mem_alloc_`; the FFTS
+     * address is a query result and owns nothing.
+     */
+    int fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) override;
+
     // `upload_chip_callable_buffer` is inherited from `DeviceRunnerBase`.
 
     /**

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -76,6 +76,7 @@
 #include "common/unified_log.h"
 #include "host_log.h"
 #include "host/raii_scope_guard.h"
+#include "host/kernel_pipeline_contract.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -90,6 +91,10 @@ static_assert(
         PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
     "host-side C API codes must stay below the negation of every latched device code"
 );
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *, PipelineContract *) {
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
 
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -52,6 +52,8 @@
 #include "common/strace.h"
 #include "common/unified_log.h"
 #include "host/platform_compile_info.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "host/raii_scope_guard.h"
 #include "common/host_api.h"
 #include "utils/device_arena.h"
@@ -488,6 +490,52 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
     }
     out->sm_size = SharedMemoryHandle::calculate_size_per_ring(sizing.task_window_sizes);
     return true;
+}
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out) {
+    if (config == nullptr || out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(
+            config->runtime_env.ring_task_window, config->runtime_env.ring_heap, config->runtime_env.ring_dep_pool,
+            &sizing
+        )) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    uint64_t total_window = 0;
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r)
+        total_window += sizing.task_window_sizes[r];
+    // OrchestratorLayout stores the sum in int32_t and asserts before narrowing.
+    if (total_window > static_cast<uint64_t>(INT32_MAX)) return PTO_RUNTIME_ERR_INTERNAL;
+
+    // Layout has a fixed number of regions; window/dep counts are int32-bounded.
+    // Their reserve-only size arithmetic requires the platform's 64-bit size_t.
+    static_assert(sizeof(size_t) == sizeof(uint64_t));
+    ArenaStaticSizes sizes;
+    if (!derive_arena_static_sizes(sizing, &sizes)) return PTO_RUNTIME_ERR_INTERNAL;
+    constexpr size_t max_usable = std::numeric_limits<size_t>::max() - (DeviceArena::kDefaultBaseAlign - 1);
+    if (sizes.total_heap > max_usable || sizes.sm_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+    DeviceArena arena;
+    const auto layout =
+        runtime_reserve_layout(arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
+    if (layout.offsets.arena_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+
+    const PipelineContract candidate = {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        1,
+        {
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, sizes.total_heap},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, sizes.sm_size},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, layout.offsets.arena_size},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+    if (!is_valid_tmr_kernel_pipeline_contract(&candidate)) return PTO_RUNTIME_ERR_INTERNAL;
+    *out = candidate;
+    return 0;
 }
 
 // per-run: the only signature-aware step. Copy the orch args, replacing each

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -69,6 +69,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -84,6 +84,9 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_platform_ops.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_persistent_args.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/tmr_kernel_invocation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -91,6 +91,16 @@ extern "C" __attribute__((weak, visibility("hidden"))) bool publish_runtime_chip
 // DeviceRunner Implementation
 // =============================================================================
 
+int DeviceRunner::fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) {
+    if (args == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    const int rc = init_aicore_register_addresses(&args->regs, device_id, mem_alloc_);
+    if (rc != 0) {
+        LOG_ERROR("fill_persistent_arch_fields: init_aicore_register_addresses failed: %d", rc);
+    }
+    return rc;
+}
+
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 // `setup_static_arena`, `create_thread`, `attach_current_thread`,
@@ -941,12 +951,19 @@ int DeviceRunner::finalize() {
         // before abandon_common_after_device_failure() clears it.
         constexpr int kFatalResetAttempts = 3;
         const bool sdma_provisioned = dma_workspace_handle_ != nullptr;
-        int reset_rc = attempt_fatal_reset(
-            [this]() {
-                return force_reset_device();
-            },
-            sdma_provisioned ? 1 : kFatalResetAttempts
-        );
+        // A kernel-mode context owns neither the device nor its ACL state, so
+        // force_reset_device() refuses. Asking anyway would log that refusal
+        // once per attempt and then report a reset that "did not confirm
+        // clean", which reads as a failed reset rather than the designed
+        // refusal it is.
+        const bool owns_device_reset = !execution_mode_latch().is_kernel();
+        int reset_rc = owns_device_reset ? attempt_fatal_reset(
+                                               [this]() {
+                                                   return force_reset_device();
+                                               },
+                                               sdma_provisioned ? 1 : kFatalResetAttempts
+                                           ) :
+                                           0;
         const bool reset_confirmed = reset_rc == 0;
         if (!reset_confirmed) {
             LOG_ERROR(
@@ -998,6 +1015,7 @@ int DeviceRunner::finalize() {
     // chip-callable buffer pool, the three arenas, device_wall,
     // mem_alloc_.finalize(), and cached arena sizes.
     rc = finalize_common();
+    if (rc != 0 && execution_mode_latch().is_kernel()) return rc;
 
     // Reset device and finalize ACL AFTER all device memory is freed. When the
     // ACL layer was brought up (comm path), aclrtResetDevice supersedes

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -107,6 +107,20 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // A kernel-mode context borrows the caller's device and ACL context, so
+    // the ACL lifecycle (aclInit / aclrtSetDevice / aclrtResetDevice[Force] /
+    // aclFinalize) belongs to the caller. Every call site of those APIs falls
+    // into one of three classes: (a) the aclInit / aclrtSetDevice below this
+    // guard, (b) calls inside force_reset_device(), behind its own
+    // kernel-mode guard, or (c) calls gated on acl_ready_, which only the
+    // path below this guard sets. finalize()'s rt-layer device reset on the
+    // acl_ready_ == false path is intercepted by the kernel-mode branch
+    // inside finalize(). Together these keep the caller's device and ACL
+    // state unreachable in kernel mode.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("ensure_acl_ready: refused — a kernel-mode context does not own the caller's ACL lifecycle");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
 
     // aclInit is process-wide; CANN returns 100002 if it has already been
     // initialized (possibly by another owner), which we treat as success.
@@ -816,6 +830,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -956,10 +978,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup all profiling subsystems (free shm + per-buffer dev/host
@@ -990,6 +1017,10 @@ int DeviceRunner::finalize() {
             if (rc == 0) rc = finalize_rc;
         }
         acl_ready_ = false;
+    } else if (execution_mode_latch().is_kernel()) {
+        // A kernel-mode context borrows the caller's device; the device
+        // reset belongs to the caller, so the healthy close path releases
+        // only context-owned resources.
     } else {
         int reset_rc = rtDeviceReset(device_id_);
         if (reset_rc != 0) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -120,6 +120,12 @@ public:
      */
     int finalize() override;
 
+    /**
+     * a5 fills the per-core register table only: it has no ffts_base_addr
+     * field. The table is allocated on `mem_alloc_`.
+     */
+    int fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) override;
+
     // `upload_chip_callable_buffer`, `register_callable`,
     // `record_host_orch_callable`, `unregister_callable`, `has_callable`,
     // `bind_callable_to_runtime`, `aicpu_dlopen_count`, and

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -83,6 +83,7 @@
 #include "host_log.h"
 #include "host/platform_compile_info.h"
 #include "host/raii_scope_guard.h"
+#include "host/kernel_pipeline_contract.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -103,6 +104,10 @@ static_assert(
         SCHEDULER_PROFILING_SCHED_PHASES_LEVEL == static_cast<uint64_t>(ChipSwimlaneLevel::SCHED_PHASES),
     "AICore Scheduler profiling levels must match the chip-swimlane contract"
 );
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *, PipelineContract *) {
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
 
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -52,6 +52,8 @@
 #include "common/strace.h"
 #include "common/unified_log.h"
 #include "host/platform_compile_info.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "host/raii_scope_guard.h"
 #include "common/host_api.h"
 #include "utils/device_arena.h"
@@ -488,6 +490,52 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
     }
     out->sm_size = SharedMemoryHandle::calculate_size_per_ring(sizing.task_window_sizes);
     return true;
+}
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out) {
+    if (config == nullptr || out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(
+            config->runtime_env.ring_task_window, config->runtime_env.ring_heap, config->runtime_env.ring_dep_pool,
+            &sizing
+        )) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    uint64_t total_window = 0;
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r)
+        total_window += sizing.task_window_sizes[r];
+    // OrchestratorLayout stores the sum in int32_t and asserts before narrowing.
+    if (total_window > static_cast<uint64_t>(INT32_MAX)) return PTO_RUNTIME_ERR_INTERNAL;
+
+    // Layout has a fixed number of regions; window/dep counts are int32-bounded.
+    // Their reserve-only size arithmetic requires the platform's 64-bit size_t.
+    static_assert(sizeof(size_t) == sizeof(uint64_t));
+    ArenaStaticSizes sizes;
+    if (!derive_arena_static_sizes(sizing, &sizes)) return PTO_RUNTIME_ERR_INTERNAL;
+    constexpr size_t max_usable = std::numeric_limits<size_t>::max() - (DeviceArena::kDefaultBaseAlign - 1);
+    if (sizes.total_heap > max_usable || sizes.sm_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+    DeviceArena arena;
+    const auto layout =
+        runtime_reserve_layout(arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
+    if (layout.offsets.arena_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+
+    const PipelineContract candidate = {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        1,
+        {
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, sizes.total_heap},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, sizes.sm_size},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, layout.offsets.arena_size},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+    if (!is_valid_tmr_kernel_pipeline_contract(&candidate)) return PTO_RUNTIME_ERR_INTERNAL;
+    *out = candidate;
+    return 0;
 }
 
 // per-run: the only signature-aware step. Copy the orch args, replacing each

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -450,7 +450,8 @@ public:
      *
      * Drains recycled/done/ready first (just discards — release goes via
      * dev_to_host_ to avoid double-free) and then iterates the full mapping
-     * table. Each unique allocation base is released exactly once.
+     * table. Each unique allocation base is released exactly once, in no
+     * specified order.
      */
     template <typename ReleaseFn>
     void release_all_owned(const ReleaseFn &release_fn) {
@@ -479,7 +480,6 @@ public:
                 }
             }
         }
-        std::sort(release_order.begin(), release_order.end(), std::less<void *>{});
         for (void *p : release_order) {
             release_fn(p);
         }
@@ -693,7 +693,7 @@ public:
     void notify_ready_waiters() {
         for (int shard_index = 0; shard_index < shard_count_; shard_index++) {
             auto &shard = ready_shards_[shard_index];
-            std::lock_guard<std::mutex> lock(shard.wait_mutex);
+            std::scoped_lock<std::mutex> lock(shard.wait_mutex);
             shard.cv.notify_all();
         }
     }

--- a/src/common/platform/include/host/execution_mode_latch.h
+++ b/src/common/platform/include/host/execution_mode_latch.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include "execution_mode.h"
+#include "runtime_c_api.h"
+
+/**
+ * Write-once execution identity of one device context.
+ *
+ * A context's mode is a property of its construction, not a state that
+ * evolves: the C ABI creates contexts mode-less (`create_device_context`
+ * takes no parameters), so the first init entry to run completes the
+ * construction by latching the mode, and the latch never changes afterwards
+ * — not on finalize, not on error. `simpler_init` latches PROGRAM before
+ * touching any runner state, so a live program context is never unlatched
+ * and the program/kernel mutual exclusion is enforced on every init, not by
+ * anyone remembering a separate claim step. Re-initializing a finalized
+ * context under the same mode stays possible (latching the held mode is
+ * idempotent); changing a context's identity is not. That permission is real
+ * for PROGRAM, whose finalize resets device_id_ to -1; for KERNEL the latch
+ * would allow the re-latch but KernelExecutionState's phase machine refuses
+ * the re-init, since close() leaves the phase Closed and initialize() accepts
+ * only New.
+ *
+ * There is no unlatch and no rollback: an init that fails after latching
+ * leaves the context on that identity permanently, so a handle from a failed
+ * kernel init can never be recycled into a program context. Latching is
+ * therefore the step an init takes once it has decided which identity it is
+ * constructing, and an init that adopts device state must roll that state
+ * back itself.
+ *
+ * Every kernel-mode guard keys on is_kernel(), which is false until an init
+ * latches KERNEL — so the guards arm exactly when a kernel context comes
+ * into existence.
+ */
+class ExecutionModeLatch {
+public:
+    /** Latch the identity. Idempotent for the held mode; a different mode
+        returns PTO_RUNTIME_ERR_INVALID_STATE. */
+    int latch(SimplerExecutionMode mode) {
+        std::scoped_lock lock(mutex_);
+        if (latched_ && mode_ != mode) return PTO_RUNTIME_ERR_INVALID_STATE;
+        mode_ = mode;
+        latched_ = true;
+        return 0;
+    }
+
+    bool is_kernel() const {
+        std::scoped_lock lock(mutex_);
+        return latched_ && mode_ == SIMPLER_MODE_KERNEL;
+    }
+
+    bool is_latched() const {
+        std::scoped_lock lock(mutex_);
+        return latched_;
+    }
+
+    /** The held mode; meaningful only once is_latched(). */
+    SimplerExecutionMode latched_mode() const {
+        std::scoped_lock lock(mutex_);
+        return mode_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    bool latched_{false};
+    SimplerExecutionMode mode_{SIMPLER_MODE_PROGRAM};
+};

--- a/src/common/platform/include/host/kernel_entry_validation.h
+++ b/src/common/platform/include/host/kernel_entry_validation.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "callable.h"
+#include "callable_protocol.h"
+#include "runtime_c_api.h"
+
+/**
+ * Structural argument validation shared by every host-runtime component's
+ * kernel-mode entries. Both platform c_api implementations (onboard and sim)
+ * route through these checks, so a stub and a real implementation accept and
+ * reject exactly the same arguments — the same parity rule the shared phase
+ * machine follows. Each function returns 0 or PTO_RUNTIME_ERR_INTERNAL and
+ * mutates nothing; logging stays with the callers.
+ */
+
+/* A binary buffer and its size describe one object, so they are valid only
+   present-together or absent-together. */
+inline bool kernel_binary_span_is_consistent(const void *binary, size_t size) {
+    return (binary == nullptr) == (size == 0);
+}
+
+inline int validate_kernel_init_args(
+    const void *ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
+    size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size, const void *config,
+    uint64_t context_generation
+) {
+    if (ctx == nullptr || config == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (device_id < 0 || context_generation == 0) return PTO_RUNTIME_ERR_INTERNAL;
+    if (!kernel_binary_span_is_consistent(aicpu_binary, aicpu_size) ||
+        !kernel_binary_span_is_consistent(aicore_binary, aicore_size) ||
+        !kernel_binary_span_is_consistent(dispatcher_binary, dispatcher_size)) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    return 0;
+}
+
+inline int validate_kernel_prepare_callable_args(
+    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size, const void *caller_stream
+) {
+    if (ctx == nullptr || callable == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_size < sizeof(ChipCallable)) return PTO_RUNTIME_ERR_INTERNAL;
+    /* ChipCallable's storage_ is CALLABLE_CHILD_ALIGN-aligned relative to the
+       header, so a misaligned image puts every child at a misaligned address. */
+    if (reinterpret_cast<uintptr_t>(callable) % alignof(ChipCallable) != 0) return PTO_RUNTIME_ERR_INTERNAL;
+    return 0;
+}
+
+inline int
+validate_kernel_launch_args(const void *ctx, int32_t callable_id, const void *args, const void *caller_stream) {
+    if (ctx == nullptr || args == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
+    return 0;
+}

--- a/src/common/platform/include/host/kernel_entry_validation.h
+++ b/src/common/platform/include/host/kernel_entry_validation.h
@@ -13,9 +13,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <cstring>
 
 #include "callable.h"
 #include "callable_protocol.h"
+#include "kernel_invocation_validation.h"
 #include "runtime_c_api.h"
 
 /**
@@ -49,14 +51,53 @@ inline int validate_kernel_init_args(
 }
 
 inline int validate_kernel_prepare_callable_args(
-    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size, const void *caller_stream
+    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
-    if (ctx == nullptr || callable == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (ctx == nullptr || callable == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
     if (callable_size < sizeof(ChipCallable)) return PTO_RUNTIME_ERR_INTERNAL;
     /* ChipCallable's storage_ is CALLABLE_CHILD_ALIGN-aligned relative to the
        header, so a misaligned image puts every child at a misaligned address. */
     if (reinterpret_cast<uintptr_t>(callable) % alignof(ChipCallable) != 0) return PTO_RUNTIME_ERR_INTERNAL;
+    const auto *bytes = static_cast<const uint8_t *>(callable);
+    int32_t sig_count = 0;
+    int32_t cached_scalars = 0;
+    std::memcpy(&sig_count, bytes + offsetof(ChipCallable, sig_count_), sizeof(sig_count));
+    std::memcpy(&cached_scalars, bytes + offsetof(ChipCallable, scalar_count_), sizeof(cached_scalars));
+    int32_t tensors = 0;
+    int32_t scalars = 0;
+    const auto *signature = reinterpret_cast<const ArgDirection *>(bytes + offsetof(ChipCallable, signature_));
+    if (simpler::kernel::derive_invocation_counts(signature, sig_count, cached_scalars, &tensors, &scalars) !=
+        simpler::kernel::InvocationStatus::Ok)
+        return PTO_RUNTIME_ERR_INTERNAL;
+
+    const auto *image = static_cast<const ChipCallable *>(callable);
+    const auto valid_name = [](const char *name, uint32_t length) {
+        return length < CALLABLE_FUNC_NAME_MAX && name[length] == '\0' && std::memchr(name, '\0', length) == nullptr;
+    };
+    if (!valid_name(image->func_name_, image->func_name_len_) ||
+        !valid_name(image->config_name_, image->config_name_len_))
+        return PTO_RUNTIME_ERR_INTERNAL;
+    const size_t storage_size = callable_size - offsetof(ChipCallable, storage_);
+    size_t used = image->binary_size_;
+    constexpr size_t max_children = sizeof(image->child_offsets_) / sizeof(image->child_offsets_[0]);
+    if (used > storage_size || image->child_count_ < 0 || static_cast<size_t>(image->child_count_) > max_children)
+        return PTO_RUNTIME_ERR_INTERNAL;
+    for (int32_t i = 0; i < image->child_count_; ++i) {
+        const size_t offset = image->child_offsets_[i];
+        // Canonical child packing starts at the next aligned byte after
+        // the preceding binary; subtraction precedes every span read.
+        const size_t padding = (CALLABLE_ALIGN - used % CALLABLE_ALIGN) % CALLABLE_ALIGN;
+        if (padding > storage_size - used || offset != used + padding ||
+            CoreCallable::binary_data_offset() > storage_size - offset)
+            return PTO_RUNTIME_ERR_INTERNAL;
+        const auto *child = reinterpret_cast<const CoreCallable *>(image->storage_ + offset);
+        if (child->sig_count_ < 0 || child->sig_count_ > CORE_MAX_TENSOR_ARGS) return PTO_RUNTIME_ERR_INTERNAL;
+        const size_t binary_offset = offset + CoreCallable::binary_data_offset();
+        if (child->binary_size_ > storage_size - binary_offset) return PTO_RUNTIME_ERR_INTERNAL;
+        used = binary_offset + child->binary_size_;
+    }
+    if (used != storage_size) return PTO_RUNTIME_ERR_INTERNAL;
     return 0;
 }
 

--- a/src/common/platform/include/host/kernel_execution_state.h
+++ b/src/common/platform/include/host/kernel_execution_state.h
@@ -33,7 +33,14 @@ struct KernelContextOps {
     int (*get_current_device)(void *context, int *device_id){nullptr};
     int (*create_hidden_stream)(void *context, void **stream){nullptr};
     int (*destroy_hidden_stream)(void *context, void *stream){nullptr};
-    int (*create_event)(void *context, void **event){nullptr};
+    /**
+     * Creation flag every context event is born with, forwarded verbatim to
+     * create_event. The platform constant it carries is knowledge of whoever
+     * builds this table; KernelExecutionState only relays it, so a host-only
+     * test observes the flag the platform actually asked for.
+     */
+    uint32_t event_flag{0};
+    int (*create_event)(void *context, uint32_t flag, void **event){nullptr};
     int (*destroy_event)(void *context, void *event){nullptr};
 
     bool valid() const {
@@ -79,24 +86,39 @@ enum class KernelContextPhase : uint8_t {
     Closed,
 };
 
+/**
+ * The two streams a context creates and owns. Only Aicore is hidden in the
+ * capture sense; Aicpu is a dedicated private stream. Neither is the caller's.
+ */
 enum class KernelStreamKind : size_t {
     Aicpu = 0,
     Aicore,
     Count,
 };
 
+/**
+ * One event per edge of the chained caller ↔ aicpu ↔ aicore synchronization,
+ * plus the call tail. Caller and aicore are never adjacent, so no event joins
+ * them directly.
+ *
+ * AicoreStart is recorded on the aicpu stream *before* the AICPU launch: the
+ * AICPU orchestrator spins on AICore's handshake report, so an AicoreStart
+ * recorded after the launch could only fire once the AICPU task completed,
+ * which is a deadlock.
+ */
 enum class KernelEventKind : size_t {
-    PrepareTail = 0,
-    Start,
-    AicoreDone,
-    SerialTail,
+    Start = 0,   /* caller → aicpu fork */
+    AicoreStart, /* aicpu → aicore fork */
+    AicoreDone,  /* aicore → aicpu join */
+    AicpuDone,   /* aicpu → caller join */
+    SerialTail,  /* caller-visible call tail; the stream-switch gate reads it */
     Count,
 };
 
 /**
  * Context-lifetime state for the borrowed kernel execution mode.
  *
- * This object owns the persistent hidden stream pair and event set; every
+ * This object owns the dedicated AICPU stream, hidden AICore stream and event set; every
  * graph-visible persistent execution resource belongs here rather than in a
  * per-invocation object. The caller stream is never stored or destroyed —
  * each launch receives it as a borrowed argument.
@@ -126,9 +148,9 @@ enum class KernelEventKind : size_t {
  * The destructor performs no runtime calls. If a caller skips explicit close
  * while an ACLGraph can still reference these handles, freeing them would be
  * a use-after-free, so the handles leak instead. Refusing to destroy an
- * unclosed kernel runner is the public C API's half of that contract;
- * destroy_device_context refuses only on an outstanding native run, so that
- * refusal does not yet cover an unclosed kernel runner.
+ * unclosed kernel runner is the public C API's half of that contract:
+ * destroy_device_context refuses while this object owns stream/event handles
+ * or the runner has an outstanding native run.
  */
 class KernelExecutionState {
 public:

--- a/src/common/platform/include/host/kernel_execution_state.h
+++ b/src/common/platform/include/host/kernel_execution_state.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+#include "runtime_c_api.h"
+
+/**
+ * Runtime operations owned by the kernel-context lifecycle — the complete
+ * vocabulary available to context init and close.
+ *
+ * Deliberately absent from this table: device/stream synchronization, device
+ * reset, ACL finalization, capture queries, model handles, and
+ * stream-to-model attachment. Keeping those operations unrepresentable makes
+ * the host-only lifecycle tests an architectural guard instead of a mock
+ * that can silently exercise forbidden behavior.
+ */
+struct KernelContextOps {
+    void *context{nullptr};
+    int (*get_current_device)(void *context, int *device_id){nullptr};
+    int (*create_hidden_stream)(void *context, void **stream){nullptr};
+    int (*destroy_hidden_stream)(void *context, void *stream){nullptr};
+    int (*create_event)(void *context, void **event){nullptr};
+    int (*destroy_event)(void *context, void *event){nullptr};
+
+    bool valid() const {
+        return get_current_device != nullptr && create_hidden_stream != nullptr && destroy_hidden_stream != nullptr &&
+               create_event != nullptr && destroy_event != nullptr;
+    }
+};
+
+/**
+ * Allocation-free operation table for one borrowed-stream kernel-mode
+ * enqueue — the complete vocabulary available to a launch. Synchronization,
+ * allocation, stream/event creation, capture inspection, and model
+ * attachment cannot be expressed. The opaque context normally points to a
+ * stack snapshot owned by the caller.
+ *
+ * The unrepresentability guarantee binds only launch code that routes every
+ * runtime call through this table; routing through it is the launch
+ * implementation's obligation, and its call-sequence tests are what hold the
+ * obligation.
+ */
+struct KernelLaunchOps {
+    void *context{nullptr};
+    int (*wait_event)(void *context, void *stream, void *event) noexcept {nullptr};
+    int (*memset_handshake)(void *context, void *stream) noexcept {nullptr};
+    int (*record_event)(void *context, void *event, void *stream) noexcept {nullptr};
+    int (*launch_aicpu)(void *context, void *stream) noexcept {nullptr};
+    int (*launch_aicore)(void *context, void *stream) noexcept {nullptr};
+    int (*cancel_waiting_aicore)(void *context, void *stream) noexcept {nullptr};
+
+    bool valid() const {
+        return wait_event != nullptr && memset_handshake != nullptr && record_event != nullptr &&
+               launch_aicpu != nullptr && launch_aicore != nullptr && cancel_waiting_aicore != nullptr;
+    }
+};
+
+enum class KernelContextPhase : uint8_t {
+    New = 0,
+    Initializing,
+    Collecting,
+    ReadyEnqueued,
+    Poisoned,
+    Closing,
+    Closed,
+};
+
+enum class KernelStreamKind : size_t {
+    Aicpu = 0,
+    Aicore,
+    Count,
+};
+
+enum class KernelEventKind : size_t {
+    PrepareTail = 0,
+    Start,
+    AicoreDone,
+    SerialTail,
+    Count,
+};
+
+/**
+ * Context-lifetime state for the borrowed kernel execution mode.
+ *
+ * This object owns the persistent hidden stream pair and event set; every
+ * graph-visible persistent execution resource belongs here rather than in a
+ * per-invocation object. The caller stream is never stored or destroyed —
+ * each launch receives it as a borrowed argument.
+ *
+ * Phase machine:
+ *   New → (initialize) → Collecting ⇄ ReadyEnqueued
+ *   Collecting/ReadyEnqueued → (poison, on partial-enqueue failure) → Poisoned
+ *   Collecting/ReadyEnqueued/Poisoned → (close) → Closing → Closed
+ * Initializing is held only inside initialize()'s critical section and the
+ * lock is released with the phase already past it, so no caller observes it;
+ * close()'s rejection of it is defensive. The stream and event sets are the
+ * launch protocol's shared vocabulary, common to both runtimes, so
+ * initialize() creates all of them unconditionally.
+ *
+ * A pre-enqueue validation failure leaves the phase unchanged. Poisoned
+ * rejects dispatch but still accepts close. Closing is sticky: entered
+ * before the first destructive teardown step, it rejects all dispatch, and a
+ * cleanup failure stays in Closing for explicit close() retry — successfully
+ * destroyed handles are nulled, so a retry redoes only the remainder.
+ *
+ * Error reporting keeps two slots so a controlled runtime error can never
+ * mask a real teardown failure: last_runtime_error() latches the first
+ * poison cause, unexpected_teardown_error() latches the first real cleanup
+ * failure. A caller deciding an overall verdict consults them in that order
+ * before reporting controlled success.
+ *
+ * The destructor performs no runtime calls. If a caller skips explicit close
+ * while an ACLGraph can still reference these handles, freeing them would be
+ * a use-after-free, so the handles leak instead. Refusing to destroy an
+ * unclosed kernel runner is the public C API's half of that contract;
+ * destroy_device_context refuses only on an outstanding native run, so that
+ * refusal does not yet cover an unclosed kernel runner.
+ */
+class KernelExecutionState {
+public:
+    KernelExecutionState() = default;
+    ~KernelExecutionState() = default;
+    KernelExecutionState(const KernelExecutionState &) = delete;
+    KernelExecutionState &operator=(const KernelExecutionState &) = delete;
+
+    int initialize(int requested_device_id, const KernelContextOps &ops);
+    int mark_ready_enqueued();
+    void poison(int runtime_error);
+    int close();
+
+    KernelContextPhase phase() const;
+    bool accepts_dispatch() const;
+    int device_id() const;
+    int last_runtime_error() const;
+    int unexpected_teardown_error() const;
+    bool has_live_resources() const;
+    void *hidden_stream(KernelStreamKind kind) const;
+    void *event(KernelEventKind kind) const;
+
+private:
+    int cleanup_owned_resources_locked();
+    bool has_live_resources_locked() const;
+
+    mutable std::mutex mutex_;
+    KernelContextPhase phase_{KernelContextPhase::New};
+    int device_id_{-1};
+    int last_runtime_error_{0};
+    int unexpected_teardown_error_{0};
+    KernelContextOps ops_{};
+    std::array<void *, static_cast<size_t>(KernelStreamKind::Count)> hidden_streams_{};
+    std::array<void *, static_cast<size_t>(KernelEventKind::Count)> events_{};
+};

--- a/src/common/platform/include/host/kernel_pipeline_contract.h
+++ b/src/common/platform/include/host/kernel_pipeline_contract.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-typedef enum SimplerExecutionMode {
-    /* Exclusive-device execution. */
-    SIMPLER_MODE_PROGRAM = 0,
-    /* Caller-stream execution on a borrowed device. */
-    SIMPLER_MODE_KERNEL = 1,
-} SimplerExecutionMode;
+#include "worker/runtime_c_api.h"
+
+// Internal host-runtime hook, not a dlsym lifecycle API. Input is borrowed and
+// immutable during the call; output is caller-exclusive and unchanged on error.
+// No device resources are acquired or retained. Separate calls may run concurrently.
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out);

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -25,9 +25,11 @@
  */
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -437,6 +439,17 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
 
     // CANN dlog must be levelled BEFORE the device context is opened
     // (rtSetDevice inside attach_current_thread): CANN snapshots the
@@ -1199,6 +1212,49 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * This backend reports kernel mode unsupported: supported() is 0 and init
+ * refuses after the shared structural validation, so no context here ever
+ * latches kernel mode and prepare/launch reject with INVALID_STATE.
+ * Argument validation is shared with every other component through
+ * kernel_entry_validation.h, so an argument this stub accepts is one a real
+ * implementation accepts.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -30,6 +30,8 @@
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "host/kernel_entry_validation.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -1237,6 +1239,17 @@ int simpler_kernel_mode_init(
         config, context_generation
     );
     if (rc != 0) return rc;
+    try {
+        PipelineContract contract{};
+        const int rc = build_kernel_pipeline_contract_impl(config, &contract);
+        if (rc != 0) return rc;
+        if (!is_valid_pipeline_contract(&contract, SIMPLER_MODE_KERNEL) || !has_serviceable_arena_topology(contract) ||
+            !has_serviceable_stream_topology(contract)) {
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
     LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
     return PTO_RUNTIME_ERR_UNSUPPORTED;
 }

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -378,6 +378,14 @@ void destroy_device_context(DeviceContextHandle ctx) {
         LOG_ERROR("destroy_device_context: refusing to destroy a context with an unfinalized native run");
         return;
     }
+    // An unclosed kernel context still owns stream and event handles a
+    // captured ACLGraph may reference. Destroying it would free them under the
+    // graph, so the context is deliberately leaked instead: the caller closes
+    // it explicitly, or the process ends.
+    if (runner != nullptr && runner->kernel_execution_state().has_live_resources()) {
+        LOG_ERROR("destroy_device_context: refusing to destroy an unclosed kernel context; leaving it alive");
+        return;
+    }
     delete runner;
 }
 
@@ -427,7 +435,8 @@ int finalize_device(DeviceContextHandle ctx) {
             LOG_ERROR("finalize_device: native run must be finalized first");
             return PTO_RUNTIME_ERR_INTERNAL;
         }
-        return runner->finalize();
+        const int rc = runner->finalize();
+        return rc;
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -535,6 +544,68 @@ int simpler_init(
  * Per-callable_id preparation
  * =========================================================================== */
 
+/**
+ * Upload and record one callable on `runner`, leaving the AICPU-side
+ * registration launch to the caller: program mode brings the device up lazily
+ * and launches on the runner's own AICPU stream, kernel mode is already up and
+ * launches on the kernel context's. `needs_aicpu_register` reports whether
+ * that launch is owed — hbg resolves its orchestration host-side and owes
+ * none.
+ */
+static int record_callable_on_runner(
+    DeviceRunnerBase *runner, int32_t callable_id, const void *callable, bool *needs_aicpu_register
+) {
+    *needs_aicpu_register = false;
+    CallableArtifacts artifacts;
+    auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
+        if (artifacts.chip_buffer_hash != 0) {
+            runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
+        }
+    });
+    const HostApi host_api(runner, 0, 0, &g_host_api_ops);
+    int rc = register_callable_impl(reinterpret_cast<const ChipCallable *>(callable), &host_api, &artifacts);
+    if (rc != 0) return rc;
+
+    auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
+        if (artifacts.host_dlopen_handle != nullptr) {
+            dlclose(artifacts.host_dlopen_handle);
+        }
+    });
+
+    // Re-pack ChildKernelAddr -> std::pair to match the existing
+    // record_device_orch_callable* signature. The named struct only crosses
+    // the runtime-maker / device-runner interface; CallableState stores the
+    // historical pair shape.
+    std::vector<std::pair<int, uint64_t>> kernel_addrs;
+    kernel_addrs.reserve(artifacts.kernel_addrs.size());
+    for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
+        kernel_addrs.emplace_back(c.func_id, c.device_addr);
+    }
+
+    // hbg's register_callable_impl populates host_dlopen_handle; trb's leaves
+    // it null and fills orch_so_data + func_name/config_name.
+    if (artifacts.host_dlopen_handle != nullptr) {
+        rc = runner->record_host_orch_callable(
+            callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.host_dlopen_handle,
+            artifacts.host_orch_func_ptr, std::move(kernel_addrs), std::move(artifacts.signature)
+        );
+        if (rc != 0) return rc;
+        host_dlopen_guard.dismiss();
+        chip_buffer_guard.dismiss();
+        return 0;
+    }
+
+    rc = runner->record_device_orch_callable(
+        callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.chip_buffer_dev,
+        artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(), artifacts.config_name.c_str(),
+        std::move(kernel_addrs), std::move(artifacts.signature)
+    );
+    if (rc != 0) return rc;
+    chip_buffer_guard.dismiss();
+    *needs_aicpu_register = true;
+    return 0;
+}
+
 int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
     if (ctx == NULL || callable == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
@@ -547,54 +618,9 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         int rc = runner->attach_current_thread(runner->device_id());
         if (rc != 0) return rc;
 
-        CallableArtifacts artifacts;
-        auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
-            if (artifacts.chip_buffer_hash != 0) {
-                runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
-            }
-        });
-        const HostApi host_api(runner, 0, 0, &g_host_api_ops);
-        rc = register_callable_impl(reinterpret_cast<const ChipCallable *>(callable), &host_api, &artifacts);
-        if (rc != 0) {
-            return rc;
-        }
-        auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
-            if (artifacts.host_dlopen_handle != nullptr) {
-                dlclose(artifacts.host_dlopen_handle);
-            }
-        });
-
-        // Re-pack ChildKernelAddr -> std::pair to match the existing
-        // record_device_orch_callable* signature. The named struct only crosses
-        // the runtime-maker / device-runner interface; CallableState
-        // stores the historical pair shape.
-        std::vector<std::pair<int, uint64_t>> kernel_addrs;
-        kernel_addrs.reserve(artifacts.kernel_addrs.size());
-        for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
-            kernel_addrs.emplace_back(c.func_id, c.device_addr);
-        }
-
-        // hbg's register_callable_impl populates host_dlopen_handle; trb's
-        // leaves it null and fills orch_so_data + func_name/config_name.
         bool needs_aicpu_register = false;
-        if (artifacts.host_dlopen_handle != nullptr) {
-            rc = runner->record_host_orch_callable(
-                callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.host_dlopen_handle,
-                artifacts.host_orch_func_ptr, std::move(kernel_addrs), std::move(artifacts.signature)
-            );
-            if (rc != 0) return rc;
-            host_dlopen_guard.dismiss();
-            chip_buffer_guard.dismiss();
-        } else {
-            rc = runner->record_device_orch_callable(
-                callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.chip_buffer_dev,
-                artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-                artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
-            );
-            if (rc != 0) return rc;
-            chip_buffer_guard.dismiss();
-            needs_aicpu_register = true;
-        }
+        rc = record_callable_on_runner(runner, callable_id, callable, &needs_aicpu_register);
+        if (rc != 0) return rc;
         if (needs_aicpu_register) {
             rc = runner->launch_device_register(callable_id);
             if (rc != 0) {
@@ -1219,12 +1245,10 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
 /* ===========================================================================
  * Kernel-mode lifecycle
  *
- * This backend reports kernel mode unsupported: supported() is 0 and init
- * refuses after the shared structural validation, so no context here ever
- * latches kernel mode and prepare/launch reject with INVALID_STATE.
- * Argument validation is shared with every other component through
- * kernel_entry_validation.h, so an argument this stub accepts is one a real
- * implementation accepts.
+ * Init and prepare create context-owned resources on a borrowed device.
+ * Launch remains a rejecting stub, so supported() reports 0. Structural
+ * argument validation is shared with the simulated components through
+ * kernel_entry_validation.h.
  * =========================================================================== */
 
 int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
@@ -1234,7 +1258,7 @@ int simpler_kernel_mode_init(
     const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
     const CallConfig *config, uint64_t context_generation
 ) {
-    const int rc = validate_kernel_init_args(
+    int rc = validate_kernel_init_args(
         ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
         config, context_generation
     );
@@ -1250,17 +1274,82 @@ int simpler_kernel_mode_init(
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
-    return PTO_RUNTIME_ERR_UNSUPPORTED;
+
+    DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+    // A same-mode latch is idempotent, but initialization is not. Reject
+    // reuse before replacing executors. The adopted device identity also
+    // catches init failures whose resource rollback
+    // returned the kernel execution state to New.
+    if (runner->device_id() >= 0 || runner->kernel_execution_state().phase() != KernelContextPhase::New) {
+        LOG_ERROR("simpler_kernel_mode_init: this context has already been initialized or requires close");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    rc = runner->execution_mode_latch().latch(SIMPLER_MODE_KERNEL);
+    if (rc != 0) {
+        LOG_ERROR("simpler_kernel_mode_init: incompatible execution-mode latch");
+        return rc;
+    }
+
+    // The caller's CANN log level is the caller's: unlike simpler_init, this
+    // path opens no device context of its own, so it has nothing to level and
+    // no standing to change a process-wide setting it does not own.
+    try {
+        std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
+        std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
+        runner->set_executors(std::move(aicpu_vec), std::move(aicore_vec));
+        if (dispatcher_binary != NULL && dispatcher_size > 0) {
+            std::vector<uint8_t> dispatcher_vec(dispatcher_binary, dispatcher_binary + dispatcher_size);
+            runner->set_dispatcher_binary(std::move(dispatcher_vec));
+        }
+        rc = runner->init_kernel_context(device_id);
+    } catch (...) {
+        rc = PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (rc != 0) {
+        runner->kernel_execution_state().poison(rc);
+        return rc;
+    }
+    return 0;
 }
 
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
-    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size);
     if (rc != 0) return rc;
-    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
-    return PTO_RUNTIME_ERR_INVALID_STATE;
+
+    DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+    if (!runner->execution_mode_latch().is_kernel()) {
+        LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    if (!runner->kernel_execution_state().accepts_dispatch()) {
+        LOG_ERROR("simpler_kernel_mode_prepare_callable: the kernel context no longer accepts preparation");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+
+    try {
+        // The caller owns the thread's current device; this records identity
+        // without binding the thread or changing device configuration.
+        rc = runner->adopt_borrowed_device(runner->device_id());
+        if (rc != 0) return rc;
+
+        // prepare_kernel_callable's AICPU registration self-skips a callable
+        // whose orchestration was resolved host-side, so the flag it reports
+        // adds nothing here.
+        bool needs_aicpu_register = false;
+        rc = record_callable_on_runner(runner, callable_id, callable, &needs_aicpu_register);
+        if (rc != 0) return rc;
+
+        rc = runner->prepare_kernel_callable(callable_id);
+        if (rc != 0) {
+            runner->unregister_callable(callable_id);
+            return rc;
+        }
+        return 0;
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
 }
 
 int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -45,6 +45,7 @@
 #include "common/sdma_warmup_layout.h"
 #include "common/unified_log.h"
 #include "host/acl_error_log.h"
+#include "kernel_platform_ops.h"
 #include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
@@ -515,6 +516,10 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
     // writes here would still be a C++ data race.
     if (device_id_ == -1) {
         timeout_config_ = resolve_onboard_timeout_config();
+        // aclrtSetOpExecuteTimeOutV2 is device-global: it changes the
+        // op-execute timeout of every operator any process runs on this
+        // device, including the host framework's own. Only a context that
+        // owns the device may set it.
         configure_aicore_op_timeout();
         device_id_ = device_id;
     }
@@ -613,7 +618,7 @@ int DeviceRunnerBase::ensure_device_initialized() {
         );
     }
 
-    rc = ensure_binaries_loaded();
+    rc = ensure_binaries_loaded(stream_aicpu_);
     if (rc != 0) return rc;
 
     // Before the AICPU init launch: that launch is what publishes the workspace
@@ -621,13 +626,84 @@ int DeviceRunnerBase::ensure_device_initialized() {
     rc = ensure_dma_workspace_provisioned();
     if (rc != 0) return rc;
 
-    rc = ensure_aicpu_init_launched();
+    rc = ensure_aicpu_init_launched(stream_aicpu_);
     if (rc != 0) return rc;
 
     return ensure_dma_workspace_warmed();
 }
 
-int DeviceRunnerBase::ensure_aicpu_init_launched() {
+int DeviceRunnerBase::init_kernel_context(int device_id) {
+    int rc = adopt_borrowed_device(device_id);
+    if (rc != 0) return rc;
+
+    rc = kernel_exec_state_.initialize(device_id_, make_onboard_kernel_context_ops());
+    if (rc != 0) {
+        LOG_ERROR("init_kernel_context: context stream/event creation failed: %d", rc);
+        return rc;
+    }
+
+    rtStream_t control_stream = static_cast<rtStream_t>(kernel_exec_state_.hidden_stream(KernelStreamKind::Aicpu));
+    rtStream_t aicore_stream = static_cast<rtStream_t>(kernel_exec_state_.hidden_stream(KernelStreamKind::Aicore));
+
+    // Same latch as the program path: resolve_block_dim() is pure arithmetic
+    // once this holds.
+    if (max_block_dim_ == 0) {
+        max_block_dim_ = query_max_block_dim(aicore_stream, &max_cube_cores_, &max_vector_cores_);
+        LOG_INFO(
+            "DeviceRunner: kernel context device=%d max_block_dim=%d (cube=%u, vector=%u)", device_id_, max_block_dim_,
+            max_cube_cores_, max_vector_cores_
+        );
+    }
+
+    rc = ensure_binaries_loaded(control_stream);
+    if (rc != 0) return rc;
+
+    // The async-DMA workspace is program mode's SDMA channel; kernel mode
+    // provisions none, so this launch publishes the all-zero addresses that
+    // mean "that engine is unavailable".
+    return ensure_aicpu_init_launched(control_stream);
+}
+
+PersistentArgsOps DeviceRunnerBase::persistent_args_ops() {
+    PersistentArgsOps ops{};
+    ops.context = this;
+    ops.alloc = [](void *context, size_t bytes) -> void * {
+        return static_cast<DeviceRunnerBase *>(context)->mem_alloc_.alloc(bytes);
+    };
+    ops.free_ = [](void *context, void *ptr) -> int {
+        return static_cast<DeviceRunnerBase *>(context)->mem_alloc_.free(ptr);
+    };
+    ops.copy_h2d = [](void *, void *dst, size_t dst_bytes, const void *src, size_t src_bytes) -> int {
+        return static_cast<int>(rtMemcpy(dst, dst_bytes, src, src_bytes, RT_MEMCPY_HOST_TO_DEVICE));
+    };
+    ops.fill_arch_fields = [](void *context, KernelArgs *args, uint64_t device_id) -> int {
+        return static_cast<DeviceRunnerBase *>(context)->fill_persistent_arch_fields(args, device_id);
+    };
+    return ops;
+}
+
+int DeviceRunnerBase::prepare_kernel_callable(int32_t callable_id) {
+    rtStream_t control_stream = static_cast<rtStream_t>(kernel_exec_state_.hidden_stream(KernelStreamKind::Aicpu));
+    if (control_stream == nullptr) {
+        LOG_ERROR("prepare_kernel_callable: no live kernel context");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+
+    int rc = register_callable_on_device(callable_id, control_stream);
+    if (rc != 0) return rc;
+
+    // Idempotent: only the first prepared callable allocates. The uploaded
+    // Runtime keeps its per-callable and per-invocation fields at the
+    // sentinels Runtime() sets — binding a callable into the device image is a
+    // later step's work, and overwriting them here would make every launch
+    // silently run whichever callable was prepared first.
+    rc = persistent_args_.prepare_once(kernel_runtime_, persistent_args_ops(), static_cast<uint64_t>(device_id_));
+    if (rc != 0) return rc;
+
+    return kernel_exec_state_.mark_ready_enqueued();
+}
+
+int DeviceRunnerBase::ensure_aicpu_init_launched(rtStream_t control_stream) {
     if (aicpu_init_launched_) {
         return 0;
     }
@@ -652,14 +728,14 @@ int DeviceRunnerBase::ensure_aicpu_init_launched() {
 
     LOG_INFO("=== launch_aicpu_payload %s ===", host::KernelNames::InitName);
     int rc = launch_aicpu_payload(
-        stream_aicpu_, &init_args, sizeof(init_args), host::KernelNames::InitName, /*aicpu_num=*/1
+        control_stream, &init_args, sizeof(init_args), host::KernelNames::InitName, /*aicpu_num=*/1
     );
     if (rc != 0) {
         LOG_ERROR("ensure_aicpu_init_launched: launch_aicpu_payload failed: %d", rc);
         return rc;
     }
 
-    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    rc = aclrtSynchronizeStreamWithTimeout(control_stream, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
     if (rc != 0) {
         LOG_ERROR("ensure_aicpu_init_launched: stream sync failed: %d (device_id=%d)", rc, device_id_);
         return rc;
@@ -668,15 +744,16 @@ int DeviceRunnerBase::ensure_aicpu_init_launched() {
     return 0;
 }
 
-int DeviceRunnerBase::ensure_binaries_loaded() {
+int DeviceRunnerBase::ensure_binaries_loaded(rtStream_t control_stream) {
     // Check if already loaded (binaries are owned by the runner via
     // set_executors and live for the runner's lifetime).
     if (binaries_loaded_) {
         return 0;
     }
 
-    // Device must be set first
-    if (stream_aicpu_ == nullptr) {
+    // The control stream is what the bootstrap launch rides; a context that
+    // has not created one yet has no device to bootstrap on.
+    if (control_stream == nullptr) {
         LOG_ERROR("Device not set before loading binaries");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -698,7 +775,7 @@ int DeviceRunnerBase::ensure_binaries_loaded() {
     // rtsLaunchCpuKernel directly against the preinstall file.
     int rc = load_aicpu_op_.BootstrapDispatcher(
         dispatcher_so_binary_.data(), dispatcher_so_binary_.size(), aicpu_so_binary_.data(), aicpu_so_binary_.size(),
-        stream_aicpu_, device_id_
+        control_stream, device_id_
     );
     if (rc != 0) {
         LOG_ERROR("LoadAicpuOp::BootstrapDispatcher failed: %d", rc);
@@ -786,8 +863,12 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
     if (callable == nullptr) {
         return 0;
     }
-    if (stream_aicpu_ == nullptr) {
-        LOG_ERROR("Run context not prepared before upload_chip_callable_buffer()");
+    // The upload allocates and copies; it needs a bound device and nothing
+    // else. A kernel-mode context has no stream_aicpu_ — its AICPU stream
+    // belongs to KernelExecutionState — so the stream is not the precondition
+    // to test here.
+    if (device_id_ < 0) {
+        LOG_ERROR("No device bound before upload_chip_callable_buffer()");
         return 0;
     }
 
@@ -912,11 +993,24 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
         return 0;
     }
 
-    int rc = ensure_device_initialized();
+    const int rc = ensure_device_initialized();
     if (rc != 0) {
         LOG_ERROR("launch_device_register: ensure_device_initialized failed: %d", rc);
         return rc;
     }
+    return register_callable_on_device(callable_id, stream_aicpu_);
+}
+
+int DeviceRunnerBase::register_callable_on_device(int32_t callable_id, rtStream_t control_stream) {
+    auto it = callables_.find(callable_id);
+    if (it == callables_.end()) {
+        LOG_ERROR("register_callable_on_device: callable_id=%d not registered", callable_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (it->second.host_dlopen_handle != nullptr) {
+        return 0;
+    }
+    int rc = 0;
 
     // Build the orch-SO descriptor straight from CallableState — no full
     // Runtime H2D as the old prewarm path did. Registration always (re)dlopens
@@ -933,23 +1027,23 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
 
     LOG_INFO("=== launch_aicpu_payload %s ===", host::KernelNames::RegisterCallableName);
     rc = launch_aicpu_payload(
-        stream_aicpu_, &reg_args, sizeof(reg_args), host::KernelNames::RegisterCallableName, /*aicpu_num=*/1
+        control_stream, &reg_args, sizeof(reg_args), host::KernelNames::RegisterCallableName, /*aicpu_num=*/1
     );
     if (rc != 0) {
-        LOG_ERROR("launch_device_register: launch_aicpu_payload failed: %d", rc);
+        LOG_ERROR("register_callable_on_device: launch_aicpu_payload failed: %d", rc);
         return rc;
     }
 
-    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    rc = aclrtSynchronizeStreamWithTimeout(control_stream, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
     if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
         LOG_ERROR(
-            "launch_device_register: stream sync timeout timeout_ms=%d device_id=%d", PLATFORM_STREAM_SYNC_TIMEOUT_MS,
-            device_id_
+            "register_callable_on_device: stream sync timeout timeout_ms=%d device_id=%d",
+            PLATFORM_STREAM_SYNC_TIMEOUT_MS, device_id_
         );
         return rc;
     }
     if (rc != 0) {
-        LOG_ERROR("launch_device_register: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
+        LOG_ERROR("register_callable_on_device: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
         ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
@@ -1614,6 +1708,20 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
             free_tensor(device_wall_dev_ptr_);
         }
         device_wall_dev_ptr_ = nullptr;
+    }
+
+    // Kernel-mode context resources. The argument blocks route through
+    // mem_alloc_, so they are released before its finalize below; the streams
+    // and events do not, and go after them so a caller that inspects the
+    // teardown sees arguments released while their owning context still
+    // exists. Both are no-ops on a program-mode context.
+    if (abandon_device_resources) {
+        persistent_args_.abandon();
+    } else {
+        const int args_rc = persistent_args_.finalize_once();
+        if (args_rc != 0 && rc == 0) rc = args_rc;
+        const int close_rc = kernel_exec_state_.close();
+        if (close_rc != 0 && rc == 0) rc = close_rc;
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -373,7 +373,26 @@ int DeviceRunnerBase::setup_static_arena(
     ArenaBank &bank = this->arena_bank(arena_bank);
 
     bool arena_changed = false;
-    auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+    // A kernel-mode context's config is context-static, so each region is
+    // committed at most once and never grown or released afterwards; captured
+    // graphs may hold the committed base address. A request that would
+    // re-base or release a committed region under kernel mode is therefore an
+    // internal invariant break, not caller-configurable behavior. The refusal
+    // is not self-contained: the caller collapses a nonzero return to
+    // `ok = false` and then releases all three regions unconditionally, and
+    // DeviceArena::release() frees the backing buffer — so a fired guard drops
+    // the very base addresses it names.
+    const bool kernel_mode = execution_mode_latch().is_kernel();
+    auto commit_region = [&arena_changed,
+                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (requested_size == 0) {
             // hbg's runtime_arena path: caller passed 0 and never reserved
             // a region. Leave the arena uncommitted; acquire_pooled_* will
@@ -441,6 +460,10 @@ int DeviceRunnerBase::setup_static_arena(
 }
 
 std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
+    // A freshly spawned thread carries no CANN device context of its own, so
+    // this bind creates one rather than taking anything from the caller — it
+    // is the one rtSetDevice a borrowed-device context still owns, and it is
+    // scoped to a thread this runner created.
     int dev_id = device_id_;
     return std::thread([dev_id, fn = std::move(fn)]() {
         rtSetDevice(dev_id);
@@ -448,7 +471,7 @@ std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
     });
 }
 
-int DeviceRunnerBase::attach_current_thread(int device_id) {
+int DeviceRunnerBase::bind_current_thread(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("Invalid device_id: %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -468,13 +491,57 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
         ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
+    return 0;
+}
 
-    // simpler_init performs the only lifetime write. Prepared-run admission
-    // and execution subsequently attach different host threads, so repeated
-    // same-value writes here would still be a C++ data race.
+int DeviceRunnerBase::attach_current_thread(int device_id) {
+    // rtSetDevice and the op-execute watchdog below are acts of device
+    // ownership, so this entry belongs to a program context. A kernel context
+    // reaches its device through adopt_borrowed_device instead; the one caller
+    // here that runs under both identities is DeviceRunner::finalize(), which
+    // skips this call on a kernel latch.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("attach_current_thread: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
+
+    int rc = bind_current_thread(device_id);
+    if (rc != 0) return rc;
+
+    // Both writers of device_id_ — this one and adopt_borrowed_device — guard
+    // on the still-unset value, and both run before any prepare, execution or
+    // collector thread attaches. Prepared-run admission and execution
+    // subsequently attach different host threads, so repeated same-value
+    // writes here would still be a C++ data race.
     if (device_id_ == -1) {
         timeout_config_ = resolve_onboard_timeout_config();
         configure_aicore_op_timeout();
+        device_id_ = device_id;
+    }
+    return 0;
+}
+
+int DeviceRunnerBase::adopt_borrowed_device(int device_id) {
+    // The caller already holds this device current on its own threads, so the
+    // only thing a kernel context takes from it is the identity: no
+    // rtSetDevice, and no configure_aicore_op_timeout, which would rewrite the
+    // op-execute watchdog for every other user of that card. Resolving the
+    // timeout config is pure environment parsing and stays, because the stream
+    // and scheduler timeouts derived from it are read on both identities.
+    if (!execution_mode_latch().is_kernel()) {
+        LOG_ERROR("adopt_borrowed_device: refused — the context has not latched kernel mode");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    if (device_id < 0) {
+        LOG_ERROR("Invalid device_id: %d", device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ != -1 && device_id_ != device_id) {
+        LOG_ERROR("DeviceRunner already on device %d; close before adopting device %d", device_id_, device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ == -1) {
+        timeout_config_ = resolve_onboard_timeout_config();
         device_id_ = device_id;
     }
     return 0;

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -19,8 +19,9 @@
  *   - The trivial tensor-memory wrappers (`allocate_tensor`,
  *     `free_tensor`, `copy_*_device`).
  *   - The arena-pool accessors (`acquire_pooled_gm_heap`, etc.).
- *   - Device lifecycle: `attach_current_thread`,
- *     `configure_aicore_op_timeout`, `ensure_device_initialized`,
+ *   - Device lifecycle: `bind_current_thread`, `attach_current_thread`,
+ *     `adopt_borrowed_device`, `configure_aicore_op_timeout`,
+ *     `ensure_device_initialized`,
  *     `ensure_binaries_loaded`, persistent AICPU/AICore streams,
  *     dispatcher/executor bytes, `LoadAicpuOp`, `KernelArgsHelper`.
  *   - block_dim resolution: `query_max_block_dim`, `resolve_block_dim`.
@@ -65,6 +66,7 @@
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -133,6 +135,15 @@ public:
      * distinct buffers; tests read this to prove the split is real.
      */
     uint64_t retained_temp_addr(uint32_t slot_id) const;
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. Every kernel-mode guard on the ACL-lifecycle and arena
+     * paths keys on is_kernel(); `attach_current_thread` refuses outright on a
+     * kernel latch, which is what keeps the program-mode entries and the
+     * per-thread device bind off a borrowed device.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
@@ -215,17 +226,37 @@ public:
     std::thread create_thread(std::function<void()> fn);
 
     /**
-     * Attach the current host thread to the target device.
+     * Bind the calling thread to a device, taking nothing else from it.
      *
-     * Required before host-side runtime initialization may allocate or
-     * free device memory on the current thread. Idempotent for the same
-     * id; errors if called with a different id after a prior attach.
-     * No streams are created here.
+     * Idempotent for the same id; errors if called with a different id after
+     * a prior adopt. Creates no streams and records no identity.
+     *
+     * @param device_id  Device ID (0-15)
+     * @return 0 on success, error code on failure.
+     */
+    int bind_current_thread(int device_id);
+
+    /**
+     * Bind the current host thread and adopt the device for a program
+     * context: on the first call it also resolves the timeout config, writes
+     * the card's op-execute watchdog, and records device_id_.
+     *
+     * Required before host-side runtime initialization may allocate or free
+     * device memory on the current thread. Refuses with
+     * PTO_RUNTIME_ERR_UNSUPPORTED on a context latched to kernel mode, which
+     * owns neither the bind nor the watchdog.
      *
      * @param device_id  Device ID (0-15)
      * @return 0 on success, error code on failure.
      */
     int attach_current_thread(int device_id);
+    /**
+     * Record which device a kernel-mode context runs on. Takes no device side
+     * effect: the caller already holds the device current, so this neither
+     * binds the thread nor touches the card's op-execute watchdog. Requires
+     * the execution-mode latch to already read kernel.
+     */
+    int adopt_borrowed_device(int device_id);
 
     /**
      * One-shot device initialization. Performs, in order:
@@ -303,7 +334,7 @@ public:
         sdma_warmup_binary_ = std::move(sdma_warmup_binary);
     }
 
-    /** The device id captured by simpler_init's `attach_current_thread` call. */
+    /** Which device this context is on; -1 until an init entry adopts one. */
     int device_id() const { return device_id_; }
 
     /**
@@ -1176,9 +1207,16 @@ protected:
 
     // ---- State shared by both a2a3 and a5 ---------------------------------
     //
-    // `device_id_` is written once by simpler_init and is immutable while
-    // native prepare, execution, and collector threads attach to the runner.
+    // Which device this context is on — not a claim of ownership, which the
+    // execution-mode latch carries instead. Written once before any prepare,
+    // execution or collector thread attaches: `attach_current_thread` writes
+    // it for a program context and `adopt_borrowed_device` for a kernel one, both
+    // guarded on the still-unset value, so repeated same-value writes from
+    // later-attaching threads cannot race.
     int device_id_{-1};
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -67,6 +67,8 @@
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
 #include "host/execution_mode_latch.h"
+#include "host/kernel_execution_state.h"
+#include "kernel_persistent_args.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -144,6 +146,25 @@ public:
      * per-thread device bind off a borrowed device.
      */
     ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
+
+    /** Context-lifetime streams and events, live only in kernel mode. */
+    KernelExecutionState &kernel_execution_state() { return kernel_exec_state_; }
+
+    /**
+     * Bring up a kernel-mode context on a device the caller already owns:
+     * adopt its identity without changing the caller's device binding, create
+     * the context's own streams and events, then bootstrap the inner AICPU SO
+     * and launch simpler_aicpu_init on the context's AICPU stream. Creates no
+     * async-DMA workspace — that channel belongs to program mode.
+     */
+    int init_kernel_context(int device_id);
+
+    /**
+     * Register one callable on a kernel-mode context and make sure the
+     * context's persistent argument blocks exist. Idempotent in the part that
+     * matters: only the first callable pays for the argument blocks.
+     */
+    int prepare_kernel_callable(int32_t callable_id);
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
@@ -670,6 +691,14 @@ public:
     virtual int finalize() = 0;
 
     /**
+     * Populate the device-side KernelArgs fields only this architecture knows
+     * how to produce: the per-core register table on both, plus a2a3's FFTS
+     * base address. Anything allocated here must come from `mem_alloc_`, which
+     * is what PersistentKernelArgs releases through. DFX fields stay zero.
+     */
+    virtual int fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) = 0;
+
+    /**
      * dep_gen enablement setter. The shared c_api `simpler_run` calls this
      * unconditionally; a2a3 and a5 override it to capture submit_task inputs.
      * The base default is a no-op for any arch that does not implement dep_gen.
@@ -843,15 +872,26 @@ protected:
      */
     void configure_aicore_op_timeout();
 
+    /** The four operations PersistentKernelArgs is allowed to perform. */
+    PersistentArgsOps persistent_args_ops();
+
     /**
-     * Load AICPU SO and initialize device args. Called from
-     * `ensure_device_initialized()` after the persistent streams are
-     * created. Reads `aicpu_so_binary_` / `dispatcher_so_binary_` off
-     * the runner; releases both host buffers on success.
+     * Launch the AICPU callable registration on `control_stream` and wait for
+     * it. The device must already be up; launch_device_register() is the
+     * program-mode entry that brings it up first.
+     */
+    int register_callable_on_device(int32_t callable_id, rtStream_t control_stream);
+
+    /**
+     * Load AICPU SO and initialize device args. Called after the context's
+     * AICPU control stream exists, with that stream: it is `stream_aicpu_`
+     * for a program-mode context and the kernel context's own AICPU stream
+     * otherwise. Reads `aicpu_so_binary_` / `dispatcher_so_binary_` off the
+     * runner; releases both host buffers on success.
      *
      * @return 0 on success, error code on failure.
      */
-    int ensure_binaries_loaded();
+    int ensure_binaries_loaded(rtStream_t control_stream);
 
     /**
      * Initial launch of `simpler_aicpu_init`, latching the invariants (orch
@@ -862,7 +902,11 @@ protected:
      *
      * @return 0 on success, error code on failure.
      */
-    int ensure_aicpu_init_launched();
+    /**
+     * Launch simpler_aicpu_init on the context's AICPU control stream and
+     * wait for it. Same stream ownership rule as ensure_binaries_loaded().
+     */
+    int ensure_aicpu_init_launched(rtStream_t control_stream);
 
     /**
      * Provision the async-DMA workspaces this Worker asked for (see
@@ -1217,6 +1261,15 @@ protected:
     // This context's execution identity. Write-once: the first init entry to
     // run latches it, and it never changes afterwards.
     ExecutionModeLatch execution_mode_latch_;
+    // Kernel-mode context state. Both stay at their default-constructed
+    // values for a program-mode context, and neither performs a runtime call
+    // on destruction.
+    KernelExecutionState kernel_exec_state_;
+    PersistentKernelArgs persistent_args_;
+    // The Runtime image a kernel-mode context uploads once. Its per-callable
+    // and per-invocation fields stay at the sentinels Runtime() sets; binding
+    // a callable into it is a later step's work.
+    Runtime kernel_runtime_;
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results

--- a/src/common/platform/onboard/host/kernel_persistent_args.cpp
+++ b/src/common/platform/onboard/host/kernel_persistent_args.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * PersistentKernelArgs implementation.
+ *
+ * Linked into both a2a3 and a5 `libhost_runtime.so`, once per runtime variant:
+ * the `KernelArgs` layout and the `Runtime` device-image length both come from
+ * the include path the arch/runtime CMake sets up.
+ */
+
+#include "kernel_persistent_args.h"
+
+#include "common/unified_log.h"
+#include "runtime_c_api.h"
+
+int PersistentKernelArgs::prepare_once(const Runtime &host_runtime, const PersistentArgsOps &ops, uint64_t device_id) {
+    if (prepared_) return 0;
+    if (!ops.valid()) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: incomplete operation table");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    ops_ = ops;
+
+    // Only the device-read prefix of Runtime crosses to the device: trb copies
+    // its `dev` descriptor (offset 0), hbg copies the whole object.
+    const size_t runtime_bytes = runtime_device_copy_size(host_runtime);
+    void *runtime_dev = ops_.alloc(ops_.context, runtime_bytes);
+    if (runtime_dev == nullptr) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: alloc for runtime_args failed");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    int rc = ops_.copy_h2d(ops_.context, runtime_dev, runtime_bytes, &host_runtime, runtime_bytes);
+    if (rc != 0) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: copy of runtime_args failed: %d", rc);
+        (void)ops_.free_(ops_.context, runtime_dev);
+        return rc;
+    }
+    args_.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
+
+    rc = ops_.fill_arch_fields(ops_.context, &args_, device_id);
+    if (rc != 0) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: arch field init failed: %d", rc);
+        (void)ops_.free_(ops_.context, runtime_dev);
+        args_ = KernelArgs{};
+        return rc;
+    }
+
+    // Taken last: this is a whole-struct copy of `args_`, so every field the
+    // device reads — including the two blocks above — must already be set.
+    void *device_args = ops_.alloc(ops_.context, sizeof(KernelArgs));
+    if (device_args == nullptr) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: alloc for device KernelArgs failed");
+        rc = PTO_RUNTIME_ERR_INTERNAL;
+    } else {
+        rc = ops_.copy_h2d(ops_.context, device_args, sizeof(KernelArgs), &args_, sizeof(KernelArgs));
+        if (rc != 0) {
+            LOG_ERROR("PersistentKernelArgs::prepare_once: copy of device KernelArgs failed: %d", rc);
+            (void)ops_.free_(ops_.context, device_args);
+        }
+    }
+    if (rc != 0) {
+        if (args_.regs != 0) (void)ops_.free_(ops_.context, reinterpret_cast<void *>(args_.regs));
+        (void)ops_.free_(ops_.context, runtime_dev);
+        args_ = KernelArgs{};
+        return rc;
+    }
+
+    device_k_args_ = reinterpret_cast<KernelArgs *>(device_args);
+    prepared_ = true;
+    return 0;
+}
+
+int PersistentKernelArgs::release_block(void *block, int &first_error) {
+    const int rc = ops_.free_(ops_.context, block);
+    if (rc != 0 && first_error == 0) first_error = rc;
+    return rc;
+}
+
+int PersistentKernelArgs::finalize_once() {
+    if (ops_.free_ == nullptr) {
+        device_k_args_ = nullptr;
+        args_ = KernelArgs{};
+        prepared_ = false;
+        return 0;
+    }
+
+    int first_error = 0;
+    if (device_k_args_ != nullptr && release_block(device_k_args_, first_error) == 0) {
+        device_k_args_ = nullptr;
+    }
+    if (args_.regs != 0 && release_block(reinterpret_cast<void *>(args_.regs), first_error) == 0) {
+        args_.regs = 0;
+    }
+    if (args_.runtime_args != nullptr && release_block(args_.runtime_args, first_error) == 0) {
+        args_.runtime_args = nullptr;
+    }
+    if (first_error != 0) return first_error;
+
+    args_ = KernelArgs{};
+    prepared_ = false;
+    return 0;
+}
+
+void PersistentKernelArgs::abandon() {
+    args_ = KernelArgs{};
+    device_k_args_ = nullptr;
+    ops_ = {};
+    prepared_ = false;
+}

--- a/src/common/platform/onboard/host/kernel_persistent_args.h
+++ b/src/common/platform/onboard/host/kernel_persistent_args.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Context-lifetime owner of the AICore argument block.
+ *
+ * `KernelArgsHelper` reallocates its device blocks per prepared run; this owner
+ * allocates them exactly once and hands the same three device addresses to
+ * every subsequent launch, so a steady-state launch performs no allocation and
+ * no host-to-device copy.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "common/kernel_args.h"
+#include "runtime.h"
+
+/**
+ * The complete vocabulary available to argument preparation — the third
+ * restricted table alongside KernelContextOps and KernelLaunchOps, and the
+ * only one of the three that may allocate. Synchronization, stream and event
+ * operations are absent, so a launch-path operation cannot be written against
+ * this table at all.
+ *
+ * Allocation, release and host-to-device copy arrive as operations rather
+ * than a `MemoryAllocator &` because `MemoryAllocator::alloc` / `free` are
+ * non-virtual and `rtMemcpy` is a free function: a host-only test can observe
+ * the balance of this object's device traffic only if they are parameters.
+ *
+ * `fill_arch_fields` exists for the second reason, which allocation
+ * indirection alone does not solve: the device-side fields that are neither
+ * pure memory nor uniform across architectures. The register table comes from
+ * an arch entry that takes its own allocator and a different signature on
+ * a2a3 than on a5, and reaches the driver; `ffts_base_addr` exists only on
+ * a2a3. Absorbing both at the table's construction point keeps the platform
+ * knowledge with the platform, exactly as `KernelContextOps::event_flag` does
+ * for ACL_EVENT_SYNC.
+ */
+struct PersistentArgsOps {
+    void *context{nullptr};
+    void *(*alloc)(void *context, size_t bytes){nullptr};
+    int (*free_)(void *context, void *ptr){nullptr};
+    int (*copy_h2d)(void *context, void *dst, size_t dst_bytes, const void *src, size_t src_bytes){nullptr};
+    /**
+     * Populate the arch-specific device fields of `args`: `regs` on both
+     * arches (a2a3 additionally selecting AicoreRegKind::Ctrl) and
+     * `ffts_base_addr` on a2a3. DFX fields stay zero. Anything this
+     * allocates must come from `alloc` above, so release through `free_`
+     * matches and a host-only test's counts balance.
+     */
+    int (*fill_arch_fields)(void *context, KernelArgs *args, uint64_t device_id){nullptr};
+
+    bool valid() const {
+        return alloc != nullptr && free_ != nullptr && copy_h2d != nullptr && fill_arch_fields != nullptr;
+    }
+};
+
+/**
+ * Prepare-once / reuse-N-times / release-at-close owner of the three device
+ * blocks an AICore launch reads: the device `Runtime` image, the per-core
+ * register table, and the device copy of `KernelArgs` itself.
+ *
+ * Every operation this object performs happens in `prepare_once` and
+ * `finalize_once`. The destructor performs none, so an owner that is dropped
+ * without `finalize_once` leaks its device blocks rather than freeing memory
+ * an in-flight device program may still read.
+ *
+ * The ops table is stored at `prepare_once` because `finalize_once` and
+ * `abandon` run from a teardown path that no longer has it, the same reason
+ * `KernelExecutionState` stores its own.
+ */
+class PersistentKernelArgs {
+public:
+    PersistentKernelArgs() = default;
+    ~PersistentKernelArgs() = default;
+    PersistentKernelArgs(const PersistentKernelArgs &) = delete;
+    PersistentKernelArgs &operator=(const PersistentKernelArgs &) = delete;
+
+    /**
+     * Allocate and populate the three device blocks. Idempotent: a second
+     * call on a prepared owner returns 0 without allocating, which is what
+     * makes it correct to call from every prepare_callable.
+     *
+     * A failure at any step releases whatever this call allocated, in reverse
+     * order, and leaves the owner unprepared with all three fields back at
+     * their unset values; the original failure code is returned.
+     */
+    int prepare_once(const Runtime &host_runtime, const PersistentArgsOps &ops, uint64_t device_id);
+
+    bool is_prepared() const { return prepared_; }
+
+    /** Device address of the `KernelArgs` copy AICore's kernel entry receives. */
+    KernelArgs *device_k_args() const { return device_k_args_; }
+
+    const KernelArgs &args() const { return args_; }
+
+    /**
+     * Release the three device blocks in reverse allocation order. Idempotent.
+     *
+     * A failed release keeps its address so a retry redoes only the remainder,
+     * and leaves the owner prepared; the first failure code is returned.
+     */
+    int finalize_once();
+
+    /**
+     * Drop the device-address bookkeeping without calling the ops table. The
+     * device blocks are gone with the reset or quarantined device that made
+     * releasing them meaningless.
+     */
+    void abandon();
+
+private:
+    int release_block(void *block, int &first_error);
+
+    KernelArgs args_{};
+    KernelArgs *device_k_args_{nullptr};
+    PersistentArgsOps ops_{};
+    bool prepared_{false};
+};

--- a/src/common/platform/onboard/host/kernel_platform_ops.cpp
+++ b/src/common/platform/onboard/host/kernel_platform_ops.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * CANN implementation of the kernel-mode context vocabulary.
+ *
+ * Linked into both a2a3 and a5 `libhost_runtime.so`.
+ */
+
+#include "kernel_platform_ops.h"
+
+#include <acl/acl.h>
+#include <runtime/rt.h>
+
+#include "common/unified_log.h"
+#include "host/acl_error_log.h"
+
+namespace {
+
+int get_current_device(void *, int *device_id) {
+    int32_t current = -1;
+    const aclError rc = aclrtGetDevice(&current);
+    if (rc != ACL_SUCCESS) {
+        LOG_ERROR("kernel context: aclrtGetDevice failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    *device_id = static_cast<int>(current);
+    return 0;
+}
+
+int create_hidden_stream(void *, void **stream) {
+    rtStream_t created = nullptr;
+    const rtError_t rc = rtStreamCreate(&created, 0);
+    if (rc != RT_ERROR_NONE) {
+        LOG_ERROR("kernel context: rtStreamCreate failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    *stream = created;
+    return 0;
+}
+
+int destroy_hidden_stream(void *, void *stream) {
+    const rtError_t rc = rtStreamDestroy(static_cast<rtStream_t>(stream));
+    if (rc != RT_ERROR_NONE) {
+        LOG_ERROR("kernel context: rtStreamDestroy failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    return 0;
+}
+
+int create_event(void *, uint32_t flag, void **event) {
+    aclrtEvent created = nullptr;
+    const aclError rc = aclrtCreateEventExWithFlag(&created, flag);
+    if (rc != ACL_SUCCESS) {
+        LOG_ERROR("kernel context: aclrtCreateEventExWithFlag(flag=0x%x) failed: %d", flag, static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    *event = created;
+    return 0;
+}
+
+int destroy_event(void *, void *event) {
+    const aclError rc = aclrtDestroyEvent(static_cast<aclrtEvent>(event));
+    if (rc != ACL_SUCCESS) {
+        LOG_ERROR("kernel context: aclrtDestroyEvent failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    return 0;
+}
+
+}  // namespace
+
+KernelContextOps make_onboard_kernel_context_ops() {
+    KernelContextOps ops{};
+    ops.get_current_device = &get_current_device;
+    ops.create_hidden_stream = &create_hidden_stream;
+    ops.destroy_hidden_stream = &destroy_hidden_stream;
+    ops.event_flag = ACL_EVENT_SYNC;
+    ops.create_event = &create_event;
+    ops.destroy_event = &destroy_event;
+    return ops;
+}

--- a/src/common/platform/onboard/host/kernel_platform_ops.h
+++ b/src/common/platform/onboard/host/kernel_platform_ops.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The CANN backing of the kernel-mode context vocabulary.
+ *
+ * Every platform constant the context lifecycle needs — chiefly the event
+ * creation flag — is resolved here, so KernelExecutionState stays free of
+ * CANN and its host-only tests keep observing the values this platform
+ * actually asks for.
+ */
+
+#pragma once
+
+#include "host/kernel_execution_state.h"
+
+/**
+ * The context-lifetime operation table backed by CANN.
+ *
+ * Every entry is a free CANN call, so the table carries no receiver and its
+ * `context` stays null. Events are created with ACL_EVENT_SYNC: the launch
+ * sequence waits on them from a stream and never queries their status from
+ * the host.
+ */
+KernelContextOps make_onboard_kernel_context_ops();

--- a/src/common/platform/onboard/host/tmr_kernel_invocation.cpp
+++ b/src/common/platform/onboard/host/tmr_kernel_invocation.cpp
@@ -9,35 +9,14 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#pragma once
+#include "tmr_kernel_invocation.h"
 
-#include "aicpu_loader/host/load_aicpu_op.h"
-#include "worker/runtime_c_api.h"
-#include "worker/tmr_kernel_invocation.h"
-
-class DeviceRunnerBase;
+#include "device_runner_base.h"
 
 namespace simpler::tmr {
 
-inline constexpr char TmrKernelInvocationName[] = "simpler_aicpu_kernel_exec";
-
-// The runner owns the initialized loader. The same borrowing and complete
-// enqueue/commit contract below applies to this production transport adapter.
 int enqueue_tmr_invocation_aicpu(
     DeviceRunnerBase &runner, void *stream, int32_t aicpu_num, const TmrEncodingCandidate &candidate,
-    const PreparedInvocationView &callable, const TmrExecutionBindingView &binding
-) noexcept;
-
-// Called by the owner's KernelLaunchOps::launch_aicpu callback. The owner
-// holds candidate, callable and binding live through this call and commits
-// its encoding cache only after the complete enqueue sequence succeeds.
-// stream is the owner's dedicated AICPU stream, not the borrowed caller
-// stream. The owner establishes event ordering outside this transport call.
-// The loader must have registered the kernel-mode entry, not the program
-// KernelArgs entry. CPU transport copy/lifetime support is a platform
-// integration precondition, verified with the native snapshot probe.
-inline int enqueue_tmr_invocation_aicpu(
-    host::LoadAicpuOp &loader, void *stream, int32_t aicpu_num, const TmrEncodingCandidate &candidate,
     const PreparedInvocationView &callable, const TmrExecutionBindingView &binding
 ) noexcept {
     if (stream == nullptr || aicpu_num <= 0) return PTO_RUNTIME_ERR_INTERNAL;
@@ -47,8 +26,8 @@ inline int enqueue_tmr_invocation_aicpu(
     if (status != InvocationStatus::Ok) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         const auto packet = candidate.packet();
-        return loader.LaunchBuiltInOp(
-            stream, const_cast<uint8_t *>(packet.data), packet.size, aicpu_num, TmrKernelInvocationName
+        return runner.launch_aicpu_payload(
+            stream, const_cast<uint8_t *>(packet.data), packet.size, TmrKernelInvocationName, aicpu_num
         );
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;

--- a/src/common/platform/onboard/host/tmr_kernel_invocation.h
+++ b/src/common/platform/onboard/host/tmr_kernel_invocation.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "aicpu_loader/host/load_aicpu_op.h"
+#include "worker/runtime_c_api.h"
+#include "worker/tmr_kernel_invocation.h"
+
+namespace simpler::tmr {
+
+inline constexpr char TmrKernelInvocationName[] = "simpler_aicpu_kernel_exec";
+
+// Called by the owner's KernelLaunchOps::launch_aicpu callback. The owner
+// holds candidate, callable and binding live through this call and commits
+// its encoding cache only after the complete enqueue sequence succeeds.
+// stream is the owner's dedicated AICPU stream, not the borrowed caller
+// stream. The owner establishes event ordering outside this transport call.
+// The loader must have registered the kernel-mode entry, not the program
+// KernelArgs entry. CPU transport copy/lifetime support is a platform
+// integration precondition, verified with the native snapshot probe.
+inline int enqueue_tmr_invocation_aicpu(
+    host::LoadAicpuOp &loader, void *stream, int32_t aicpu_num, const TmrEncodingCandidate &candidate,
+    const PreparedInvocationView &callable, const TmrExecutionBindingView &binding
+) noexcept {
+    if (stream == nullptr || aicpu_num <= 0) return PTO_RUNTIME_ERR_INTERNAL;
+    const auto status = validate_tmr_submission(candidate, callable, binding);
+    if (status == InvocationStatus::StaleCallable || status == InvocationStatus::InvalidBinding)
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    if (status != InvocationStatus::Ok) return PTO_RUNTIME_ERR_INTERNAL;
+    try {
+        const auto packet = candidate.packet();
+        return loader.LaunchBuiltInOp(
+            stream, const_cast<uint8_t *>(packet.data), packet.size, aicpu_num, TmrKernelInvocationName
+        );
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+}
+
+}  // namespace simpler::tmr

--- a/src/common/platform/shared/host/kernel_execution_state.cpp
+++ b/src/common/platform/shared/host/kernel_execution_state.cpp
@@ -31,7 +31,7 @@ int KernelExecutionState::initialize(int requested_device_id, const KernelContex
     }
     if (rc == 0) {
         for (auto &event : events_) {
-            rc = ops_.create_event(ops_.context, &event);
+            rc = ops_.create_event(ops_.context, ops_.event_flag, &event);
             if (rc != 0) break;
         }
     }

--- a/src/common/platform/shared/host/kernel_execution_state.cpp
+++ b/src/common/platform/shared/host/kernel_execution_state.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/kernel_execution_state.h"
+
+int KernelExecutionState::initialize(int requested_device_id, const KernelContextOps &ops) {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::New) return PTO_RUNTIME_ERR_INVALID_STATE;
+    if (requested_device_id < 0 || !ops.valid()) return PTO_RUNTIME_ERR_INTERNAL;
+
+    int current_device = -1;
+    int rc = ops.get_current_device(ops.context, &current_device);
+    if (rc != 0) return rc;
+    if (current_device != requested_device_id) return PTO_RUNTIME_ERR_INVALID_STATE;
+
+    phase_ = KernelContextPhase::Initializing;
+    ops_ = ops;
+    device_id_ = requested_device_id;
+
+    for (auto &stream : hidden_streams_) {
+        rc = ops_.create_hidden_stream(ops_.context, &stream);
+        if (rc != 0) break;
+    }
+    if (rc == 0) {
+        for (auto &event : events_) {
+            rc = ops_.create_event(ops_.context, &event);
+            if (rc != 0) break;
+        }
+    }
+    if (rc != 0) {
+        const int cleanup_rc = cleanup_owned_resources_locked();
+        if (cleanup_rc != 0) {
+            if (unexpected_teardown_error_ == 0) unexpected_teardown_error_ = cleanup_rc;
+            phase_ = KernelContextPhase::Closing;
+        } else {
+            phase_ = KernelContextPhase::New;
+            device_id_ = -1;
+            ops_ = {};
+        }
+        return rc;
+    }
+
+    phase_ = KernelContextPhase::Collecting;
+    return 0;
+}
+
+int KernelExecutionState::mark_ready_enqueued() {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::Collecting && phase_ != KernelContextPhase::ReadyEnqueued) {
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    phase_ = KernelContextPhase::ReadyEnqueued;
+    return 0;
+}
+
+void KernelExecutionState::poison(int runtime_error) {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::Collecting && phase_ != KernelContextPhase::ReadyEnqueued) return;
+    phase_ = KernelContextPhase::Poisoned;
+    if (last_runtime_error_ == 0) last_runtime_error_ = runtime_error;
+}
+
+int KernelExecutionState::close() {
+    std::scoped_lock lock(mutex_);
+    switch (phase_) {
+    case KernelContextPhase::New:
+        phase_ = KernelContextPhase::Closed;
+        return 0;
+    case KernelContextPhase::Closed:
+        return 0;
+    case KernelContextPhase::Initializing:
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    case KernelContextPhase::Collecting:
+    case KernelContextPhase::ReadyEnqueued:
+    case KernelContextPhase::Poisoned:
+    case KernelContextPhase::Closing:
+        break;
+    }
+    phase_ = KernelContextPhase::Closing;
+    const int rc = cleanup_owned_resources_locked();
+    if (rc != 0) {
+        if (unexpected_teardown_error_ == 0) unexpected_teardown_error_ = rc;
+        return rc;
+    }
+    phase_ = KernelContextPhase::Closed;
+    return 0;
+}
+
+int KernelExecutionState::cleanup_owned_resources_locked() {
+    int first_error = 0;
+    for (size_t i = events_.size(); i > 0; --i) {
+        void *&event = events_[i - 1];
+        if (event == nullptr) continue;
+        const int rc = ops_.destroy_event(ops_.context, event);
+        if (rc != 0) {
+            if (first_error == 0) first_error = rc;
+            continue;
+        }
+        event = nullptr;
+    }
+    for (size_t i = hidden_streams_.size(); i > 0; --i) {
+        void *&stream = hidden_streams_[i - 1];
+        if (stream == nullptr) continue;
+        const int rc = ops_.destroy_hidden_stream(ops_.context, stream);
+        if (rc != 0) {
+            if (first_error == 0) first_error = rc;
+            continue;
+        }
+        stream = nullptr;
+    }
+    return first_error;
+}
+
+KernelContextPhase KernelExecutionState::phase() const {
+    std::scoped_lock lock(mutex_);
+    return phase_;
+}
+
+bool KernelExecutionState::accepts_dispatch() const {
+    std::scoped_lock lock(mutex_);
+    return phase_ == KernelContextPhase::Collecting || phase_ == KernelContextPhase::ReadyEnqueued;
+}
+
+int KernelExecutionState::device_id() const {
+    std::scoped_lock lock(mutex_);
+    return device_id_;
+}
+
+int KernelExecutionState::last_runtime_error() const {
+    std::scoped_lock lock(mutex_);
+    return last_runtime_error_;
+}
+
+int KernelExecutionState::unexpected_teardown_error() const {
+    std::scoped_lock lock(mutex_);
+    return unexpected_teardown_error_;
+}
+
+bool KernelExecutionState::has_live_resources() const {
+    std::scoped_lock lock(mutex_);
+    return has_live_resources_locked();
+}
+
+bool KernelExecutionState::has_live_resources_locked() const {
+    for (void *stream : hidden_streams_) {
+        if (stream != nullptr) return true;
+    }
+    for (void *event : events_) {
+        if (event != nullptr) return true;
+    }
+    return false;
+}
+
+void *KernelExecutionState::hidden_stream(KernelStreamKind kind) const {
+    std::scoped_lock lock(mutex_);
+    return hidden_streams_[static_cast<size_t>(kind)];
+}
+
+void *KernelExecutionState::event(KernelEventKind kind) const {
+    std::scoped_lock lock(mutex_);
+    return events_[static_cast<size_t>(kind)];
+}

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -24,9 +24,11 @@
 #include "runtime_c_api.h"
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -433,6 +435,18 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
+
     runner->set_dma_workspace_request(enable_sdma != 0);
 
     int rc;
@@ -1010,6 +1024,49 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
 int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * Simulation never supports kernel mode: it has no real streams for a caller
+ * to lend. supported() is 0 and init refuses after the shared structural
+ * validation, so no context here ever latches kernel mode and
+ * prepare/launch reject with INVALID_STATE. Argument validation is shared
+ * with every other component through kernel_entry_validation.h, so an
+ * argument this stub accepts is one the onboard path accepts too.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by the simulator");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -29,6 +29,8 @@
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "host/kernel_entry_validation.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -1049,6 +1051,17 @@ int simpler_kernel_mode_init(
         config, context_generation
     );
     if (rc != 0) return rc;
+    try {
+        PipelineContract contract{};
+        const int rc = build_kernel_pipeline_contract_impl(config, &contract);
+        if (rc != 0) return rc;
+        if (!is_valid_pipeline_contract(&contract, SIMPLER_MODE_KERNEL) || !has_serviceable_arena_topology(contract) ||
+            !has_serviceable_stream_topology(contract)) {
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
     LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by the simulator");
     return PTO_RUNTIME_ERR_UNSUPPORTED;
 }

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -1067,9 +1067,9 @@ int simpler_kernel_mode_init(
 }
 
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
-    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size);
     if (rc != 0) return rc;
     LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
     return PTO_RUNTIME_ERR_INVALID_STATE;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -141,7 +141,26 @@ int SimDeviceRunnerBase::setup_static_arena(
     // worker's lifetime). If a caller asks for a larger layout on any
     // region, redo just that region.
     bool arena_changed = false;
-    auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+    // A kernel-mode context's config is context-static, so each region is
+    // committed at most once and never grown or released afterwards; captured
+    // graphs may hold the committed base address. A request that would
+    // re-base or release a committed region under kernel mode is therefore an
+    // internal invariant break, not caller-configurable behavior. The refusal
+    // is not self-contained: the caller collapses a nonzero return to
+    // `ok = false` and then releases all three regions unconditionally, and
+    // DeviceArena::release() frees the backing buffer — so a fired guard drops
+    // the very base addresses it names.
+    const bool kernel_mode = execution_mode_latch().is_kernel();
+    auto commit_region = [&arena_changed,
+                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (requested_size == 0) {
             if (arena.is_committed() && cached_size != 0) {
                 arena.release();

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -55,6 +55,7 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "platform_comm/comm.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
@@ -260,6 +261,15 @@ public:
     void set_dma_workspace_request(bool enable_sdma) { sdma_requested_ = enable_sdma; }
     int ensure_dma_workspace_provisioned();
     int device_id() const { return device_id_; }
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. The arena guard keys on is_kernel(). Simulation never
+     * supports kernel mode — it has no real streams for a caller to lend — so
+     * on this backend the latch only ever holds PROGRAM.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
+
     uint64_t last_device_wall_ns() const { return device_wall_ns_; }
     // Per-phase AICPU wall (ns) from the most recent run; RunWall aliases
     // last_device_wall_ns(). 0 for a phase that was never stamped. Used to emit
@@ -368,13 +378,19 @@ protected:
     // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
 
-    // Configuration. device_id_ is set once in attach_current_thread() during
-    // simpler_init and read afterwards; the user's call sequence is single-
-    // threaded with respect to it so plain int is sufficient.
+    // Configuration. device_id_ is which device this context is on — not a
+    // claim of ownership, which the execution-mode latch carries instead. Set
+    // once in attach_current_thread() during simpler_init and read afterwards;
+    // the user's call sequence is single-threaded with respect to it so plain
+    // int is sufficient.
     int device_id_{-1};
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};
+
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
 
     // Executor binaries — populated once via set_executors() during simpler_init,
     // owned for the rest of the runner's lifetime.

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -40,6 +40,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "arg_direction.h"
@@ -108,6 +109,20 @@ struct Callable {
     int32_t child_count_;
     char config_name_[CALLABLE_FUNC_NAME_MAX];
     uint32_t config_name_len_;
+    // Cached derivation of the signature: the number of ArgDirection::SCALAR
+    // entries in signature_[0..sig_count_). The factory rejects a nonzero
+    // value that disagrees with the signature; 0 additionally means "not
+    // recorded", which a legacy blob and a scalar-free orchestration share.
+    // sig_count_ includes the scalar entries, so a consumer derives the
+    // effective count first — this field when nonzero, otherwise the
+    // signature's SCALAR entries, the split count_callable_tensor_args
+    // already computes — and takes sig_count_ minus that as the tensor
+    // comparandum. Subtracting this field directly counts an unrecorded
+    // callable's scalars as tensors. Occupies
+    // four bytes of the historical padding between config_name_len_ and the
+    // 16-byte-aligned storage_, so every other field keeps its wire offset
+    // and a legacy zero-initialized blob reads as scalar_count == 0.
+    int32_t scalar_count_;
     // Children live in storage_ at CALLABLE_ALIGN-aligned offsets, but the
     // all-uint32 header above can leave offsetof(storage_) at 4-mod-8, which
     // would place an 8-byte-aligned Child (CoreCallable has a uint64) on a
@@ -129,6 +144,9 @@ struct Callable {
     uint32_t func_name_len() const { return func_name_len_; }
     const char *config_name() const { return config_name_; }
     uint32_t config_name_len() const { return config_name_len_; }
+    // 0 means either an artifact built before this field existed or an
+    // orchestration that takes no scalars; the two are indistinguishable.
+    int32_t scalar_count() const { return scalar_count_; }
 
     const Child &child(int32_t i) const {
         if (i < 0 || i >= child_count_) throw std::out_of_range("Callable: child index out of range");
@@ -149,9 +167,9 @@ private:
 
     template <typename C, int MS, int MC>
     friend std::vector<uint8_t> make_callable(
-        const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
-        const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
-        const char *config_name
+        const ArgDirection *sig, int32_t sig_count, int32_t scalar_count, const char *func_name, const void *binary,
+        uint32_t binary_size, const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers,
+        int32_t child_count, const char *config_name
     );
 };
 
@@ -176,6 +194,43 @@ static_assert(
     offsetof(ChipCallable, storage_) % CALLABLE_CHILD_ALIGN == 0,
     "ChipCallable.storage_ must be CALLABLE_CHILD_ALIGN-aligned for SIMT kernel binaries"
 );
+
+// Callable bytes are shipped through L3/L4 IPC and the on-disk kernel cache,
+// so the header layout is wire ABI. scalar_count_ must consume tail padding
+// rather than move any historical field. The constants below encode
+// CHIP_MAX_TENSOR_ARGS = 256, CORE_MAX_TENSOR_ARGS = 32,
+// CALLABLE_FUNC_NAME_MAX = 64, and MaxChildren = 1024; a deliberate capacity
+// change updates them in the same commit.
+static_assert(
+    std::is_trivially_copyable_v<ChipCallable> && std::is_standard_layout_v<ChipCallable>,
+    "ChipCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(
+    std::is_trivially_copyable_v<CoreCallable> && std::is_standard_layout_v<CoreCallable>,
+    "CoreCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(offsetof(ChipCallable, signature_) == 0, "ChipCallable wire ABI: signature offset changed");
+static_assert(offsetof(ChipCallable, sig_count_) == 1024, "ChipCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(ChipCallable, binary_size_) == 1028, "ChipCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(ChipCallable, func_name_) == 1032, "ChipCallable wire ABI: func_name offset changed");
+static_assert(offsetof(ChipCallable, func_name_len_) == 1096, "ChipCallable wire ABI: func_name_len offset changed");
+static_assert(offsetof(ChipCallable, child_func_ids_) == 1100, "ChipCallable wire ABI: child_func_ids offset changed");
+static_assert(offsetof(ChipCallable, child_offsets_) == 5196, "ChipCallable wire ABI: child_offsets offset changed");
+static_assert(offsetof(ChipCallable, child_count_) == 9292, "ChipCallable wire ABI: child_count offset changed");
+static_assert(offsetof(ChipCallable, config_name_) == 9296, "ChipCallable wire ABI: config_name offset changed");
+static_assert(
+    offsetof(ChipCallable, config_name_len_) == 9360, "ChipCallable wire ABI: config_name_len offset changed"
+);
+static_assert(offsetof(ChipCallable, scalar_count_) == 9364, "ChipCallable wire ABI: scalar_count offset changed");
+static_assert(offsetof(ChipCallable, storage_) == 9376, "ChipCallable wire ABI: storage offset changed");
+static_assert(sizeof(ChipCallable) == 9376, "ChipCallable wire ABI: header size changed");
+static_assert(offsetof(CoreCallable, signature_) == 0, "CoreCallable wire ABI: signature offset changed");
+static_assert(offsetof(CoreCallable, sig_count_) == 128, "CoreCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(CoreCallable, binary_size_) == 132, "CoreCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(CoreCallable, resolved_addr_) == 136, "CoreCallable wire ABI: resolved_addr offset changed");
+static_assert(offsetof(CoreCallable, storage_) == 144, "CoreCallable wire ABI: storage offset changed");
+static_assert(sizeof(CoreCallable) == 144, "CoreCallable wire ABI: header size changed");
+static_assert(CoreCallable::binary_data_offset() == 192, "CoreCallable wire ABI: binary data offset changed");
 
 // ============================================================================
 // Factory: make_callable for static leaf
@@ -216,8 +271,8 @@ make_callable(const ArgDirection *sig, int32_t sig_count, const void *binary, ui
 
 template <typename Child, int MaxSig, int MaxChildren>
 std::vector<uint8_t> make_callable(
-    const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
-    const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
+    const ArgDirection *sig, int32_t sig_count, int32_t scalar_count, const char *func_name, const void *binary,
+    uint32_t binary_size, const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
     // No default arg here: the friend declaration above has none, so a default
     // on this definition is a "redeclaration may not have default arguments"
     // error once ChipCallable is instantiated (the static_assert below does
@@ -230,6 +285,27 @@ std::vector<uint8_t> make_callable(
             "make_callable: requested tensor count " + std::to_string(sig_count) + " exceeds supported tensor count " +
             std::to_string(MaxSig)
         );
+    }
+    if (scalar_count < 0 || scalar_count > CHIP_MAX_SCALAR_ARGS) {
+        throw std::invalid_argument(
+            "make_callable: requested scalar count " + std::to_string(scalar_count) +
+            " is outside the supported range [0, " + std::to_string(CHIP_MAX_SCALAR_ARGS) + "]"
+        );
+    }
+    // scalar_count is a cached derivation of the signature, so a nonzero
+    // value must match the signature's SCALAR entries; 0 stays valid with any
+    // signature because it also means "not recorded" (legacy semantics).
+    if (scalar_count != 0) {
+        int32_t signature_scalars = 0;
+        for (int32_t i = 0; i < sig_count; ++i) {
+            if (sig[i] == ArgDirection::SCALAR) ++signature_scalars;
+        }
+        if (scalar_count != signature_scalars) {
+            throw std::invalid_argument(
+                "make_callable: requested scalar count " + std::to_string(scalar_count) +
+                " disagrees with the signature's " + std::to_string(signature_scalars) + " SCALAR entries"
+            );
+        }
     }
     if (child_count > MaxChildren) throw std::invalid_argument("make_callable: child_count exceeds MaxChildren");
 
@@ -250,6 +326,7 @@ std::vector<uint8_t> make_callable(
     for (int32_t i = 0; i < sig_count; ++i)
         obj->signature_[i] = sig[i];
     obj->sig_count_ = sig_count;
+    obj->scalar_count_ = scalar_count;
     obj->binary_size_ = binary_size;
 
     // Store func_name (null-terminated, truncated to CALLABLE_FUNC_NAME_MAX-1)

--- a/src/common/task_interface/execution_mode.h
+++ b/src/common/task_interface/execution_mode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The one definition of a context's execution mode, shared by every layer
+ * that names it: the host-side identity latch on the platform runners, the
+ * invocation wire header, and the C ABI documentation. A context's mode is
+ * decided by which init entry runs first and never changes afterwards.
+ */
+
+#pragma once
+
+typedef enum SimplerExecutionMode {
+    /* Historical exclusive-device semantics, claimed by simpler_init. */
+    SIMPLER_MODE_PROGRAM = 0,
+    /* Borrowed-device semantics, claimed by simpler_kernel_mode_init. */
+    SIMPLER_MODE_KERNEL = 1,
+} SimplerExecutionMode;

--- a/src/common/task_interface/execution_mode.h
+++ b/src/common/task_interface/execution_mode.h
@@ -8,12 +8,18 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+/**
+ * The one definition of a context's execution mode, shared by every layer
+ * that names it: the host-side identity latch on the platform runners, the
+ * invocation wire header, and the C ABI documentation. A context's mode is
+ * decided by which init entry runs first and never changes afterwards.
+ */
 
 #pragma once
 
 typedef enum SimplerExecutionMode {
-    /* Exclusive-device execution. */
+    /* Historical exclusive-device semantics, claimed by simpler_init. */
     SIMPLER_MODE_PROGRAM = 0,
-    /* Caller-stream execution on a borrowed device. */
+    /* Borrowed-device semantics, claimed by simpler_kernel_mode_init. */
     SIMPLER_MODE_KERNEL = 1,
 } SimplerExecutionMode;

--- a/src/common/task_interface/kernel_invocation_header.h
+++ b/src/common/task_interface/kernel_invocation_header.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unified invocation-args wire header (host → AICPU).
+ *
+ * Every kernel-mode launch ships one immutable args snapshot to the AICPU:
+ * this fixed header followed by `payload_bytes` of runtime-specific payload.
+ * The header is the shared envelope both runtimes use; the payload format
+ * under it belongs to each runtime (tensormap_and_ringbuffer carries
+ * graph-build input, host_build_graph carries a serialized graph blob) and is
+ * not constrained here. Validating identity, generation, and capacity against
+ * this header before dispatching to the runtime payload consumer is the AICPU
+ * dispatch entry's obligation: that validation lives with the consumers, not
+ * in this header, and no consumer implements it.
+ *
+ * Both sides of this wire are produced by the same build (`build_runtimes.py`
+ * emits the host runtime and the AICPU executor into one
+ * `build/lib/{arch}/{variant}/{runtime}/`), so the struct carries no version
+ * or size negotiation: evolving it means changing both sides in one tree.
+ * The layout is still shipped by memcpy through CANN's HostArgs deep copy, so
+ * the struct is POD, position-independent, and carries no pointers.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "execution_mode.h"
+
+typedef struct SimplerKernelInvocationHeader {
+    uint32_t mode;       /* SimplerExecutionMode of the issuing context */
+    int32_t callable_id; /* target callable; matches the prepared registration */
+    /* Occupancy generation of the residency slot `callable_id` resolves to —
+       a property of the slot, not of the callable in it. The counter advances
+       when the slot takes a different tenant, so a generation carried by the
+       callable could not detect slot reuse. Zero means "not recorded"; a live
+       generation starts at 1, matching PipelineSlotLease and CanonicalIdentity.
+       The comparison belongs on the AICPU dispatch path because replay does
+       not return to the host, so a stale captured snapshot has to be caught
+       on-device. Nothing mints this value and no device-side comparand
+       exists. */
+    uint64_t generation;
+    /* Byte length of the runtime-specific payload that follows this header. */
+    uint64_t payload_bytes;
+    /* Arg counts of this invocation. ChipCallable's sig_count includes the
+       scalar entries, and its scalar_count() reads 0 both for a scalar-free
+       orchestration and for an artifact built before that field existed, so
+       a consumer derives the effective scalar count first — scalar_count()
+       when nonzero, otherwise the signature's ArgDirection::SCALAR entries —
+       then checks tensor_count against sig_count minus it and scalar_count
+       against it. Subtracting scalar_count() directly would count an
+       unrecorded callable's scalars as tensors. */
+    int32_t tensor_count;
+    int32_t scalar_count;
+    /* Count of host-only duplicate tensor args (a tensor the host must read
+       is passed twice: a device arg plus a host-only copy). Zero until the
+       host-only copy contract lands; consumers reject nonzero meanwhile. */
+    int32_t host_copy_tensor_count;
+} SimplerKernelInvocationHeader;
+
+#ifdef __cplusplus
+#include <type_traits>
+
+static_assert(
+    std::is_trivially_copyable_v<SimplerKernelInvocationHeader> &&
+    std::is_standard_layout_v<SimplerKernelInvocationHeader>
+);
+#endif

--- a/src/common/task_interface/kernel_invocation_validation.h
+++ b/src/common/task_interface/kernel_invocation_validation.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "arg_direction.h"
+#include "callable_protocol.h"
+#include "kernel_invocation_header.h"
+
+namespace simpler::kernel {
+
+struct ByteSpan {
+    const uint8_t *data{nullptr};
+    size_t size{0};
+};
+
+enum class InvocationStatus {
+    Ok,
+    InvalidArgument,
+    InvalidHeader,
+    InvalidCounts,
+    InvalidSignature,
+    InvalidSize,
+    StaleCallable,
+    InvalidBinding,
+    InvalidTensor,
+    AllocationFailure,
+};
+
+// Values come from an independently validated, live prepared registration.
+// The resource owner protects publication and borrowing through consumption.
+// slot_generation versions callable residency, not its execution context.
+struct PreparedInvocationView {
+    int32_t callable_id;
+    int32_t tensor_count;
+    int32_t scalar_count;
+    uint64_t slot_generation;
+};
+
+inline bool valid_invocation_counts(int32_t tensors, int32_t scalars) noexcept {
+    return tensors >= 0 && tensors <= CHIP_MAX_TENSOR_ARGS && scalars >= 0 && scalars <= CHIP_MAX_SCALAR_ARGS &&
+           tensors + scalars <= CHIP_MAX_TENSOR_ARGS;
+}
+
+// signature names a readable, aligned array of sig_count entries; its owning
+// callable's flexible-array bounds are validated before this function is called.
+inline InvocationStatus derive_invocation_counts(
+    const ArgDirection *signature, int32_t sig_count, int32_t cached_scalars, int32_t *tensors, int32_t *scalars
+) noexcept {
+    if (tensors == nullptr || scalars == nullptr || (signature == nullptr && sig_count != 0))
+        return InvocationStatus::InvalidArgument;
+    if (sig_count < 0 || sig_count > CHIP_MAX_TENSOR_ARGS || cached_scalars < 0 ||
+        cached_scalars > CHIP_MAX_SCALAR_ARGS)
+        return InvocationStatus::InvalidCounts;
+    int32_t scalar_count = 0;
+    for (int32_t i = 0; i < sig_count; ++i) {
+        switch (signature[i]) {
+        case ArgDirection::SCALAR:
+            ++scalar_count;
+            break;
+        case ArgDirection::IN:
+        case ArgDirection::OUT:
+        case ArgDirection::INOUT:
+            if (scalar_count != 0) return InvocationStatus::InvalidSignature;
+            break;
+        default:
+            return InvocationStatus::InvalidSignature;
+        }
+    }
+    if (!valid_invocation_counts(sig_count - scalar_count, scalar_count) ||
+        (cached_scalars != 0 && cached_scalars != scalar_count))
+        return InvocationStatus::InvalidSignature;
+    *tensors = sig_count - scalar_count;
+    *scalars = scalar_count;
+    return InvocationStatus::Ok;
+}
+
+inline bool valid_prepared_invocation(const PreparedInvocationView &view) noexcept {
+    return view.callable_id >= 0 && view.callable_id < MAX_REGISTERED_CALLABLE_IDS && view.slot_generation != 0 &&
+           valid_invocation_counts(view.tensor_count, view.scalar_count);
+}
+
+inline InvocationStatus validate_invocation_header(
+    ByteSpan packet, const PreparedInvocationView &trusted, SimplerKernelInvocationHeader *out
+) noexcept {
+    if (out == nullptr || packet.data == nullptr) return InvocationStatus::InvalidArgument;
+    if (packet.size < sizeof(SimplerKernelInvocationHeader)) return InvocationStatus::InvalidSize;
+    SimplerKernelInvocationHeader header{};
+    std::memcpy(&header, packet.data, sizeof(header));
+    if (header.mode != SIMPLER_MODE_KERNEL || header.callable_id < 0 ||
+        header.callable_id >= MAX_REGISTERED_CALLABLE_IDS || header.generation == 0)
+        return InvocationStatus::InvalidHeader;
+    if (!valid_invocation_counts(header.tensor_count, header.scalar_count) || header.host_copy_tensor_count != 0)
+        return InvocationStatus::InvalidCounts;
+    if (header.payload_bytes != packet.size - sizeof(header)) return InvocationStatus::InvalidSize;
+    if (!valid_prepared_invocation(trusted)) return InvocationStatus::InvalidArgument;
+    if (header.callable_id != trusted.callable_id || header.generation != trusted.slot_generation)
+        return InvocationStatus::StaleCallable;
+    if (header.tensor_count != trusted.tensor_count || header.scalar_count != trusted.scalar_count)
+        return InvocationStatus::InvalidCounts;
+    *out = header;
+    return InvocationStatus::Ok;
+}
+
+}  // namespace simpler::kernel

--- a/src/common/tensormap_and_ringbuffer/kernel_invocation.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_invocation.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "task_interface/kernel_invocation_validation.h"
+#include "task_interface/tensor.h"
+
+namespace simpler::tmr {
+
+using kernel::ByteSpan;
+using kernel::InvocationStatus;
+using kernel::PreparedInvocationView;
+
+// Borrowed from the owner of an immutable execution binding. This view does
+// not allocate, publish, retain or release the referenced device resources.
+// The provider owns the binding format and capacity validation. The address
+// is opaque here; context_generation is independent of callable residency.
+struct TmrExecutionBindingView {
+    uint64_t device_binding_addr;
+    uint64_t context_generation;
+};
+
+struct TmrBindingRef {
+    uint64_t device_binding_addr;
+    uint64_t context_generation;
+};
+static_assert(std::is_trivially_copyable_v<TmrBindingRef> && std::is_standard_layout_v<TmrBindingRef>);
+static_assert(sizeof(TmrBindingRef) == 16);
+static_assert(offsetof(TmrBindingRef, device_binding_addr) == 0);
+static_assert(offsetof(TmrBindingRef, context_generation) == 8);
+
+inline InvocationStatus tmr_invocation_size(const PreparedInvocationView &callable, size_t *out) noexcept {
+    if (out == nullptr || !kernel::valid_prepared_invocation(callable)) return InvocationStatus::InvalidArgument;
+    // Validated counts bound each term and the sum on all supported hosts.
+    *out = sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef) +
+           static_cast<size_t>(callable.tensor_count) * sizeof(ChipTensor) +
+           static_cast<size_t>(callable.scalar_count) * sizeof(uint64_t);
+    return InvocationStatus::Ok;
+}
+
+inline InvocationStatus normalize_invocation_tensor(const ChipTensor &input, ChipTensor *out) noexcept {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    const uint64_t element_bytes = get_element_size(input.dtype);
+    if (input.address_space != AddressSpace::DEVICE || element_bytes == 0 || input.ndims == 0 ||
+        input.ndims > MAX_TENSOR_DIMS)
+        return InvocationStatus::InvalidTensor;
+    bool empty = false;
+    for (uint32_t i = 0; i < input.ndims; ++i)
+        empty |= input.shapes[i] == 0;
+    if (!empty) {
+        const uint64_t limit = std::numeric_limits<uint64_t>::max();
+        uint64_t elements = 1;
+        uint64_t extent = 1;
+        for (uint32_t i = 0; i < input.ndims; ++i) {
+            if (input.strides[i] == 0 || elements > limit / input.shapes[i]) return InvocationStatus::InvalidTensor;
+            elements *= input.shapes[i];
+            const uint64_t term = static_cast<uint64_t>(input.shapes[i] - 1) * input.strides[i];
+            if (term > limit - extent) return InvocationStatus::InvalidTensor;
+            extent += term;
+        }
+        if (elements > limit / element_bytes || input.buffer.addr == 0 ||
+            input.buffer.size > limit - input.buffer.addr || input.start_offset > limit - extent ||
+            input.start_offset + extent > input.buffer.size / element_bytes)
+            return InvocationStatus::InvalidTensor;
+    }
+    // Empty views capture no bytes. Canonical row-major empty shapes can have
+    // zero strides; neither an address nor backing bytes are required.
+    ChipTensor normalized;
+    std::memset(&normalized, 0, sizeof(normalized));
+    normalized.buffer = input.buffer;
+    normalized.start_offset = input.start_offset;
+    normalized.ndims = input.ndims;
+    normalized.dtype = input.dtype;
+    normalized.address_space = input.address_space;
+    for (uint32_t i = 0; i < input.ndims; ++i) {
+        normalized.shapes[i] = input.shapes[i];
+        normalized.strides[i] = input.strides[i];
+    }
+    std::memcpy(out, &normalized, sizeof(normalized));
+    return InvocationStatus::Ok;
+}
+
+class TmrInvocationView;
+inline InvocationStatus decode_tmr_invocation(
+    ByteSpan packet, const PreparedInvocationView &trusted_callable, const TmrExecutionBindingView &trusted_binding,
+    TmrInvocationView *out
+) noexcept;
+
+// The immutable packet storage outlives this view and every read through it.
+class TmrInvocationView {
+public:
+    int32_t tensor_count() const noexcept { return header_.tensor_count; }
+    int32_t scalar_count() const noexcept { return header_.scalar_count; }
+    bool valid() const noexcept { return packet_.data != nullptr; }
+
+    bool tensor(int32_t index, ChipTensor *out) const noexcept {
+        if (out == nullptr || !valid() || index < 0 || index >= tensor_count()) return false;
+        const size_t offset = sizeof(header_) + sizeof(TmrBindingRef) + static_cast<size_t>(index) * sizeof(*out);
+        std::memcpy(out, packet_.data + offset, sizeof(*out));
+        return true;
+    }
+
+    bool scalar(int32_t index, uint64_t *out) const noexcept {
+        if (out == nullptr || !valid() || index < 0 || index >= scalar_count()) return false;
+        const size_t offset = sizeof(header_) + sizeof(TmrBindingRef) +
+                              static_cast<size_t>(tensor_count()) * sizeof(ChipTensor) +
+                              static_cast<size_t>(index) * sizeof(*out);
+        std::memcpy(out, packet_.data + offset, sizeof(*out));
+        return true;
+    }
+
+private:
+    ByteSpan packet_{};
+    SimplerKernelInvocationHeader header_{};
+    friend InvocationStatus decode_tmr_invocation(
+        ByteSpan, const PreparedInvocationView &, const TmrExecutionBindingView &, TmrInvocationView *
+    ) noexcept;
+};
+
+inline InvocationStatus decode_tmr_invocation(
+    ByteSpan packet, const PreparedInvocationView &trusted_callable, const TmrExecutionBindingView &trusted_binding,
+    TmrInvocationView *out
+) noexcept {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    TmrInvocationView candidate;
+    auto status = kernel::validate_invocation_header(packet, trusted_callable, &candidate.header_);
+    if (status != InvocationStatus::Ok) return status;
+    size_t expected_bytes = 0;
+    status = tmr_invocation_size(trusted_callable, &expected_bytes);
+    if (status != InvocationStatus::Ok) return status;
+    if (packet.size != expected_bytes) return InvocationStatus::InvalidSize;
+    TmrBindingRef binding{};
+    std::memcpy(&binding, packet.data + sizeof(SimplerKernelInvocationHeader), sizeof(binding));
+    if (trusted_binding.device_binding_addr == 0 || trusted_binding.context_generation == 0 ||
+        binding.device_binding_addr != trusted_binding.device_binding_addr ||
+        binding.context_generation != trusted_binding.context_generation)
+        return InvocationStatus::InvalidBinding;
+    candidate.packet_ = packet;
+    for (int32_t i = 0; i < candidate.tensor_count(); ++i) {
+        ChipTensor tensor{};
+        ChipTensor normalized{};
+        candidate.tensor(i, &tensor);
+        status = normalize_invocation_tensor(tensor, &normalized);
+        if (status != InvocationStatus::Ok) return status;
+    }
+    *out = candidate;
+    return InvocationStatus::Ok;
+}
+
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "entry_args.h"
+#include "kernel_invocation.h"
+
+namespace simpler::tmr {
+
+// out is caller-owned invocation storage and outlives config/orchestration
+// and every TensorRef derived from it. It is not a persistent Runtime prefix.
+inline InvocationStatus materialize_tmr_entry_args(const TmrInvocationView &view, EntryArgsStorage *out) noexcept {
+    if (out == nullptr || !view.valid()) return InvocationStatus::InvalidArgument;
+    out->clear();
+    for (int32_t i = 0; i < view.tensor_count(); ++i) {
+        ChipTensor tensor{};
+        view.tensor(i, &tensor);
+        out->tensors_[i] = Tensor::from_boundary(tensor);
+    }
+    for (int32_t i = 0; i < view.scalar_count(); ++i)
+        view.scalar(i, &out->scalars_[i]);
+    out->tensor_count_ = view.tensor_count();
+    out->scalar_count_ = view.scalar_count();
+    return InvocationStatus::Ok;
+}
+
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
@@ -33,4 +33,18 @@ inline InvocationStatus materialize_tmr_entry_args(const TmrInvocationView &view
     return InvocationStatus::Ok;
 }
 
+// trusted views are resolved independently of packet before this call. No
+// execution state is published until admission succeeds. out stays unchanged
+// on rejection and owns the converted arguments through their final use.
+inline InvocationStatus consume_tmr_invocation(
+    ByteSpan packet, const PreparedInvocationView &callable, const TmrExecutionBindingView &binding,
+    EntryArgsStorage *out
+) noexcept {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    TmrInvocationView view;
+    const auto status = decode_tmr_invocation(packet, callable, binding, &view);
+    if (status != InvocationStatus::Ok) return status;
+    return materialize_tmr_entry_args(view, out);
+}
+
 }  // namespace simpler::tmr

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -253,6 +253,14 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = load_symbol<CommGlobalDomainReleaseFn>(handle, "comm_global_domain_release");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
         comm_destroy_fn_ = load_symbol<CommDestroyFn>(handle, "comm_destroy");
+        // Kernel-mode lifecycle entries are part of the uniform host_runtime.so
+        // ABI like the ACL/comm group above: every runtime exports them, and
+        // variants without kernel-mode support ship validating stubs.
+        kernel_supported_fn_ = load_symbol<SimplerKernelSupportedFn>(handle, "simpler_kernel_mode_supported");
+        kernel_init_fn_ = load_symbol<SimplerKernelInitFn>(handle, "simpler_kernel_mode_init");
+        kernel_prepare_callable_fn_ =
+            load_symbol<SimplerKernelPrepareCallableFn>(handle, "simpler_kernel_mode_prepare_callable");
+        kernel_launch_fn_ = load_symbol<SimplerKernelLaunchFn>(handle, "simpler_kernel_mode_launch");
     } catch (...) {
         throw;
     }
@@ -380,6 +388,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw;
     }
@@ -439,6 +451,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw std::runtime_error("simpler_init failed with code " + std::to_string(init_rc));
     }
@@ -529,6 +545,10 @@ void ChipWorker::finalize() {
     comm_global_domain_release_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
+    kernel_supported_fn_ = nullptr;
+    kernel_init_fn_ = nullptr;
+    kernel_prepare_callable_fn_ = nullptr;
+    kernel_launch_fn_ = nullptr;
     runtime_bufs_.clear();
     pipeline_generations_.reset();
     pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <limits>
@@ -495,8 +496,20 @@ void ChipWorker::finalize() {
     // communicator handles and streams before tearing down the device context.
     clear_comm_sessions();
 
+    int device_finalize_rc = 0;
     if (device_ctx_ != nullptr && finalize_device_fn_ != nullptr && initialized_) {
-        finalize_device_fn_(device_ctx_);
+        device_finalize_rc = finalize_device_fn_(device_ctx_);
+    }
+    // A context whose teardown did not complete still owns device resources,
+    // and unloading the library that owns their release routines — or
+    // destroying the context that holds them — is unrecoverable. Both the
+    // context and the handle stay, so an explicit retry can finish the job.
+    if (device_finalize_rc != 0) {
+        std::fprintf(
+            stderr, "ChipWorker::finalize: device teardown failed (%d); keeping the context and host runtime loaded\n",
+            device_finalize_rc
+        );
+        return;
     }
     if (device_ctx_ != nullptr && destroy_device_context_fn_ != nullptr) {
         destroy_device_context_fn_(device_ctx_);

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -266,7 +266,8 @@ void ChipWorker::init(
     }
 
     const PipelineContract *contract = get_pipeline_contract_fn();
-    if (!is_valid_pipeline_contract(contract) || !has_serviceable_arena_topology(*contract)) {
+    if (!is_valid_pipeline_contract(contract) || !has_serviceable_arena_topology(*contract) ||
+        !has_serviceable_stream_topology(*contract)) {
         throw std::runtime_error("host runtime returned a PipelineContract this build cannot accept");
     }
     const PipelineContract resolved_contract = *contract;

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -296,6 +296,10 @@ private:
     using CommGlobalDomainReleaseFn = int (*)(uint64_t);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
+    using SimplerKernelSupportedFn = decltype(&simpler_kernel_mode_supported);
+    using SimplerKernelInitFn = decltype(&simpler_kernel_mode_init);
+    using SimplerKernelPrepareCallableFn = decltype(&simpler_kernel_mode_prepare_callable);
+    using SimplerKernelLaunchFn = decltype(&simpler_kernel_mode_launch);
 
     struct CommSession {
         void *handle = nullptr;
@@ -356,6 +360,10 @@ private:
     CommGlobalDomainReleaseFn comm_global_domain_release_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;
+    SimplerKernelSupportedFn kernel_supported_fn_ = nullptr;
+    SimplerKernelInitFn kernel_init_fn_ = nullptr;
+    SimplerKernelPrepareCallableFn kernel_prepare_callable_fn_ = nullptr;
+    SimplerKernelLaunchFn kernel_launch_fn_ = nullptr;
     void *device_ctx_ = nullptr;
     std::vector<CommSession> comm_sessions_;
     std::unordered_map<uint64_t, size_t> comm_session_index_;

--- a/src/common/worker/pipeline_contract.h
+++ b/src/common/worker/pipeline_contract.h
@@ -16,28 +16,31 @@
  * will honor are stated in one place and can be exercised on their own.
  */
 
-#ifndef SRC_COMMON_WORKER_PIPELINE_CONTRACT_H_
-#define SRC_COMMON_WORKER_PIPELINE_CONTRACT_H_
+#pragma once
 
 #include <cstdint>
 
 #include "runtime_c_api.h"
+#include "execution_mode.h"
 
 /**
- * Whether this build can honor `contract`.
+ * Whether `contract` has a valid structure and mode-specific byte counts.
+ * Serviceability and runtime-specific resource sets are checked separately.
  *
  * Rejects a contract whose ABI version is not the one compiled in, that
  * declares more resources than fit, that asks for a pipeline depth outside
  * the supported range, or whose resources carry an unspecified or out-of-range kind, an
- * out-of-range class, or a non-zero reserved `bytes_per_copy`.
+ * out-of-range class, or a byte count incompatible with the mode and kind.
  *
  * The unspecified-kind rule is what catches a `resource_count` larger than the
  * entries a runtime actually filled in: the trailing entries are still zeroed,
  * and zero is not a resource. Repeated kinds stay legal, so a runtime may
  * declare several resources of one kind.
  */
-inline bool is_valid_pipeline_contract(const PipelineContract *contract) {
-    if (contract == nullptr || contract->abi_version != PTO_PIPELINE_CONTRACT_ABI_VERSION ||
+// Accept the raw mode value so unknown values can be rejected before an enum cast.
+inline bool is_valid_pipeline_contract(const PipelineContract *contract, uint32_t mode) {
+    if ((mode != SIMPLER_MODE_PROGRAM && mode != SIMPLER_MODE_KERNEL) || contract == nullptr ||
+        contract->abi_version != PTO_PIPELINE_CONTRACT_ABI_VERSION ||
         contract->resource_count > PTO_PIPELINE_MAX_RESOURCES || contract->pipeline_depth == 0 ||
         contract->pipeline_depth > PTO_PIPELINE_MAX_DEPTH) {
         return false;
@@ -45,11 +48,17 @@ inline bool is_valid_pipeline_contract(const PipelineContract *contract) {
     for (uint32_t i = 0; i < contract->resource_count; ++i) {
         const PipelineResource &resource = contract->resources[i];
         if (resource.kind == PTO_PIPELINE_KIND_UNSPECIFIED || resource.kind > PTO_PIPELINE_AICORE_STREAM ||
-            resource.resource_class > PTO_PIPELINE_EXEC_HANDLE || resource.bytes_per_copy != 0) {
+            resource.resource_class > PTO_PIPELINE_EXEC_HANDLE) {
             return false;
         }
+        const bool sized_arena = mode == SIMPLER_MODE_KERNEL && resource.kind <= PTO_PIPELINE_RUNTIME_IMAGE;
+        if (sized_arena ? resource.bytes_per_copy == 0 : resource.bytes_per_copy != 0) return false;
     }
     return true;
+}
+
+inline bool is_valid_pipeline_contract(const PipelineContract *contract) {
+    return is_valid_pipeline_contract(contract, SIMPLER_MODE_PROGRAM);
 }
 
 /** Return the number of concrete copies required for one resource. */
@@ -65,6 +74,7 @@ inline uint32_t pipeline_resource_slot(
 }
 
 /** Find a declared resource kind, or return nullptr when the runtime does not use it. */
+// The caller must validate the contract before looking up a resource.
 inline const PipelineResource *find_pipeline_resource(const PipelineContract &contract, uint32_t kind) {
     for (uint32_t i = 0; i < contract.resource_count; ++i) {
         if (contract.resources[i].kind == kind) return &contract.resources[i];
@@ -81,6 +91,7 @@ inline const PipelineResource *find_pipeline_resource(const PipelineContract &co
  * declares one of them twice, where only the first entry would ever be read —
  * describes a layout the executor cannot produce, and is rejected at load
  * rather than at the first launch that would need the second bank.
+ * The caller must validate the contract before checking this topology.
  */
 inline bool has_serviceable_arena_topology(const PipelineContract &contract) {
     constexpr uint32_t ARENA_KINDS[] = {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_GM_SM, PTO_PIPELINE_RUNTIME_IMAGE};
@@ -104,4 +115,36 @@ inline bool has_serviceable_arena_topology(const PipelineContract &contract) {
     return true;
 }
 
-#endif  // SRC_COMMON_WORKER_PIPELINE_CONTRACT_H_
+// Each execution role is supplied exactly once. Copy counts do not prescribe
+// the number of physical streams created by the platform.
+inline bool has_serviceable_stream_topology(const PipelineContract &contract) {
+    if (contract.resource_count > PTO_PIPELINE_MAX_RESOURCES) return false;
+    constexpr uint32_t STREAM_KINDS[] = {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_AICORE_STREAM};
+    for (uint32_t kind : STREAM_KINDS) {
+        uint32_t count = 0;
+        for (uint32_t i = 0; i < contract.resource_count; ++i) {
+            const auto &resource = contract.resources[i];
+            if (resource.kind != kind) continue;
+            if (resource.resource_class != PTO_PIPELINE_EXEC_HANDLE) return false;
+            ++count;
+        }
+        if (count != 1) return false;
+    }
+    return true;
+}
+
+// Complete TMR kernel admission, including structural checks before any lookup.
+inline bool is_valid_tmr_kernel_pipeline_contract(const PipelineContract *contract) {
+    if (!is_valid_pipeline_contract(contract, SIMPLER_MODE_KERNEL) || contract->pipeline_depth != 1 ||
+        contract->resource_count != 6 || !has_serviceable_arena_topology(*contract) ||
+        !has_serviceable_stream_topology(*contract)) {
+        return false;
+    }
+    for (uint32_t kind = PTO_PIPELINE_GM_HEAP; kind <= PTO_PIPELINE_TASK_ARGS; ++kind) {
+        const auto *resource = find_pipeline_resource(*contract, kind);
+        const auto expected_class =
+            kind == PTO_PIPELINE_TASK_ARGS ? PTO_PIPELINE_HOST_PER_RUN : PTO_PIPELINE_DEVICE_SCRATCH;
+        if (resource == nullptr || resource->resource_class != expected_class) return false;
+    }
+    return true;
+}

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -30,6 +30,9 @@
  *                   simpler_unregister_callable,
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
  *                   get_run_stream_set_create_count
+ *   - kernel mode:  simpler_kernel_mode_supported, simpler_kernel_mode_init,
+ *                   simpler_kernel_mode_prepare_callable,
+ *                   simpler_kernel_mode_launch
  *   - pipeline:     get_pipeline_contract,
  *                   supports_concurrent_native_prepare_ctx,
  *                   get_arena_bank_gm_heap_base_ctx,
@@ -102,6 +105,10 @@ enum {
     /* The request names a capability this platform/runtime does not implement. */
     PTO_RUNTIME_ERR_UNSUPPORTED = PTO_RUNTIME_ERR_BASE - 1,
     PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = PTO_RUNTIME_ERR_BASE - 2,
+    /* The call is structurally valid but arrives out of order for this
+       context's lifecycle (e.g. launch on a context with no live kernel
+       claim). */
+    PTO_RUNTIME_ERR_INVALID_STATE = PTO_RUNTIME_ERR_BASE - 3,
 };
 
 /** Return values from simpler_poll_run(). */
@@ -324,7 +331,8 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  *      separate call. Only `prewarm_config->runtime_env` is read.
  *
  * Returns 0 on success, negative on attach, provisioning, or prewarm-build
- * failure.
+ * failure, and PTO_RUNTIME_ERR_INVALID_STATE when the context is already
+ * latched to kernel mode.
  */
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
@@ -522,6 +530,108 @@ size_t get_host_dlopen_count(DeviceContextHandle ctx);
  * bootstrap pair.
  */
 size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
+
+/* ===========================================================================
+ * Kernel-mode lifecycle (four entries + finalize_device)
+ *
+ * A context has one of two execution modes for its whole lifetime, decided by
+ * which init entry runs first. simpler_init latches program mode — the
+ * historical exclusive-device path driven through the prepared-run family
+ * above. simpler_kernel_mode_init latches kernel mode, which borrows the
+ * caller's already-current device and caller-owned stream to enqueue one
+ * bounded asynchronous operator per launch: no device reset, no internal
+ * stream/device synchronize on the prepare/launch/close paths, zero
+ * allocation at launch, and no capture/model-state queries, so a launch is
+ * capturable by ACLGraph as an ordinary node.
+ *
+ * Identity is a write-once property of the context, not a state that evolves:
+ * ExecutionModeLatch on the platform runner holds it, the first init entry to
+ * run latches it, and it never changes — not on finalize, not on error. There
+ * is no separate declaration call to forget, and no unlatch, so a handle from
+ * a failed kernel init can never be recycled into a program context.
+ * simpler_init latches PROGRAM before touching any process or runner state, so
+ * the mutual exclusion is enforced on every program init. Every kernel-mode
+ * guard on the device/ACL lifecycle and arena paths keys on the latch reading
+ * kernel; none of the entries below latches yet, so today only program
+ * contexts exist and those guards never fire.
+ *
+ * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
+ * context-static, so each pooled arena region is committed at most once and
+ * never grown or released afterwards. The platform arena reports a growth or
+ * release request under kernel mode as an internal invariant break
+ * (PTO_RUNTIME_ERR_INTERNAL), and capacity intent travels in
+ * CallConfig.runtime_env like everywhere else.
+ *
+ * All four entries below are part of the required dlsym surface: every
+ * host_runtime.so exports them, and variants without kernel-mode support
+ * export stubs that run the same structural validation and then refuse —
+ * supported returns 0, init reports PTO_RUNTIME_ERR_UNSUPPORTED, and
+ * prepare_callable and launch report PTO_RUNTIME_ERR_INVALID_STATE because
+ * no kernel context is live. The fifth lifecycle entry is the existing
+ * finalize_device(): in kernel mode it releases only context-owned resources
+ * and never resets the device or finalizes ACL. device_id_ records which
+ * device a context is on rather than a claim on it, so a kernel context
+ * reaches that teardown path; the platform finalize() skips the per-thread
+ * device bind on a kernel latch, because the caller already holds its own
+ * device current.
+ *
+ * These entries accept only POD structs, serialized blobs, and device/stream
+ * pointers — never framework objects. The caller stream is always an explicit
+ * parameter and is never stored beyond the call or destroyed by simpler.
+ * =========================================================================== */
+
+/** Return nonzero when this runtime/context can execute kernel-mode launches. */
+int simpler_kernel_mode_supported(DeviceContextHandle ctx);
+
+/**
+ * Initialize a kernel-mode context on the caller's already-current device.
+ *
+ * A successful call latches kernel mode on the context — mutually exclusive
+ * with the program-mode simpler_init — and the claim is what arms the
+ * kernel-mode guards on the platform's device/ACL lifecycle and arena paths.
+ *
+ * Takes no device ownership: no device reset, no ACL init/finalize, and no
+ * stream or device synchronize on this path. Creates only context-owned
+ * persistent handles used by asynchronous preparation and launch. `config`
+ * is context-static; launches never mutate it. `context_generation` is a
+ * nonzero host-process-unique identity minted by the caller for sequential
+ * contexts; generation zero is invalid.
+ */
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+);
+
+/**
+ * Stage one callable for kernel-mode launches, outside ACLGraph capture.
+ *
+ * `callable` points to a canonical ChipCallable image of exactly
+ * `callable_size` bytes. Validating every flexible-array offset before the
+ * image is hashed or uploaded is the implementation's obligation; the shared
+ * entry validation checks only the image's alignment, its size floor, and the
+ * callable id range. Preparation may allocate persistent state and
+ * enqueue asynchronous device work on `caller_stream`, but never synchronizes
+ * a stream or device — preparation errors surface through the caller's own
+ * warmup + synchronize. The stream is borrowed for this call only.
+ */
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+);
+
+/**
+ * Enqueue one bounded asynchronous kernel-mode operator invocation.
+ *
+ * `args` points to a ChipStorageTaskArgs POD whose tensor addresses are
+ * caller-owned device addresses; they are passed through without ever being
+ * dereferenced on the host. A launch performs no device malloc/free, no
+ * tensor staging, no synchronize, no capture-state query, and no
+ * stream-to-model attachment: KernelLaunchOps is the vocabulary that makes
+ * those unrepresentable, and routing every runtime call through it is the
+ * implementation's obligation. A return of 0 means the sequence was enqueued;
+ * device execution may still be in flight and may still fail asynchronously.
+ */
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream);
 
 #ifdef __cplusplus
 }

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -157,7 +157,10 @@ typedef enum PipelineResourceKind {
 typedef struct PipelineResource {
     uint32_t kind;
     uint32_t resource_class;
-    /* Size of one copy. Reserved: currently declared as 0 and required to be 0. */
+    /* Program: reserved, must be 0. Kernel: arena kinds declare nonzero
+       required usable bytes per copy, not committed HBM or capacity budgets.
+       Streams and TASK_ARGS must be 0; task-argument byte limits are not
+       represented by this field. */
     uint64_t bytes_per_copy;
 } PipelineResource;
 

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -543,7 +543,7 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  * above. simpler_kernel_mode_init latches kernel mode, which borrows the
  * caller's already-current device and caller-owned stream to enqueue one
  * bounded asynchronous operator per launch: no device reset, no internal
- * stream/device synchronize on the prepare/launch/close paths, zero
+ * stream/device synchronize on the launch path, zero
  * allocation at launch, and no capture/model-state queries, so a launch is
  * capturable by ACLGraph as an ordinary node.
  *
@@ -555,8 +555,8 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  * simpler_init latches PROGRAM before touching any process or runner state, so
  * the mutual exclusion is enforced on every program init. Every kernel-mode
  * guard on the device/ACL lifecycle and arena paths keys on the latch reading
- * kernel; none of the entries below latches yet, so today only program
- * contexts exist and those guards never fire.
+ * kernel. Onboard kernel init latches the identity before creating resources;
+ * simulated kernel init remains unsupported.
  *
  * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
  * context-static, so each pooled arena region is committed at most once and
@@ -566,17 +566,15 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  * CallConfig.runtime_env like everywhere else.
  *
  * All four entries below are part of the required dlsym surface: every
- * host_runtime.so exports them, and variants without kernel-mode support
- * export stubs that run the same structural validation and then refuse —
- * supported returns 0, init reports PTO_RUNTIME_ERR_UNSUPPORTED, and
- * prepare_callable and launch report PTO_RUNTIME_ERR_INVALID_STATE because
- * no kernel context is live. The fifth lifecycle entry is the existing
- * finalize_device(): in kernel mode it releases only context-owned resources
- * and never resets the device or finalizes ACL. device_id_ records which
- * device a context is on rather than a claim on it, so a kernel context
- * reaches that teardown path; the platform finalize() skips the per-thread
- * device bind on a kernel latch, because the caller already holds its own
- * device current.
+ * host_runtime.so exports them. Onboard implements init and prepare; launch
+ * remains a rejecting stub and supported returns 0. Simulated init reports
+ * PTO_RUNTIME_ERR_UNSUPPORTED; simulated prepare and launch report
+ * PTO_RUNTIME_ERR_INVALID_STATE after structural validation.
+ * The fifth lifecycle entry is the existing
+ * finalize_device(): in kernel mode it must release only context-owned
+ * resources and never reset the device or finalize ACL. Onboard kernel init
+ * records the borrowed device id, allowing explicit close to release the
+ * context-owned resources while the kernel-mode latch guards device reset.
  *
  * These entries accept only POD structs, serialized blobs, and device/stream
  * pointers — never framework objects. The caller stream is always an explicit
@@ -589,16 +587,22 @@ int simpler_kernel_mode_supported(DeviceContextHandle ctx);
 /**
  * Initialize a kernel-mode context on the caller's already-current device.
  *
- * A successful call latches kernel mode on the context — mutually exclusive
- * with the program-mode simpler_init — and the claim is what arms the
+ * After structural and lifecycle validation, the call latches kernel mode
+ * permanently, including on subsequent initialization failure. This is
+ * mutually exclusive with program-mode simpler_init and arms the
  * kernel-mode guards on the platform's device/ACL lifecycle and arena paths.
  *
- * Takes no device ownership: no device reset, no ACL init/finalize, and no
- * stream or device synchronize on this path. Creates only context-owned
- * persistent handles used by asynchronous preparation and launch. `config`
+ * Takes no device ownership: no device reset or ACL init/finalize. Bootstrap
+ * and AICPU initialization synchronize the context's dedicated AICPU stream
+ * outside capture. Creates context-owned persistent handles for preparation
+ * and launch. `config`
  * is context-static; launches never mutate it. `context_generation` is a
  * nonzero host-process-unique identity minted by the caller for sequential
  * contexts; generation zero is invalid.
+ * Repeated init is rejected without changing the existing context. An init
+ * failure after device binding retains kernel mode and requires explicit
+ * finalize_device() before destruction; initialization cannot be retried on
+ * that context.
  */
 int simpler_kernel_mode_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
@@ -611,15 +615,16 @@ int simpler_kernel_mode_init(
  *
  * `callable` points to a canonical ChipCallable image of exactly
  * `callable_size` bytes. Validating every flexible-array offset before the
- * image is hashed or uploaded is the implementation's obligation; the shared
- * entry validation checks only the image's alignment, its size floor, and the
- * callable id range. Preparation may allocate persistent state and
- * enqueue asynchronous device work on `caller_stream`, but never synchronizes
- * a stream or device — preparation errors surface through the caller's own
- * warmup + synchronize. The stream is borrowed for this call only.
+ * image is hashed or uploaded is the implementation's obligation. Shared
+ * entry validation checks the canonical image bounds, signature counts,
+ * symbol names, alignment, and callable id range. Preparation may allocate persistent state and
+ * enqueue device work on the context's own AICPU stream. It takes no caller
+ * stream: nothing it enqueues belongs on one, and the ordering a caller
+ * stream would have provided comes from that stream's own FIFO, which every
+ * later launch enqueues onto behind this registration.
  */
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 );
 
 /**

--- a/src/common/worker/tmr_kernel_invocation.h
+++ b/src/common/worker/tmr_kernel_invocation.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstring>
+#include <limits>
+#include <new>
+#include <utility>
+#include <vector>
+
+#include "task_interface/task_args.h"
+#include "tensormap_and_ringbuffer/kernel_invocation.h"
+
+namespace simpler::tmr {
+
+class TmrEncodingCache;
+class TmrEncodingCandidate;
+inline InvocationStatus encode_tmr_invocation(
+    const ChipStorageTaskArgs &, const PreparedInvocationView &, const TmrExecutionBindingView &,
+    const TmrEncodingCache &, TmrEncodingCandidate *
+);
+
+// Each candidate owns a distinct packet through the native copy operation.
+// A successfully encoded candidate can be committed only after the full
+// native enqueue sequence succeeds; device failures are asynchronous.
+class TmrEncodingCandidate {
+public:
+    TmrEncodingCandidate() = default;
+    TmrEncodingCandidate(TmrEncodingCandidate &&) noexcept = default;
+    TmrEncodingCandidate &operator=(TmrEncodingCandidate &&) noexcept = default;
+    TmrEncodingCandidate(const TmrEncodingCandidate &) = delete;
+    TmrEncodingCandidate &operator=(const TmrEncodingCandidate &) = delete;
+
+    ByteSpan packet() const noexcept { return {packet_.data(), packet_.size()}; }
+    bool structural_hit() const noexcept { return structural_hit_; }
+    bool same_invocation(const TmrEncodingCandidate &other) const noexcept {
+        return !packet_.empty() && packet_ == other.packet_;
+    }
+
+private:
+    std::vector<uint8_t> packet_;
+    std::vector<uint8_t> pending_template_;
+    bool structural_hit_{false};
+    friend class TmrEncodingCache;
+    friend InvocationStatus encode_tmr_invocation(
+        const ChipStorageTaskArgs &, const PreparedInvocationView &, const TmrExecutionBindingView &,
+        const TmrEncodingCache &, TmrEncodingCandidate *
+    );
+};
+
+// One entry per prepared callable. The owner serializes reads, commit and
+// destruction with lookup/enqueue/close; this class has no internal lock.
+// Submitted tasks never reference the cache's host storage.
+class TmrEncodingCache {
+public:
+    TmrEncodingCache() = default;
+    TmrEncodingCache(const TmrEncodingCache &) = delete;
+    TmrEncodingCache &operator=(const TmrEncodingCache &) = delete;
+
+    void commit(TmrEncodingCandidate &&candidate) noexcept {
+        if (!candidate.pending_template_.empty()) {
+            template_.swap(candidate.pending_template_);
+            candidate.pending_template_.clear();
+        }
+    }
+
+    size_t bytes() const noexcept { return template_.size(); }
+
+private:
+    // Canonical packet with tensor addresses and scalar bits zeroed. Scope,
+    // generations, geometry, offset and backing size remain in the key.
+    std::vector<uint8_t> template_;
+    friend InvocationStatus encode_tmr_invocation(
+        const ChipStorageTaskArgs &, const PreparedInvocationView &, const TmrExecutionBindingView &,
+        const TmrEncodingCache &, TmrEncodingCandidate *
+    );
+};
+
+inline InvocationStatus encode_tmr_invocation(
+    const ChipStorageTaskArgs &args, const PreparedInvocationView &callable, const TmrExecutionBindingView &binding,
+    const TmrEncodingCache &cache, TmrEncodingCandidate *out
+) {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    size_t bytes = 0;
+    auto status = tmr_invocation_size(callable, &bytes);
+    if (status != InvocationStatus::Ok) return status;
+    if (binding.device_binding_addr == 0 || binding.context_generation == 0) return InvocationStatus::InvalidBinding;
+    if (args.tensor_count() != callable.tensor_count || args.scalar_count() != callable.scalar_count)
+        return InvocationStatus::InvalidCounts;
+
+    try {
+        TmrEncodingCandidate candidate;
+        SimplerKernelInvocationHeader header;
+        std::memset(&header, 0, sizeof(header));
+        header.mode = SIMPLER_MODE_KERNEL;
+        header.callable_id = callable.callable_id;
+        header.generation = callable.slot_generation;
+        header.payload_bytes = bytes - sizeof(header);
+        header.tensor_count = callable.tensor_count;
+        header.scalar_count = callable.scalar_count;
+        const TmrBindingRef reference{binding.device_binding_addr, binding.context_generation};
+        const size_t tensors_offset = sizeof(header) + sizeof(reference);
+        bool matches = cache.template_.size() == bytes &&
+                       std::memcmp(cache.template_.data(), &header, sizeof(header)) == 0 &&
+                       std::memcmp(cache.template_.data() + sizeof(header), &reference, sizeof(reference)) == 0;
+        std::vector<ChipTensor> normalized(static_cast<size_t>(callable.tensor_count));
+        for (int32_t i = 0; i < callable.tensor_count; ++i) {
+            auto &tensor = normalized[static_cast<size_t>(i)];
+            status = normalize_invocation_tensor(args.tensor(i), &tensor);
+            if (status != InvocationStatus::Ok) return status;
+            tensor.buffer.addr = 0;
+            if (matches && std::memcmp(
+                               cache.template_.data() + tensors_offset + static_cast<size_t>(i) * sizeof(tensor),
+                               &tensor, sizeof(tensor)
+                           ) != 0)
+                matches = false;
+        }
+        candidate.structural_hit_ = matches;
+        if (matches) {
+            candidate.packet_ = cache.template_;
+        } else {
+            candidate.packet_.resize(bytes, 0);
+            std::memcpy(candidate.packet_.data(), &header, sizeof(header));
+            std::memcpy(candidate.packet_.data() + sizeof(header), &reference, sizeof(reference));
+            if (!normalized.empty())
+                std::memcpy(
+                    candidate.packet_.data() + tensors_offset, normalized.data(), normalized.size() * sizeof(ChipTensor)
+                );
+            candidate.pending_template_ = candidate.packet_;
+        }
+        for (int32_t i = 0; i < callable.tensor_count; ++i) {
+            const size_t addr_offset = tensors_offset + static_cast<size_t>(i) * sizeof(ChipTensor) +
+                                       offsetof(ChipTensor, buffer) + offsetof(PTOBufferHandle, addr);
+            std::memcpy(candidate.packet_.data() + addr_offset, &args.tensor(i).buffer.addr, sizeof(uint64_t));
+        }
+        const size_t scalar_offset = tensors_offset + static_cast<size_t>(callable.tensor_count) * sizeof(ChipTensor);
+        if (callable.scalar_count != 0)
+            std::memcpy(
+                candidate.packet_.data() + scalar_offset, args.scalar_data(),
+                static_cast<size_t>(callable.scalar_count) * sizeof(uint64_t)
+            );
+        *out = std::move(candidate);
+        return InvocationStatus::Ok;
+    } catch (const std::bad_alloc &) {
+        return InvocationStatus::AllocationFailure;
+    }
+}
+
+// The SDK stores argsSize in uint32_t. Actual packet length is taken from
+// owned storage, never from an unvalidated payload_bytes field.
+inline InvocationStatus validate_tmr_submission(
+    const TmrEncodingCandidate &candidate, const PreparedInvocationView &callable,
+    const TmrExecutionBindingView &binding
+) noexcept {
+    if (candidate.packet().size > std::numeric_limits<uint32_t>::max()) return InvocationStatus::InvalidSize;
+    TmrInvocationView view;
+    return decode_tmr_invocation(candidate.packet(), callable, binding, &view);
+}
+
+}  // namespace simpler::tmr

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -450,6 +450,22 @@ add_hierarchical_test(test_remote_wire hierarchical/test_remote_wire.cpp)
 add_hierarchical_test(test_remote_endpoint hierarchical/test_remote_endpoint.cpp)
 add_hierarchical_test(test_pipeline_contract hierarchical/test_pipeline_contract.cpp)
 
+# Exercise ChipWorker's actual dlopen/dlsym admission before a sentinel factory,
+# then the four built sim runtimes through the unchanged public kernel ABI.
+add_library(pipeline_contract_runtime SHARED stubs/pipeline_contract_runtime.cpp)
+target_include_directories(pipeline_contract_runtime PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+)
+add_hierarchical_test(test_pipeline_contract_loader hierarchical/test_pipeline_contract_loader.cpp)
+add_dependencies(test_pipeline_contract_loader pipeline_contract_runtime)
+target_compile_definitions(test_pipeline_contract_loader PRIVATE
+    PIPELINE_FIXTURE_PATH="$<TARGET_FILE:pipeline_contract_runtime>"
+    SIM_CONTEXT_PATH="${CMAKE_SOURCE_DIR}/../../../build/lib/libcpu_sim_context.so"
+    RUNTIME_LIBRARY_ROOT="${CMAKE_SOURCE_DIR}/../../../build/lib"
+)
+
 # Run-stream pair state machine: publication-aware AICore stream reuse,
 # submitter-gated retirement, and failed-destroy ownership. Header-only with
 # injected create/destroy, so it needs no runtime objects and no device.

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -594,6 +594,14 @@ add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_arg
 add_task_interface_test(test_callable_scalar_count types/test_callable_scalar_count.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
 add_task_interface_test(test_kernel_invocation_header types/test_kernel_invocation_header.cpp)
+add_task_interface_test(test_kernel_invocation_validation types/test_kernel_invocation_validation.cpp)
+add_common_utils_test(test_tmr_kernel_invocation common/test_tmr_kernel_invocation.cpp)
+target_include_directories(test_tmr_kernel_invocation PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_sources(test_tmr_kernel_invocation PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface/assert_compat.cpp
+)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -500,6 +500,37 @@ set_tests_properties(test_native_run_acceptance PROPERTIES LABELS "no_hardware")
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)
 
+# Kernel-mode entry argument validation: shared by every host-runtime
+# component (real implementation and stub alike), so its rejection rules are
+# provable here without any device or built .so.
+add_executable(test_kernel_entry_validation common/test_kernel_entry_validation.cpp)
+target_include_directories(test_kernel_entry_validation PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_kernel_entry_validation PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_entry_validation COMMAND test_kernel_entry_validation)
+set_tests_properties(test_kernel_entry_validation PROPERTIES LABELS "no_hardware")
+
+# Kernel-mode phase machine and restricted-vocabulary tables, table-driven with
+# fake ops: init/close balance, poison, sticky CLOSING with retry, and the
+# separate runtime-error vs teardown-error slots.
+add_executable(test_kernel_execution_state
+    common/test_kernel_execution_state.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/kernel_execution_state.cpp
+)
+target_include_directories(test_kernel_execution_state PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_kernel_execution_state PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_execution_state COMMAND test_kernel_execution_state)
+set_tests_properties(test_kernel_execution_state PROPERTIES LABELS "no_hardware")
+
 # Runtime extension payloads are per-run state even though the collector's
 # shared-memory resources remain resident across runs.
 add_executable(test_chip_swimlane_collector
@@ -544,7 +575,9 @@ set_tests_properties(test_sim_run_completion PROPERTIES LABELS "no_hardware")
 add_task_interface_test(test_buffer types/test_buffer.cpp)
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
+add_task_interface_test(test_callable_scalar_count types/test_callable_scalar_count.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
+add_task_interface_test(test_kernel_invocation_header types/test_kernel_invocation_header.cpp)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -681,6 +681,43 @@ target_include_directories(test_profiler_device_engine PRIVATE
 add_common_utils_test(test_worker_chip_orch_comm common/test_worker_chip_orch_comm.cpp)
 add_common_utils_test(test_file_marker_handshake common/test_file_marker_handshake.cpp)
 
+# Context-lifetime AICore argument owner. Built once per runtime variant
+# because the device image length it copies is a per-runtime decision
+# (runtime_device_copy_size): trb narrows to the `dev` descriptor, hbg copies
+# the whole Runtime. The injected alloc/free/copy vocabulary keeps both builds
+# free of CANN.
+set(KERNEL_PERSISTENT_ARGS_SRC
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host/kernel_persistent_args.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/kernel_execution_state.cpp)
+
+add_executable(test_kernel_persistent_args
+    common/test_kernel_persistent_args.cpp
+    ${KERNEL_PERSISTENT_ARGS_SRC}
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+)
+target_compile_definitions(test_kernel_persistent_args PRIVATE SIMPLER_UT_TRB_RUNTIME)
+target_include_directories(test_kernel_persistent_args PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/orchestration
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/common
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_kernel_persistent_args PRIVATE
+    a2a3_rt_objs
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_kernel_persistent_args COMMAND test_kernel_persistent_args)
+set_tests_properties(test_kernel_persistent_args PROPERTIES LABELS "no_hardware")
+
 add_executable(test_trb_runtime_temp_buffer
     common/test_trb_runtime_temp_buffer.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -1015,6 +1052,16 @@ add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp
 # links the Runtime implementation to pin the contract without a device.
 add_a2a3_hbg_runtime_test(test_dispatch_table a2a3/test_dispatch_table.cpp
     ${HBG_SHARED_DIR}/runtime.cpp)
+
+# The hbg half of the per-runtime pair started above: same assertions, whole-
+# Runtime device image.
+add_a2a3_hbg_runtime_test(test_hbg_kernel_persistent_args common/test_kernel_persistent_args.cpp
+    ${KERNEL_PERSISTENT_ARGS_SRC}
+    ${HBG_SHARED_DIR}/runtime.cpp)
+target_include_directories(test_hbg_kernel_persistent_args PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+)
 add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 # The seed test calls the real ready_queue_init_data_from_layout, so it links the
 # shared init TU (and the orchestrator/SM members that TU refers to).

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -1069,6 +1069,44 @@ TEST(BufferPoolManagerShardingTest, FreeBufferAllowsAllocationAddressReuse) {
     EXPECT_EQ(released, (std::vector<void *>{dev_ptr, dev_ptr}));
 }
 
+TEST(BufferPoolManagerShardingTest, ReleaseAllOwnedDeduplicatesBlocksAndClearsEveryQueue) {
+    profiling_common::BufferPoolManager<TestModule> manager;
+    profiling_common::MemoryOps ops;
+    ops.alloc = [](size_t) {
+        return ptr(0x4000);
+    };
+    ops.reg = [](void *dev_ptr, size_t, int, void **host_ptr) {
+        *host_ptr = dev_ptr;
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, nullptr, 0, 0);
+    void *host_ptr = nullptr;
+    ASSERT_EQ(manager.alloc_and_register_block(256, &host_ptr), ptr(0x4000));
+    manager.register_mapping(ptr(0x4040), ptr(0x4040));
+    manager.register_mapping(ptr(0x4080), ptr(0x4080));
+    manager.register_mapping(ptr(0x1000), nullptr);
+    manager.register_mapping(nullptr, nullptr);
+    ASSERT_TRUE(manager.push_recycled(0, ptr(0x4040), 0));
+    ASSERT_TRUE(manager.notify_copy_done(ptr(0x4000), 0, 1));
+    ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x4080), 2}, 2));
+    ASSERT_TRUE(manager.retire_unqueued_buffer(1, ptr(0x1000), 3));
+
+    std::vector<void *> released;
+    auto release = [&](void *p) {
+        released.push_back(p);
+    };
+    manager.release_all_owned(release);
+    ASSERT_EQ(released.size(), 2u);
+    EXPECT_EQ(std::set<void *>(released.begin(), released.end()), (std::set<void *>{ptr(0x1000), ptr(0x4000)}));
+    EXPECT_TRUE(manager.recycled_empty());
+    EXPECT_EQ(manager.drain_done_into_recycled(), 0u);
+    TestReadyBufferInfo ready;
+    EXPECT_FALSE(manager.try_pop_ready(ready, 2));
+    manager.release_owned_buffers(release);
+    manager.release_all_owned(release);
+    EXPECT_EQ(released.size(), 2u);
+}
+
 TEST(BufferPoolManagerShardingTest, ReleaseOwnedBuffersVisitsAllShards) {
     profiling_common::BufferPoolManager<TestModule> manager;
     ASSERT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x1000)));

--- a/tests/ut/cpp/common/test_kernel_entry_validation.cpp
+++ b/tests/ut/cpp/common/test_kernel_entry_validation.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #include "host/kernel_entry_validation.h"
 
 namespace {
@@ -73,43 +75,34 @@ TEST(KernelEntryValidation, InitRejectsEachStructuralViolation) {
 }
 
 TEST(KernelEntryValidation, PrepareCallableChecksIdRangeAndImageSize) {
-    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), kStream), 0);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable)), 0);
     EXPECT_EQ(
         validate_kernel_prepare_callable_args(
-            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable), kStream
+            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable)
         ),
         0
     );
     EXPECT_EQ(
-        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable), kStream),
+        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable)),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable)), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable)), PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable)),
         PTO_RUNTIME_ERR_INTERNAL
     );
     EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable), kStream), PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), nullptr),
-        PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable), kStream),
-        PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(
-            kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable), kStream
-        ),
-        PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1, kStream),
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1),
         PTO_RUNTIME_ERR_INTERNAL
     );
     // storage_ sits at a CALLABLE_CHILD_ALIGN offset from the header, so an
     // image the caller placed off-alignment puts every child off-alignment.
     static_assert(alignof(ChipCallable) > 1, "a misaligned image must be expressible");
     EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable), kStream),
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable)),
         PTO_RUNTIME_ERR_INTERNAL
     );
 }
@@ -123,6 +116,79 @@ TEST(KernelEntryValidation, LaunchChecksPointersAndIdRange) {
     EXPECT_EQ(
         validate_kernel_launch_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, kStream),
         PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, PrepareRejectsInvalidInvocationSignatureBeforeRegistration) {
+    alignas(ChipCallable) unsigned char image[sizeof(ChipCallable)] = {};
+    auto set_count = [&](size_t offset, int32_t count) {
+        std::memcpy(image + offset, &count, sizeof(count));
+    };
+    auto set_direction = [&](int32_t index, ArgDirection direction) {
+        std::memcpy(
+            image + offsetof(ChipCallable, signature_) + index * sizeof(direction), &direction, sizeof(direction)
+        );
+    };
+    set_count(offsetof(ChipCallable, sig_count_), -1);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_count(offsetof(ChipCallable, sig_count_), CHIP_MAX_TENSOR_ARGS + 1);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_count(offsetof(ChipCallable, sig_count_), 2);
+    set_direction(0, ArgDirection::IN);
+    set_direction(1, ArgDirection::SCALAR);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), 0);
+    set_count(offsetof(ChipCallable, scalar_count_), 1);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), 0);
+    set_count(offsetof(ChipCallable, scalar_count_), 2);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_count(offsetof(ChipCallable, scalar_count_), 0);
+    set_direction(0, ArgDirection::SCALAR);
+    set_direction(1, ArgDirection::OUT);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_direction(0, static_cast<ArgDirection>(99));
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+}
+
+TEST(KernelEntryValidation, PrepareBoundsCanonicalImageBeforeHashOrUpload) {
+    const uint8_t binary[] = {1, 2, 3};
+    const auto child = make_callable<CORE_MAX_TENSOR_ARGS>(nullptr, 0, binary, sizeof(binary));
+    const int32_t func_id = 0;
+    const auto valid = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        nullptr, 0, 0, "entry", binary, sizeof(binary), &func_id, &child, 1, "config"
+    );
+    ASSERT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, valid.data(), valid.size()), 0);
+    const auto *header = reinterpret_cast<const ChipCallable *>(valid.data());
+    const size_t child_start = offsetof(ChipCallable, storage_) + header->child_offset(0);
+    auto reject_word = [&](size_t offset, uint32_t value) {
+        auto image = valid;
+        std::memcpy(image.data() + offset, &value, sizeof(value));
+        EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image.data(), image.size()), PTO_RUNTIME_ERR_INTERNAL);
+    };
+    reject_word(offsetof(ChipCallable, binary_size_), UINT32_MAX);
+    reject_word(offsetof(ChipCallable, child_count_), UINT32_MAX);
+    reject_word(offsetof(ChipCallable, child_count_), 1025);
+    reject_word(offsetof(ChipCallable, child_offsets_), UINT32_MAX);
+    reject_word(offsetof(ChipCallable, child_offsets_), 1);
+    reject_word(offsetof(ChipCallable, child_offsets_), 0);
+    reject_word(child_start + offsetof(CoreCallable, binary_size_), UINT32_MAX);
+    reject_word(child_start + offsetof(CoreCallable, sig_count_), CORE_MAX_TENSOR_ARGS + 1);
+    reject_word(offsetof(ChipCallable, func_name_len_), CALLABLE_FUNC_NAME_MAX);
+    reject_word(offsetof(ChipCallable, config_name_len_), CALLABLE_FUNC_NAME_MAX);
+    auto unterminated = valid;
+    std::memset(unterminated.data() + offsetof(ChipCallable, func_name_), 'x', CALLABLE_FUNC_NAME_MAX);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, unterminated.data(), unterminated.size()),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, valid.data(), child_start + sizeof(CoreCallable) - 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, valid.data(), valid.size() - 1), PTO_RUNTIME_ERR_INTERNAL);
+    auto trailing = valid;
+    trailing.push_back(0);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, trailing.data(), trailing.size()), PTO_RUNTIME_ERR_INTERNAL
     );
 }
 

--- a/tests/ut/cpp/common/test_kernel_entry_validation.cpp
+++ b/tests/ut/cpp/common/test_kernel_entry_validation.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "host/kernel_entry_validation.h"
+
+namespace {
+
+int dummy_ctx_storage = 0;
+void *const kCtx = &dummy_ctx_storage;
+const uint8_t kBinary[4] = {1, 2, 3, 4};
+const int kConfigStorage = 0;
+const void *const kConfig = &kConfigStorage;
+int dummy_stream_storage = 0;
+void *const kStream = &dummy_stream_storage;
+alignas(ChipCallable) const unsigned char kCallableImage[sizeof(ChipCallable)] = {};
+
+TEST(KernelEntryValidation, BinarySpanRequiresPointerAndSizeTogether) {
+    EXPECT_TRUE(kernel_binary_span_is_consistent(nullptr, 0));
+    EXPECT_TRUE(kernel_binary_span_is_consistent(kBinary, sizeof(kBinary)));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(nullptr, 4));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(kBinary, 0));
+}
+
+TEST(KernelEntryValidation, InitAcceptsConsistentArgs) {
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        0
+    );
+}
+
+TEST(KernelEntryValidation, InitRejectsEachStructuralViolation) {
+    EXPECT_EQ(
+        validate_kernel_init_args(
+            nullptr, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1
+        ),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, nullptr, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, -1, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 0),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    // One inconsistent span per position, in both directions.
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, nullptr, 4, kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, 0, nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), kBinary, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, PrepareCallableChecksIdRangeAndImageSize) {
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), kStream), 0);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        0
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable), kStream), PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), nullptr),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1, kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    // storage_ sits at a CALLABLE_CHILD_ALIGN offset from the header, so an
+    // image the caller placed off-alignment puts every child off-alignment.
+    static_assert(alignof(ChipCallable) > 1, "a misaligned image must be expressible");
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, LaunchChecksPointersAndIdRange) {
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, kStream), 0);
+    EXPECT_EQ(validate_kernel_launch_args(nullptr, 0, kCallableImage, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, nullptr, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, nullptr), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, -1, kCallableImage, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(
+        validate_kernel_launch_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_execution_state.cpp
+++ b/tests/ut/cpp/common/test_kernel_execution_state.cpp
@@ -35,6 +35,8 @@ struct FakeContextOps {
     int events_created{0};
     int events_destroyed{0};
     uintptr_t next_handle{1};
+    uint32_t requested_event_flag{0};
+    std::vector<uint32_t> event_flags_seen;
 
     static FakeContextOps *self(void *context) { return static_cast<FakeContextOps *>(context); }
 
@@ -60,10 +62,11 @@ struct FakeContextOps {
         ops->streams_destroyed++;
         return 0;
     }
-    static int create_event(void *context, void **event) {
+    static int create_event(void *context, uint32_t flag, void **event) {
         auto *ops = self(context);
         if (ops->create_event_rc_after >= 0 && ops->events_created == ops->create_event_rc_after) return -44;
         ops->events_created++;
+        ops->event_flags_seen.push_back(flag);
         *event = reinterpret_cast<void *>(ops->next_handle++);
         return 0;
     }
@@ -78,13 +81,54 @@ struct FakeContextOps {
     }
 
     KernelContextOps table() {
-        return KernelContextOps{this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream,
-                                &create_event, &destroy_event};
+        return KernelContextOps{
+            this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream, requested_event_flag,
+            &create_event, &destroy_event
+        };
     }
 };
 
 constexpr size_t kStreamCount = static_cast<size_t>(KernelStreamKind::Count);
 constexpr size_t kEventCount = static_cast<size_t>(KernelEventKind::Count);
+
+class KernelContextCreationFailure : public ::testing::TestWithParam<int> {};
+
+TEST_P(KernelContextCreationFailure, EveryCreationPointRollsBackAndCanRetry) {
+    FakeContextOps fake;
+    const int point = GetParam();
+    if (point < static_cast<int>(kStreamCount)) {
+        fake.create_stream_rc_after = point;
+    } else {
+        fake.create_event_rc_after = point - kStreamCount;
+    }
+    KernelExecutionState state;
+    EXPECT_NE(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_created, fake.streams_destroyed);
+    EXPECT_EQ(fake.events_created, fake.events_destroyed);
+    EXPECT_EQ(fake.streams_created + fake.events_created, point);
+    fake.create_stream_rc_after = -1;
+    fake.create_event_rc_after = -1;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(fake.streams_created, fake.streams_destroyed);
+    EXPECT_EQ(fake.events_created, fake.events_destroyed);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllStreamsAndEvents, KernelContextCreationFailure, ::testing::Range(0, static_cast<int>(kStreamCount + kEventCount))
+);
+
+TEST(KernelExecutionState, DestructionWithoutCloseMakesNoRuntimeCalls) {
+    FakeContextOps fake;
+    {
+        KernelExecutionState state;
+        ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    }
+    EXPECT_EQ(fake.streams_destroyed, 0);
+    EXPECT_EQ(fake.events_destroyed, 0);
+}
 
 TEST(KernelContextOpsVocabulary, IncompleteTableIsInvalid) {
     FakeContextOps fake;
@@ -121,6 +165,7 @@ TEST(ExecutionModeLatch, ModesAreMutuallyExclusiveInBothDirections) {
     EXPECT_FALSE(program.is_kernel());
 
     ExecutionModeLatch kernel;
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
     EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
     EXPECT_EQ(kernel.latch(SIMPLER_MODE_PROGRAM), PTO_RUNTIME_ERR_INVALID_STATE);
     EXPECT_TRUE(kernel.is_kernel());
@@ -160,6 +205,20 @@ TEST(KernelExecutionState, EmptyContextInitThenCloseIsClean) {
     EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
     EXPECT_EQ(fake.events_destroyed, fake.events_created);
     // Idempotent close.
+    EXPECT_EQ(state.close(), 0);
+}
+
+TEST(KernelExecutionState, EveryEventCarriesTheFlagTheOpsTableAsksFor) {
+    constexpr uint32_t kPlatformEventFlag = 0x8;
+    FakeContextOps fake;
+    fake.requested_event_flag = kPlatformEventFlag;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+
+    ASSERT_EQ(fake.event_flags_seen.size(), kEventCount);
+    for (uint32_t flag : fake.event_flags_seen) {
+        EXPECT_EQ(flag, kPlatformEventFlag);
+    }
     EXPECT_EQ(state.close(), 0);
 }
 

--- a/tests/ut/cpp/common/test_kernel_execution_state.cpp
+++ b/tests/ut/cpp/common/test_kernel_execution_state.cpp
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "host/execution_mode_latch.h"
+#include "host/kernel_execution_state.h"
+
+namespace {
+
+/**
+ * Fake ops backing the restricted context vocabulary. Handles are small
+ * integers cast to pointers; create/destroy counters prove balance, and the
+ * failure knobs drive the CLOSING-retry and partial-init paths.
+ */
+struct FakeContextOps {
+    int current_device{3};
+    int get_device_rc{0};
+    int create_stream_rc_after{-1};  // fail the Nth create_hidden_stream (0-based); -1 = never
+    int create_event_rc_after{-1};
+    int destroy_failures_remaining{0};
+
+    int streams_created{0};
+    int streams_destroyed{0};
+    int events_created{0};
+    int events_destroyed{0};
+    uintptr_t next_handle{1};
+
+    static FakeContextOps *self(void *context) { return static_cast<FakeContextOps *>(context); }
+
+    static int get_current_device(void *context, int *device_id) {
+        auto *ops = self(context);
+        if (ops->get_device_rc != 0) return ops->get_device_rc;
+        *device_id = ops->current_device;
+        return 0;
+    }
+    static int create_hidden_stream(void *context, void **stream) {
+        auto *ops = self(context);
+        if (ops->create_stream_rc_after >= 0 && ops->streams_created == ops->create_stream_rc_after) return -42;
+        ops->streams_created++;
+        *stream = reinterpret_cast<void *>(ops->next_handle++);
+        return 0;
+    }
+    static int destroy_hidden_stream(void *context, void *) {
+        auto *ops = self(context);
+        if (ops->destroy_failures_remaining > 0) {
+            ops->destroy_failures_remaining--;
+            return -43;
+        }
+        ops->streams_destroyed++;
+        return 0;
+    }
+    static int create_event(void *context, void **event) {
+        auto *ops = self(context);
+        if (ops->create_event_rc_after >= 0 && ops->events_created == ops->create_event_rc_after) return -44;
+        ops->events_created++;
+        *event = reinterpret_cast<void *>(ops->next_handle++);
+        return 0;
+    }
+    static int destroy_event(void *context, void *) {
+        auto *ops = self(context);
+        if (ops->destroy_failures_remaining > 0) {
+            ops->destroy_failures_remaining--;
+            return -43;
+        }
+        ops->events_destroyed++;
+        return 0;
+    }
+
+    KernelContextOps table() {
+        return KernelContextOps{this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream,
+                                &create_event, &destroy_event};
+    }
+};
+
+constexpr size_t kStreamCount = static_cast<size_t>(KernelStreamKind::Count);
+constexpr size_t kEventCount = static_cast<size_t>(KernelEventKind::Count);
+
+TEST(KernelContextOpsVocabulary, IncompleteTableIsInvalid) {
+    FakeContextOps fake;
+    KernelContextOps ops = fake.table();
+    EXPECT_TRUE(ops.valid());
+    ops.create_event = nullptr;
+    EXPECT_FALSE(ops.valid());
+}
+
+TEST(KernelLaunchOpsVocabulary, IncompleteTableIsInvalid) {
+    KernelLaunchOps ops{};
+    EXPECT_FALSE(ops.valid());
+}
+
+TEST(ExecutionModeLatch, StartsUnlatched) {
+    ExecutionModeLatch latch;
+    EXPECT_FALSE(latch.is_latched());
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, LatchingIsIdempotentForTheHeldMode) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_TRUE(latch.is_latched());
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, ModesAreMutuallyExclusiveInBothDirections) {
+    ExecutionModeLatch program;
+    EXPECT_EQ(program.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(program.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_FALSE(program.is_kernel());
+
+    ExecutionModeLatch kernel;
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_PROGRAM), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(kernel.is_kernel());
+}
+
+// finalize resets a runner's device state but not its identity, so the
+// init -> finalize -> init sequence the program path already supports must
+// still latch cleanly the second time.
+TEST(ExecutionModeLatch, SameModeRelatchesAfterAFinalizedLifetime) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+TEST(KernelExecutionState, EmptyContextInitThenCloseIsClean) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Collecting);
+    EXPECT_TRUE(state.accepts_dispatch());
+    EXPECT_EQ(state.device_id(), 3);
+    EXPECT_EQ(fake.streams_created, static_cast<int>(kStreamCount));
+    EXPECT_EQ(fake.events_created, static_cast<int>(kEventCount));
+    for (size_t i = 0; i < kStreamCount; ++i) {
+        EXPECT_NE(state.hidden_stream(static_cast<KernelStreamKind>(i)), nullptr);
+    }
+    for (size_t i = 0; i < kEventCount; ++i) {
+        EXPECT_NE(state.event(static_cast<KernelEventKind>(i)), nullptr);
+    }
+
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+    // Idempotent close.
+    EXPECT_EQ(state.close(), 0);
+}
+
+TEST(KernelExecutionState, CloseOnNewContextIsANoOpSuccess) {
+    KernelExecutionState state;
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, RepeatedInitializeRejected) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Collecting);
+}
+
+TEST(KernelExecutionState, PreEnqueueValidationLeavesStateUnchanged) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(-1, fake.table()), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    KernelContextOps incomplete = fake.table();
+    incomplete.destroy_event = nullptr;
+    EXPECT_EQ(state.initialize(3, incomplete), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+    // The context stays usable after the clean rejections.
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+}
+
+TEST(KernelExecutionState, DeviceMismatchRejectedBeforeAnyCreation) {
+    FakeContextOps fake;
+    fake.current_device = 7;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, PartialInitFailureRollsBackCleanly) {
+    FakeContextOps fake;
+    fake.create_event_rc_after = 1;  // second event creation fails
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -44);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+    // The rolled-back context is reusable.
+    fake.create_event_rc_after = -1;
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+}
+
+TEST(KernelExecutionState, StreamCreateFailureRollsBackCleanly) {
+    FakeContextOps fake;
+    fake.create_stream_rc_after = 1;  // second hidden-stream creation fails
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -42);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, GetCurrentDeviceFailurePropagates) {
+    FakeContextOps fake;
+    fake.get_device_rc = -51;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -51);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, InitFailureWithFailedCleanupLandsInClosing) {
+    FakeContextOps fake;
+    fake.create_event_rc_after = 0;       // first event creation fails
+    fake.destroy_failures_remaining = 1;  // the rollback's first destroy also fails
+    KernelExecutionState state;
+    // The reported error is the create failure; the cleanup failure is
+    // latched in the separate teardown slot.
+    EXPECT_EQ(state.initialize(3, fake.table()), -44);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+    EXPECT_TRUE(state.has_live_resources());
+    EXPECT_FALSE(state.accepts_dispatch());
+    // The kept ops table lets an explicit close retry release the remainder.
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+}
+
+TEST(KernelExecutionState, ReadyEnqueuedKeepsAdmissionOpen) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.mark_ready_enqueued(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::ReadyEnqueued);
+    EXPECT_EQ(state.mark_ready_enqueued(), 0);  // append admission stays open
+    EXPECT_TRUE(state.accepts_dispatch());
+}
+
+TEST(KernelExecutionState, MarkReadyEnqueuedRejectedOffPath) {
+    KernelExecutionState state;
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+TEST(KernelExecutionState, PoisonRejectsDispatchButAllowsClose) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    ASSERT_EQ(state.mark_ready_enqueued(), 0);
+    state.poison(-7);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Poisoned);
+    EXPECT_FALSE(state.accepts_dispatch());
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    // First poison cause wins; later ones do not overwrite it.
+    state.poison(-8);
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, PoisonOutsideDispatchPhasesIsIgnored) {
+    KernelExecutionState state;
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, PoisonDuringClosingIsIgnored) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 1;
+    ASSERT_EQ(state.close(), -43);
+    ASSERT_EQ(state.phase(), KernelContextPhase::Closing);
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, PoisonAfterCloseIsIgnored) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    ASSERT_EQ(state.close(), 0);
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, InitializeRejectedFromEveryNonNewPhase) {
+    FakeContextOps fake;
+
+    KernelExecutionState ready;
+    ASSERT_EQ(ready.initialize(3, fake.table()), 0);
+    ASSERT_EQ(ready.mark_ready_enqueued(), 0);
+    EXPECT_EQ(ready.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(ready.phase(), KernelContextPhase::ReadyEnqueued);
+
+    KernelExecutionState poisoned;
+    ASSERT_EQ(poisoned.initialize(3, fake.table()), 0);
+    poisoned.poison(-7);
+    EXPECT_EQ(poisoned.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(poisoned.phase(), KernelContextPhase::Poisoned);
+
+    KernelExecutionState closing;
+    ASSERT_EQ(closing.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 1;
+    ASSERT_EQ(closing.close(), -43);
+    ASSERT_EQ(closing.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(closing.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(closing.phase(), KernelContextPhase::Closing);
+
+    KernelExecutionState closed;
+    EXPECT_EQ(closed.close(), 0);
+    EXPECT_EQ(closed.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(closed.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, ClosingIsStickyAndRetriable) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 2;
+    const int rc = state.close();
+    EXPECT_EQ(rc, -43);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_FALSE(state.accepts_dispatch());
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(state.has_live_resources());
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+
+    // Retry succeeds and releases only what is still live.
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+}
+
+TEST(KernelExecutionState, TeardownErrorSlotIsSeparateFromRuntimeError) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    state.poison(-7);
+    fake.destroy_failures_remaining = 1;
+    EXPECT_EQ(state.close(), -43);
+    // The controlled poison cause and the real teardown failure are reported
+    // through separate slots; neither masks the other.
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+    EXPECT_EQ(state.close(), 0);
+    // The first teardown failure stays latched after a successful retry.
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_persistent_args.cpp
+++ b/tests/ut/cpp/common/test_kernel_persistent_args.cpp
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * PersistentKernelArgs lifecycle, driven through a fake PersistentArgsOps so
+ * allocation balance, partial-failure rollback and the exact bytes that reach
+ * the device are all observable without a device.
+ *
+ * Compiled once per runtime variant: the trb build defines
+ * SIMPLER_UT_TRB_RUNTIME and copies only the `dev` descriptor, the hbg build
+ * copies the whole Runtime.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "kernel_persistent_args.h"
+#include "host/kernel_execution_state.h"
+#include "runtime_c_api.h"
+
+namespace {
+
+constexpr size_t kBlockAlign = 64;
+constexpr int kInjectedRc = -1701;
+constexpr uint64_t kDeviceId = 3;
+
+/**
+ * Records every allocation, release and host-to-device copy, and can fail the
+ * n-th of any of them. Blocks are 64-byte aligned so a recorded device image
+ * can be read back through the type that was copied into it.
+ *
+ * Its fill_arch_fields draws the register table from its own alloc, which is
+ * the obligation the real arch implementations carry too — otherwise the
+ * balance assertions below would not hold.
+ */
+struct FakeArgsOps {
+    struct Copy {
+        void *dst;
+        size_t dst_bytes;
+        size_t src_bytes;
+    };
+
+    ~FakeArgsOps() {
+        for (void *block : live)
+            ::free(block);
+    }
+
+    static FakeArgsOps *self(void *context) { return static_cast<FakeArgsOps *>(context); }
+
+    static void *alloc(void *context, size_t bytes) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("alloc");
+        ++ops->alloc_calls;
+        if (ops->alloc_calls == ops->fail_alloc_on) return nullptr;
+        const size_t rounded = ((bytes + kBlockAlign - 1) / kBlockAlign) * kBlockAlign;
+        void *block = ::aligned_alloc(kBlockAlign, rounded);
+        if (block != nullptr) {
+            std::memset(block, 0, rounded);
+            ops->live.insert(block);
+            ops->sizes[block] = bytes;
+        }
+        return block;
+    }
+
+    static int free_(void *context, void *ptr) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("free");
+        ++ops->free_calls;
+        ops->free_order.push_back(ptr);
+        if (ops->free_calls == ops->fail_free_on) return kInjectedRc;
+        if (ops->live.erase(ptr) == 0) {
+            ADD_FAILURE() << "release of a block this table does not own";
+            return kInjectedRc;
+        }
+        ops->sizes.erase(ptr);
+        ::free(ptr);
+        return 0;
+    }
+
+    static int copy_h2d(void *context, void *dst, size_t dst_bytes, const void *src, size_t src_bytes) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("copy");
+        ++ops->copy_calls;
+        ops->copies.push_back(Copy{dst, dst_bytes, src_bytes});
+        if (ops->copy_calls == ops->fail_copy_on) return kInjectedRc;
+        std::memcpy(dst, src, src_bytes < dst_bytes ? src_bytes : dst_bytes);
+        return 0;
+    }
+
+    static int fill_arch_fields(void *context, KernelArgs *args, uint64_t device_id) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("arch");
+        ++ops->fill_calls;
+        ops->last_device_id = device_id;
+        if (ops->fill_calls == ops->fail_fill_on) return kInjectedRc;
+        void *block = alloc(context, kBlockAlign);
+        if (block == nullptr) return kInjectedRc;
+        args->regs = reinterpret_cast<uint64_t>(block);
+        return 0;
+    }
+
+    PersistentArgsOps table() { return PersistentArgsOps{this, &alloc, &free_, &copy_h2d, &fill_arch_fields}; }
+
+    size_t live_blocks() const { return live.size(); }
+    size_t block_size(void *block) const {
+        const auto it = sizes.find(block);
+        return it == sizes.end() ? 0 : it->second;
+    }
+
+    int alloc_calls = 0;
+    int free_calls = 0;
+    int copy_calls = 0;
+    int fill_calls = 0;
+    int fail_alloc_on = 0;
+    int fail_free_on = 0;
+    int fail_copy_on = 0;
+    int fail_fill_on = 0;
+    uint64_t last_device_id = 0;
+    std::vector<Copy> copies;
+    std::vector<void *> free_order;
+    std::set<void *> live;
+    std::map<void *, size_t> sizes;
+    std::vector<std::string> calls;
+};
+
+struct FakeLifecycleOps {
+    FakeArgsOps memory;
+    uintptr_t next_handle{1};
+    std::set<void *> handles;
+    std::vector<std::string> &calls() { return memory.calls; }
+
+    static int create(void *context, void **handle, const char *kind) {
+        auto &fake = *static_cast<FakeLifecycleOps *>(context);
+        *handle = reinterpret_cast<void *>(fake.next_handle++);
+        fake.handles.insert(*handle);
+        fake.calls().push_back(std::string("create_") + kind);
+        return 0;
+    }
+    static int destroy(void *context, void *handle, const char *kind) {
+        auto &fake = *static_cast<FakeLifecycleOps *>(context);
+        EXPECT_EQ(fake.handles.erase(handle), 1u);
+        fake.calls().push_back(
+            std::string("destroy_") + kind + ":" + std::to_string(reinterpret_cast<uintptr_t>(handle))
+        );
+        return 0;
+    }
+    KernelContextOps context_ops() {
+        return {
+            this,
+            [](void *context, int *device) {
+                static_cast<FakeLifecycleOps *>(context)->calls().push_back("get_device");
+                *device = kDeviceId;
+                return 0;
+            },
+            [](void *context, void **stream) {
+                return create(context, stream, "stream");
+            },
+            [](void *context, void *stream) {
+                return destroy(context, stream, "stream");
+            },
+            0,
+            [](void *context, uint32_t, void **event) {
+                return create(context, event, "event");
+            },
+            [](void *context, void *event) {
+                return destroy(context, event, "event");
+            },
+        };
+    }
+
+    // Test-only downstream consumer; this does not implement or qualify the
+    // future binder's event protocol. It consumes the real owners' resources.
+    void launch(KernelExecutionState &state, const PersistentKernelArgs &args) {
+        ASSERT_TRUE(state.accepts_dispatch());
+        ASSERT_TRUE(args.is_prepared());
+        const KernelArgs *image = args.device_k_args();
+        ASSERT_NE(image, nullptr);
+        EXPECT_EQ(image->runtime_args, args.args().runtime_args);
+        EXPECT_EQ(image->regs, args.args().regs);
+        for (auto kind : {KernelStreamKind::Aicpu, KernelStreamKind::Aicore}) {
+            EXPECT_EQ(handles.count(state.hidden_stream(kind)), 1u);
+        }
+        for (size_t i = 0; i < static_cast<size_t>(KernelEventKind::Count); ++i) {
+            EXPECT_EQ(handles.count(state.event(static_cast<KernelEventKind>(i))), 1u);
+        }
+        calls().push_back("fake_launch");
+    }
+};
+
+class KernelResourceLifecycle : public ::testing::TestWithParam<int> {};
+
+TEST_P(KernelResourceLifecycle, HasExactResourceCallOrder) {
+    FakeLifecycleOps fake;
+    std::vector<std::string> expected{"get_device", "create_stream", "create_stream"};
+    expected.insert(expected.end(), static_cast<size_t>(KernelEventKind::Count), "create_event");
+    {
+        KernelExecutionState state;
+        Runtime runtime;
+        PersistentKernelArgs args;
+        ASSERT_EQ(state.initialize(kDeviceId, fake.context_ops()), 0);
+        EXPECT_EQ(fake.calls(), expected);
+        ASSERT_EQ(args.prepare_once(runtime, fake.memory.table(), kDeviceId), 0);
+        ASSERT_EQ(state.mark_ready_enqueued(), 0);
+        expected.insert(expected.end(), {"alloc", "copy", "arch", "alloc", "alloc", "copy"});
+        EXPECT_EQ(fake.calls(), expected);
+        const auto *device_args = args.device_k_args();
+        const auto *runtime_args = args.args().runtime_args;
+        const auto regs = args.args().regs;
+        for (int i = 0; i < GetParam(); ++i) {
+            SCOPED_TRACE(i);
+            ASSERT_EQ(args.prepare_once(runtime, fake.memory.table(), kDeviceId), 0);
+            fake.launch(state, args);
+            expected.push_back("fake_launch");
+            EXPECT_EQ(fake.calls(), expected);
+            EXPECT_EQ(args.device_k_args(), device_args);
+            EXPECT_EQ(args.args().runtime_args, runtime_args);
+            EXPECT_EQ(args.args().regs, regs);
+        }
+        ASSERT_EQ(args.finalize_once(), 0);
+        expected.insert(expected.end(), {"free", "free", "free"});
+        EXPECT_EQ(fake.calls(), expected);
+        ASSERT_EQ(state.close(), 0);
+        for (uintptr_t id = 2 + static_cast<size_t>(KernelEventKind::Count); id > 2; --id)
+            expected.push_back("destroy_event:" + std::to_string(id));
+        expected.insert(expected.end(), {"destroy_stream:2", "destroy_stream:1"});
+        EXPECT_EQ(fake.calls(), expected);
+        EXPECT_TRUE(fake.handles.empty());
+        EXPECT_EQ(fake.memory.live_blocks(), 0u);
+        EXPECT_EQ(args.finalize_once(), 0);
+        EXPECT_EQ(state.close(), 0);
+    }
+    EXPECT_EQ(fake.calls(), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(LaunchCounts, KernelResourceLifecycle, ::testing::Values(0, 1, 128));
+
+// ---------------------------------------------------------------------------
+// UT-P1 / UT-P2: prepare once, then reuse.
+// ---------------------------------------------------------------------------
+
+TEST(PersistentKernelArgs, ReusesTheSameAddressesForEveryLaunch) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    ASSERT_TRUE(args.is_prepared());
+    EXPECT_EQ(ops.last_device_id, kDeviceId);
+
+    KernelArgs *const device_args = args.device_k_args();
+    Runtime *const runtime_args = args.args().runtime_args;
+    const uint64_t regs = args.args().regs;
+    ASSERT_NE(device_args, nullptr);
+    ASSERT_NE(runtime_args, nullptr);
+    ASSERT_NE(regs, 0u);
+
+    const int allocs_after_prepare = ops.alloc_calls;
+    const int copies_after_prepare = ops.copy_calls;
+    for (int i = 0; i < 128; ++i) {
+        EXPECT_EQ(args.device_k_args(), device_args);
+        EXPECT_EQ(args.args().runtime_args, runtime_args);
+        EXPECT_EQ(args.args().regs, regs);
+    }
+    EXPECT_EQ(ops.alloc_calls, allocs_after_prepare);
+    EXPECT_EQ(ops.copy_calls, copies_after_prepare);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, PrepareOnceIsIdempotent) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    const int allocs = ops.alloc_calls;
+    const int copies = ops.copy_calls;
+    const int fills = ops.fill_calls;
+    KernelArgs *const device_args = args.device_k_args();
+
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    EXPECT_EQ(ops.alloc_calls, allocs);
+    EXPECT_EQ(ops.copy_calls, copies);
+    EXPECT_EQ(ops.fill_calls, fills);
+    EXPECT_EQ(args.device_k_args(), device_args);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, IncompleteOpsTableIsRejectedBeforeAnyAllocation) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    PersistentArgsOps incomplete = ops.table();
+    EXPECT_TRUE(incomplete.valid());
+    incomplete.fill_arch_fields = nullptr;
+    EXPECT_FALSE(incomplete.valid());
+
+    EXPECT_EQ(args.prepare_once(runtime, incomplete, kDeviceId), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(ops.alloc_calls, 0);
+}
+
+// ---------------------------------------------------------------------------
+// UT-P3 / UT-F2: every failing step rolls back to "never prepared".
+// ---------------------------------------------------------------------------
+
+struct RollbackCase {
+    const char *name;
+    int fail_alloc_on;
+    int fail_copy_on;
+    int fail_fill_on;
+};
+
+class PersistentKernelArgsRollback : public ::testing::TestWithParam<RollbackCase> {};
+
+TEST_P(PersistentKernelArgsRollback, ReleasesEverythingItAllocated) {
+    const RollbackCase &c = GetParam();
+    FakeArgsOps ops;
+    ops.fail_alloc_on = c.fail_alloc_on;
+    ops.fail_copy_on = c.fail_copy_on;
+    ops.fail_fill_on = c.fail_fill_on;
+
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    const int rc = args.prepare_once(runtime, ops.table(), kDeviceId);
+    EXPECT_NE(rc, 0) << c.name;
+    EXPECT_FALSE(args.is_prepared()) << c.name;
+    EXPECT_EQ(args.device_k_args(), nullptr) << c.name;
+    EXPECT_EQ(args.args().runtime_args, nullptr) << c.name;
+    EXPECT_EQ(args.args().regs, 0u) << c.name;
+    EXPECT_EQ(ops.live_blocks(), 0u) << c.name;
+
+    // A second attempt on a rolled-back owner starts from scratch and succeeds.
+    ops.fail_alloc_on = 0;
+    ops.fail_copy_on = 0;
+    ops.fail_fill_on = 0;
+    EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0) << c.name;
+    EXPECT_TRUE(args.is_prepared()) << c.name;
+    EXPECT_EQ(args.finalize_once(), 0) << c.name;
+    EXPECT_EQ(ops.live_blocks(), 0u) << c.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EveryAllocatingStep, PersistentKernelArgsRollback,
+    ::testing::Values(
+        RollbackCase{"runtime_args alloc", 1, 0, 0}, RollbackCase{"runtime_args copy", 0, 1, 0},
+        RollbackCase{"arch fields", 0, 0, 1}, RollbackCase{"arch fields alloc", 2, 0, 0},
+        RollbackCase{"device KernelArgs alloc", 3, 0, 0}, RollbackCase{"device KernelArgs copy", 0, 2, 0}
+    ),
+    [](const ::testing::TestParamInfo<RollbackCase> &info) {
+        std::string name(info.param.name);
+        for (char &ch : name) {
+            if (ch == ' ') ch = '_';
+        }
+        return name;
+    }
+);
+
+// ---------------------------------------------------------------------------
+// UT-P4 / UT-P5 / UT-F4 / UT-F5: release, abandon, retry.
+// ---------------------------------------------------------------------------
+
+TEST(PersistentKernelArgs, FinalizeOnceBalancesAndIsIdempotent) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    KernelArgs *const device_args = args.device_k_args();
+    Runtime *const runtime_args = args.args().runtime_args;
+    const uint64_t regs = args.args().regs;
+    ASSERT_EQ(args.finalize_once(), 0);
+
+    // Reverse allocation order: the device copy that names the other two
+    // blocks is released before either of them.
+    ASSERT_EQ(ops.free_order.size(), 3u);
+    EXPECT_EQ(ops.free_order[0], device_args);
+    EXPECT_EQ(ops.free_order[1], reinterpret_cast<void *>(regs));
+    EXPECT_EQ(ops.free_order[2], runtime_args);
+
+    EXPECT_EQ(ops.free_calls, ops.alloc_calls);
+    EXPECT_EQ(ops.live_blocks(), 0u);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.args().runtime_args, nullptr);
+    EXPECT_EQ(args.args().regs, 0u);
+
+    const int frees = ops.free_calls;
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees);
+}
+
+TEST(PersistentKernelArgs, FinalizeRetryRedoesOnlyTheRemainder) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    // The device KernelArgs block is released first; failing that one release
+    // still releases the remaining two and keeps only the failed address.
+    ops.fail_free_on = ops.free_calls + 1;
+    EXPECT_EQ(args.finalize_once(), kInjectedRc);
+    EXPECT_NE(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.args().runtime_args, nullptr);
+    EXPECT_EQ(args.args().regs, 0u);
+    EXPECT_EQ(ops.live_blocks(), 1u);
+    EXPECT_TRUE(args.is_prepared());
+
+    ops.fail_free_on = 0;
+    const int frees_before_retry = ops.free_calls;
+    EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees_before_retry + 1);
+    EXPECT_EQ(ops.live_blocks(), 0u);
+    EXPECT_EQ(args.device_k_args(), nullptr);
+    EXPECT_FALSE(args.is_prepared());
+}
+
+TEST(PersistentKernelArgs, AbandonNeverReachesTheOpsTable) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    const int frees = ops.free_calls;
+
+    args.abandon();
+
+    EXPECT_EQ(ops.free_calls, frees);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.args().runtime_args, nullptr);
+    EXPECT_EQ(args.args().regs, 0u);
+
+    // A later release attempt on an abandoned owner still reaches no table.
+    EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees);
+}
+
+TEST(PersistentKernelArgs, DestructionReleasesNothing) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    {
+        PersistentKernelArgs args;
+        ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    }
+    EXPECT_EQ(ops.free_calls, 0);
+    EXPECT_NE(ops.live_blocks(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// UT-P6 / UT-P7: what actually crosses to the device.
+// ---------------------------------------------------------------------------
+
+TEST(PersistentKernelArgs, CopiesExactlyTheRuntimeDeviceImage) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    ASSERT_EQ(ops.copies.size(), 2u);
+
+    const size_t image_bytes = runtime_device_copy_size(runtime);
+#if defined(SIMPLER_UT_TRB_RUNTIME)
+    EXPECT_EQ(image_bytes, sizeof(DeviceRuntimeLaunchDesc));
+    EXPECT_LT(image_bytes, sizeof(Runtime));
+#else
+    EXPECT_EQ(image_bytes, sizeof(Runtime));
+#endif
+
+    EXPECT_EQ(ops.copies[0].src_bytes, image_bytes);
+    EXPECT_EQ(ops.copies[0].dst_bytes, image_bytes);
+    EXPECT_EQ(ops.copies[0].dst, args.args().runtime_args);
+    EXPECT_EQ(ops.block_size(args.args().runtime_args), image_bytes);
+    EXPECT_EQ(std::memcmp(args.args().runtime_args, &runtime, image_bytes), 0);
+
+    EXPECT_EQ(ops.copies[1].src_bytes, sizeof(KernelArgs));
+    EXPECT_EQ(ops.copies[1].dst, args.device_k_args());
+    EXPECT_EQ(std::memcmp(args.device_k_args(), &args.args(), sizeof(KernelArgs)), 0);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, LeavesThePerCallableDispatchFieldsAtTheirSentinels) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    // The device image starts at offset 0 of Runtime under both variants, so
+    // the uploaded bytes answer the accessors the device-side code uses.
+    const Runtime *const uploaded = reinterpret_cast<const Runtime *>(args.args().runtime_args);
+    EXPECT_EQ(uploaded->get_active_callable_id(), -1);
+    for (int func_id = 0; func_id < RUNTIME_MAX_FUNC_ID; ++func_id) {
+        ASSERT_EQ(uploaded->get_function_bin_addr(func_id), 0u) << "func_id=" << func_id;
+    }
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, LeavesEveryDfxFieldZero) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    const KernelArgs *const uploaded = args.device_k_args();
+    EXPECT_EQ(uploaded->dump_data_base, 0u);
+    EXPECT_EQ(uploaded->chip_swimlane_data_base, 0u);
+    EXPECT_EQ(uploaded->pmu_data_base, 0u);
+    EXPECT_EQ(uploaded->dep_gen_data_base, 0u);
+    EXPECT_EQ(uploaded->scope_stats_data_base, 0u);
+    EXPECT_EQ(uploaded->chip_swimlane_aicore_rotation_table, 0u);
+    EXPECT_EQ(uploaded->device_wall_data_base, 0u);
+    EXPECT_EQ(uploaded->enable_profiling_flag, 0u);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
+++ b/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
@@ -92,6 +92,49 @@ TEST(TmrKernelInvocation, CacheHitStillUsesCurrentAddressesAndScalars) {
     EXPECT_EQ(cache.bytes(), first.packet().size);
 }
 
+TEST(TmrKernelInvocation, ConsumptionRejectsBeforeChangingCallerStorage) {
+    auto args = make_args();
+    TmrEncodingCache cache;
+    TmrEncodingCandidate packet;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &packet), InvocationStatus::Ok);
+    EntryArgsStorage storage{};
+    storage.scalar_count_ = 1;
+    storage.scalars_[0] = 1234;
+    auto stale = kCallable;
+    ++stale.slot_generation;
+    EXPECT_EQ(consume_tmr_invocation(packet.packet(), stale, kBinding, &storage), InvocationStatus::StaleCallable);
+    EXPECT_EQ(storage.scalar_count(), 1);
+    EXPECT_EQ(storage.scalar(0), 1234u);
+    auto wrong_binding = kBinding;
+    ++wrong_binding.context_generation;
+    EXPECT_EQ(
+        consume_tmr_invocation(packet.packet(), kCallable, wrong_binding, &storage), InvocationStatus::InvalidBinding
+    );
+    EXPECT_EQ(storage.scalar(0), 1234u);
+    EXPECT_EQ(
+        consume_tmr_invocation({packet.packet().data, packet.packet().size - 1}, kCallable, kBinding, &storage),
+        InvocationStatus::InvalidSize
+    );
+    EXPECT_EQ(storage.scalar(0), 1234u);
+    ASSERT_EQ(consume_tmr_invocation(packet.packet(), kCallable, kBinding, &storage), InvocationStatus::Ok);
+    EXPECT_EQ(storage.tensor_count(), 1);
+    EXPECT_EQ(storage.scalar(0), 19u);
+}
+
+TEST(TmrKernelInvocation, RetainedCacheIsBoundedAcrossRepeatedInvocations) {
+    TmrEncodingCache cache;
+    size_t expected_bytes = 0;
+    ASSERT_EQ(tmr_invocation_size(kCallable, &expected_bytes), InvocationStatus::Ok);
+    for (uint64_t i = 0; i < 10000; ++i) {
+        auto args = make_args(0x20000 + i * 64, i);
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+        EXPECT_EQ(candidate.structural_hit(), i != 0);
+        cache.commit(std::move(candidate));
+        EXPECT_EQ(cache.bytes(), expected_bytes);
+    }
+}
+
 TEST(TmrKernelInvocation, FailedCandidateAndUnsubmittedCandidatePreserveCache) {
     TmrEncodingCache cache;
     auto args = make_args();

--- a/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
+++ b/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "tensormap_and_ringbuffer/kernel_invocation_args.h"
+#include "worker/tmr_kernel_invocation.h"
+
+namespace {
+using namespace simpler::tmr;
+
+const PreparedInvocationView kCallable{3, 1, 1, 4};
+const TmrExecutionBindingView kBinding{0x10000, 8};
+
+ChipStorageTaskArgs make_args(uint64_t address = 0x20000, uint64_t scalar = 19) {
+    ChipStorageTaskArgs args{};
+    const uint32_t shape[] = {2, 4};
+    args.add_tensor(
+        make_tensor_external(reinterpret_cast<void *>(address), shape, 2, DataType::FLOAT32, AddressSpace::DEVICE)
+    );
+    args.add_scalar(scalar);
+    return args;
+}
+
+TEST(TmrKernelInvocation, RoundtripAndBorrowedConversion) {
+    auto args = make_args();
+    TmrEncodingCache cache;
+    TmrEncodingCandidate candidate;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    EXPECT_EQ(
+        candidate.packet().size,
+        sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef) + sizeof(ChipTensor) + sizeof(uint64_t)
+    );
+    EXPECT_FALSE(candidate.structural_hit());
+    TmrInvocationView view;
+    ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    EntryArgsStorage storage{};
+    ASSERT_EQ(materialize_tmr_entry_args(view, &storage), InvocationStatus::Ok);
+    EXPECT_EQ(storage.tensor_count(), 1);
+    EXPECT_EQ(storage.scalar(0), 19u);
+    EXPECT_EQ(storage.tensor(0).buffer.addr, 0x20000u);
+    EXPECT_EQ(storage.tensor(0).numel(), 8u);
+    EXPECT_EQ(storage.tensor(0).version, 0);
+    EXPECT_FALSE(storage.tensor(0).manual_dep);
+    ChipTensor tensor{};
+    EXPECT_FALSE(view.tensor(-1, &tensor));
+    EXPECT_FALSE(view.tensor(1, &tensor));
+    EXPECT_FALSE(view.tensor(0, nullptr));
+}
+
+TEST(TmrKernelInvocation, CacheHitStillUsesCurrentAddressesAndScalars) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    TmrEncodingCandidate first;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &first), InvocationStatus::Ok);
+    cache.commit(std::move(first));
+    TmrEncodingCandidate equal;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &equal), InvocationStatus::Ok);
+    EXPECT_TRUE(equal.structural_hit());
+    EXPECT_TRUE(first.same_invocation(equal));
+    auto changed = make_args(0x30000, 77);
+    TmrEncodingCandidate next;
+    ASSERT_EQ(encode_tmr_invocation(changed, kCallable, kBinding, cache, &next), InvocationStatus::Ok);
+    EXPECT_TRUE(next.structural_hit());
+    EXPECT_FALSE(first.same_invocation(next));
+    TmrInvocationView view;
+    ASSERT_EQ(decode_tmr_invocation(next.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    ChipTensor tensor{};
+    uint64_t scalar{};
+    ASSERT_TRUE(view.tensor(0, &tensor));
+    ASSERT_TRUE(view.scalar(0, &scalar));
+    EXPECT_EQ(tensor.buffer.addr, 0x30000u);
+    EXPECT_EQ(scalar, 77u);
+    ASSERT_EQ(decode_tmr_invocation(first.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    ASSERT_TRUE(view.scalar(0, &scalar));
+    EXPECT_EQ(scalar, 19u);
+    EXPECT_EQ(cache.bytes(), first.packet().size);
+}
+
+TEST(TmrKernelInvocation, FailedCandidateAndUnsubmittedCandidatePreserveCache) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    TmrEncodingCandidate candidate;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    cache.commit(std::move(candidate));
+    const auto saved = std::vector<uint8_t>(candidate.packet().data, candidate.packet().data + candidate.packet().size);
+    auto bad = args;
+    bad.tensor(0).buffer.addr = 0;
+    EXPECT_EQ(encode_tmr_invocation(bad, kCallable, kBinding, cache, &candidate), InvocationStatus::InvalidTensor);
+    EXPECT_EQ(std::memcmp(candidate.packet().data, saved.data(), saved.size()), 0);
+    {
+        TmrEncodingCandidate unsubmitted;
+        auto other = args;
+        other.tensor(0).shapes[0] = 1;
+        ASSERT_EQ(encode_tmr_invocation(other, kCallable, kBinding, cache, &unsubmitted), InvocationStatus::Ok);
+        EXPECT_FALSE(unsubmitted.structural_hit());
+    }
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    EXPECT_TRUE(candidate.structural_hit());
+}
+
+TEST(TmrKernelInvocation, CanonicalFieldsIgnoreUnusedDimensionsAndPadding) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    TmrEncodingCandidate first, second;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &first), InvocationStatus::Ok);
+    cache.commit(std::move(first));
+    ChipTensor noisy;
+    std::memset(&noisy, 0xa5, sizeof(noisy));
+    noisy.buffer = args.tensor(0).buffer;
+    noisy.start_offset = 0;
+    noisy.ndims = 2;
+    noisy.dtype = DataType::FLOAT32;
+    noisy.address_space = AddressSpace::DEVICE;
+    for (int i = 0; i < 2; ++i) {
+        noisy.shapes[i] = args.tensor(0).shapes[i];
+        noisy.strides[i] = args.tensor(0).strides[i];
+    }
+    args.tensor(0) = noisy;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &second), InvocationStatus::Ok);
+    EXPECT_TRUE(second.structural_hit());
+    EXPECT_TRUE(first.same_invocation(second));
+}
+
+TEST(TmrKernelInvocation, GeometryBackingAndGenerationsInvalidateTemplate) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    args.tensor(0).buffer.size = 128;
+    TmrEncodingCandidate first;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &first), InvocationStatus::Ok);
+    cache.commit(std::move(first));
+    for (int change = 0; change < 7; ++change) {
+        auto current = args;
+        auto callable = kCallable;
+        auto binding = kBinding;
+        if (change == 0) current.tensor(0).shapes[0] = 1;
+        if (change == 1) current.tensor(0).strides[0] = 8;
+        if (change == 2) current.tensor(0).start_offset = 1;
+        if (change == 3) current.tensor(0).buffer.size = 132;
+        if (change == 4) ++callable.slot_generation;
+        if (change == 5) ++binding.context_generation;
+        if (change == 6) current.tensor(0).dtype = DataType::FLOAT16;
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(current, callable, binding, cache, &candidate), InvocationStatus::Ok);
+        EXPECT_FALSE(candidate.structural_hit());
+    }
+}
+
+TEST(TmrKernelInvocation, DecoderRejectsCorruptionTruncationAndPreservesView) {
+    TmrEncodingCache cache;
+    TmrEncodingCandidate candidate;
+    auto args = make_args();
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    TmrInvocationView good;
+    ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &good), InvocationStatus::Ok);
+    std::vector<uint8_t> unaligned(candidate.packet().size + 1);
+    std::memcpy(unaligned.data() + 1, candidate.packet().data, candidate.packet().size);
+    TmrInvocationView view;
+    ASSERT_EQ(
+        decode_tmr_invocation({unaligned.data() + 1, candidate.packet().size}, kCallable, kBinding, &view),
+        InvocationStatus::Ok
+    );
+    for (size_t length = 0; length < candidate.packet().size; ++length) {
+        EXPECT_NE(
+            decode_tmr_invocation({candidate.packet().data, length}, kCallable, kBinding, &good), InvocationStatus::Ok
+        );
+        EXPECT_TRUE(good.valid());
+    }
+    auto stale = kCallable;
+    ++stale.slot_generation;
+    EXPECT_EQ(validate_tmr_submission(candidate, stale, kBinding), InvocationStatus::StaleCallable);
+    auto other_binding = kBinding;
+    ++other_binding.context_generation;
+    EXPECT_EQ(validate_tmr_submission(candidate, kCallable, other_binding), InvocationStatus::InvalidBinding);
+    other_binding = kBinding;
+    other_binding.device_binding_addr += 64;
+    EXPECT_EQ(validate_tmr_submission(candidate, kCallable, other_binding), InvocationStatus::InvalidBinding);
+    other_binding.device_binding_addr = 0;
+    EXPECT_EQ(validate_tmr_submission(candidate, kCallable, other_binding), InvocationStatus::InvalidBinding);
+    const size_t tensor_offset = sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef);
+    const uint64_t bad_packet_scalar = 77;
+    std::memcpy(
+        unaligned.data() + 1 + tensor_offset + sizeof(ChipTensor), &bad_packet_scalar, sizeof(bad_packet_scalar)
+    );
+    uint8_t bad_dtype = 255;
+    std::memcpy(unaligned.data() + 1 + tensor_offset + offsetof(ChipTensor, dtype), &bad_dtype, sizeof(bad_dtype));
+    EXPECT_EQ(
+        decode_tmr_invocation({unaligned.data() + 1, candidate.packet().size}, kCallable, kBinding, &good),
+        InvocationStatus::InvalidTensor
+    );
+    uint64_t scalar{};
+    ASSERT_TRUE(good.scalar(0, &scalar));
+    EXPECT_EQ(scalar, 19u);
+}
+
+TEST(TmrKernelInvocation, SelfConsistentEnvelopeStillRequiresExactTmrSize) {
+    TmrEncodingCache cache;
+    TmrEncodingCandidate candidate;
+    ASSERT_EQ(encode_tmr_invocation(make_args(), kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    TmrInvocationView view;
+    ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    for (const size_t length : {candidate.packet().size - 1, candidate.packet().size + 1}) {
+        std::vector<uint8_t> packet(candidate.packet().data, candidate.packet().data + candidate.packet().size);
+        packet.resize(length);
+        SimplerKernelInvocationHeader header{};
+        std::memcpy(&header, packet.data(), sizeof(header));
+        header.payload_bytes = length - sizeof(header);
+        std::memcpy(packet.data(), &header, sizeof(header));
+        SimplerKernelInvocationHeader checked{};
+        ASSERT_EQ(
+            simpler::kernel::validate_invocation_header({packet.data(), packet.size()}, kCallable, &checked),
+            InvocationStatus::Ok
+        );
+        EXPECT_EQ(
+            decode_tmr_invocation({packet.data(), packet.size()}, kCallable, kBinding, &view),
+            InvocationStatus::InvalidSize
+        );
+        uint64_t scalar{};
+        ASSERT_TRUE(view.scalar(0, &scalar));
+        EXPECT_EQ(scalar, 19u);
+    }
+}
+
+TEST(TmrKernelInvocation, InvalidTensorArithmeticAndHostBackingAreRejected) {
+    auto args = make_args();
+    for (int change = 0; change < 8; ++change) {
+        auto t = args.tensor(0);
+        if (change == 0) t.address_space = AddressSpace::HOST;
+        if (change == 1) t.ndims = 0;
+        if (change == 2) t.ndims = MAX_TENSOR_DIMS + 1;
+        if (change == 3) t.strides[0] = 0;
+        if (change == 4) t.buffer.size = 31;
+        if (change == 5) t.start_offset = std::numeric_limits<uint64_t>::max();
+        if (change == 6) t.buffer.addr = std::numeric_limits<uint64_t>::max();
+        if (change == 7) {
+            t.ndims = 5;
+            for (int i = 0; i < 5; ++i)
+                t.shapes[i] = t.strides[i] = std::numeric_limits<uint32_t>::max();
+        }
+        ChipTensor out = args.tensor(0);
+        EXPECT_EQ(normalize_invocation_tensor(t, &out), InvocationStatus::InvalidTensor);
+        EXPECT_EQ(out.buffer.addr, args.tensor(0).buffer.addr);
+    }
+}
+
+TEST(TmrKernelInvocation, EmptyTensorMatchesBoundaryConversionWithoutBacking) {
+    const uint32_t shapes[][3] = {{0, 1, 1}, {0, 8, 1}, {8, 0, 1}, {2, 0, 3}};
+    const uint32_t ranks[] = {1, 2, 2, 3};
+    TmrEncodingCache cache;
+    for (int i = 0; i < 4; ++i) {
+        auto args = make_args();
+        args.tensor(0) = make_tensor_external(nullptr, shapes[i], ranks[i], DataType::FLOAT32, AddressSpace::DEVICE);
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+        TmrInvocationView view;
+        ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+        EntryArgsStorage storage{};
+        ASSERT_EQ(materialize_tmr_entry_args(view, &storage), InvocationStatus::Ok);
+        EXPECT_EQ(storage.tensor(0).numel(), 0u);
+        EXPECT_EQ(storage.tensor(0).extent_elem(), Tensor::from_boundary(args.tensor(0)).extent_elem());
+    }
+    auto args = make_args();
+    auto parent = Tensor::from_boundary(args.tensor(0));
+    const uint32_t empty_shape[] = {0, 4}, beyond[] = {100, 0};
+    args.tensor(0) = parent.view(empty_shape, beyond).to_boundary();
+    TmrEncodingCandidate candidate;
+    EXPECT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+}
+
+TEST(TmrKernelInvocation, MinimumMaximumAndScalarOnlyPackets) {
+    TmrEncodingCache cache;
+    const PreparedInvocationView cases[] = {{0, 0, 0, 1}, {0, 256, 0, 1}, {0, 0, 128, 1}, {0, 128, 128, 1}};
+    for (const auto &callable : cases) {
+        ChipStorageTaskArgs args{};
+        auto sample = make_args();
+        for (int i = 0; i < callable.tensor_count; ++i)
+            args.add_tensor(sample.tensor(0));
+        for (int i = 0; i < callable.scalar_count; ++i)
+            args.add_scalar(static_cast<uint64_t>(i));
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(args, callable, kBinding, cache, &candidate), InvocationStatus::Ok);
+        EXPECT_EQ(validate_tmr_submission(candidate, callable, kBinding), InvocationStatus::Ok);
+    }
+}
+
+TEST(TmrKernelInvocation, IndependentCallsAndOwnerSerializedSharedCache) {
+    TmrEncodingCache shared;
+    std::mutex owner;
+    std::atomic<int> failures{0};
+    std::vector<std::thread> threads;
+    for (int worker = 0; worker < 4; ++worker) {
+        threads.emplace_back([&, worker] {
+            TmrEncodingCache local;
+            for (int iteration = 0; iteration < 100; ++iteration) {
+                auto args = make_args(0x20000 + worker * 0x1000, iteration);
+                TmrEncodingCandidate independent;
+                if (encode_tmr_invocation(args, kCallable, kBinding, local, &independent) != InvocationStatus::Ok)
+                    ++failures;
+                local.commit(std::move(independent));
+                std::lock_guard<std::mutex> guard(owner);
+                TmrEncodingCandidate candidate;
+                if (encode_tmr_invocation(args, kCallable, kBinding, shared, &candidate) != InvocationStatus::Ok ||
+                    !candidate.same_invocation(independent))
+                    ++failures;
+                shared.commit(std::move(candidate));
+            }
+        });
+    }
+    for (auto &thread : threads)
+        thread.join();
+    EXPECT_EQ(failures, 0);
+}
+}  // namespace

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -18,23 +18,29 @@
 // fake only remembers the slot and records malloc/copy counts.
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "arg_direction.h"
+#include "call_config.h"
 #include "common/host_api.h"
+#include "host/kernel_pipeline_contract.h"
 #include "runtime_status.h"
 #include "runtime_types.h"
 #include "shared_memory.h"
 #include "runtime.h"
 #include "task_args.h"
 #include "worker/runtime_c_api.h"
+#include "worker/pipeline_contract.h"
 
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
@@ -483,4 +489,168 @@ TEST_F(TrbRuntimeTempBufferTest, PreparedRuntimeEnvRequiresTheActiveArenaKey) {
     heap[2] = 2048;
     EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 0);
     EXPECT_NE(fake_.observed_key, fake_.compatibility_key);
+}
+
+namespace {
+
+CallConfig small_kernel_config() {
+    CallConfig config;
+    for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+        config.runtime_env.ring_task_window[i] = 4;
+        config.runtime_env.ring_heap[i] = 1024;
+        config.runtime_env.ring_dep_pool[i] = 4;
+    }
+    return config;
+}
+
+uint64_t required_bytes(const PipelineContract &contract, PipelineResourceKind kind) {
+    for (uint32_t i = 0; i < contract.resource_count; ++i) {
+        if (contract.resources[i].kind == kind) return contract.resources[i].bytes_per_copy;
+    }
+    ADD_FAILURE() << "Missing resource " << kind;
+    return 0;
+}
+
+void expect_same_contract(const PipelineContract &a, const PipelineContract &b) {
+    EXPECT_EQ(a.abi_version, b.abi_version);
+    EXPECT_EQ(a.pipeline_depth, b.pipeline_depth);
+    ASSERT_EQ(a.resource_count, b.resource_count);
+    for (uint32_t i = 0; i < a.resource_count; ++i) {
+        EXPECT_EQ(a.resources[i].kind, b.resources[i].kind);
+        EXPECT_EQ(a.resources[i].resource_class, b.resources[i].resource_class);
+        EXPECT_EQ(a.resources[i].bytes_per_copy, b.resources[i].bytes_per_copy);
+    }
+}
+
+}  // namespace
+
+TEST(KernelPipelineBuilder, DefaultAndPackedInputsPreserveProgramContract) {
+    const PipelineContract program_before = *get_pipeline_contract();
+    CallConfig defaults;
+    PipelineContract contract{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&defaults, &contract), 0);
+    EXPECT_TRUE(is_valid_tmr_kernel_pipeline_contract(&contract));
+    EXPECT_EQ(contract.pipeline_depth, 1u);
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_TASK_ARGS), 0u);
+
+    // CallConfig is packed and may start at any byte; use a genuinely unaligned input.
+    alignas(uint64_t) std::array<unsigned char, sizeof(CallConfig) + 1> packed{};
+    ASSERT_NE(
+        reinterpret_cast<uintptr_t>(packed.data() + 1 + offsetof(CallConfig, runtime_env)) % alignof(uint64_t), 0u
+    );
+    const CallConfig small = small_kernel_config();
+    std::memcpy(packed.data() + 1, &small, sizeof(small));
+    const auto before = packed;
+    PipelineContract expected{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&small, &expected), 0);
+    ASSERT_EQ(
+        build_kernel_pipeline_contract_impl(reinterpret_cast<const CallConfig *>(packed.data() + 1), &contract), 0
+    );
+    expect_same_contract(contract, expected);
+    EXPECT_EQ(packed, before);
+    expect_same_contract(*get_pipeline_contract(), program_before);
+    EXPECT_TRUE(is_valid_pipeline_contract(get_pipeline_contract()));
+    EXPECT_EQ(get_pipeline_contract()->pipeline_depth, 2u);
+}
+
+TEST(KernelPipelineBuilder, InvalidSizesLeaveOutputUntouched) {
+    PipelineContract output;
+    std::memset(&output, 0x5a, sizeof(output));
+    std::array<unsigned char, sizeof(output)> original{};
+    std::memcpy(original.data(), &output, sizeof(output));
+    auto reject = [&](const CallConfig *config) {
+        EXPECT_EQ(build_kernel_pipeline_contract_impl(config, &output), PTO_RUNTIME_ERR_INTERNAL);
+        EXPECT_EQ(std::memcmp(&output, original.data(), sizeof(output)), 0);
+    };
+    reject(nullptr);
+    auto config = small_kernel_config();
+    EXPECT_EQ(build_kernel_pipeline_contract_impl(&config, nullptr), PTO_RUNTIME_ERR_INTERNAL);
+    for (uint64_t bad : {uint64_t{1}, uint64_t{3}, uint64_t{6}, uint64_t{1} << 31}) {
+        config = small_kernel_config();
+        config.runtime_env.ring_task_window[0] = bad;
+        reject(&config);
+    }
+    config = small_kernel_config();
+    config.runtime_env.ring_task_window[0] = uint64_t{1} << 30;
+    config.runtime_env.ring_task_window[1] = uint64_t{1} << 30;
+    reject(&config);
+    config = small_kernel_config();
+    config.runtime_env.ring_heap[0] = 1023;
+    reject(&config);
+    config.runtime_env.ring_heap[0] = std::numeric_limits<uint64_t>::max();
+    reject(&config);
+    for (uint64_t bad : {uint64_t{3}, uint64_t{INT32_MAX} + 1}) {
+        config = small_kernel_config();
+        config.runtime_env.ring_dep_pool[0] = bad;
+        reject(&config);
+    }
+    // Sum fits uint64_t but adding DeviceArena base-alignment slack would overflow.
+    config = small_kernel_config();
+    config.runtime_env.ring_heap[0] = std::numeric_limits<uint64_t>::max() - 3 * 1024;
+    reject(&config);
+    // Last usable byte before that alignment limit is legal; reserve must not allocate it.
+    config.runtime_env.ring_heap[0] -= 1023;
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &output), 0);
+    EXPECT_EQ(required_bytes(output, PTO_PIPELINE_GM_HEAP), std::numeric_limits<uint64_t>::max() - 1023);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, KernelRequirementsMatchRealBindWithoutQuerySideEffects) {
+    auto config = small_kernel_config();
+    PipelineContract contract{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &contract), 0);
+    EXPECT_EQ(fake_.setup_static_arena_count, 0);
+    EXPECT_EQ(fake_.device_malloc_count, 0);
+    EXPECT_EQ(fake_.copy_to_count, 0);
+    Runtime runtime = make_runtime();
+    ChipStorageTaskArgs args;
+    ASSERT_EQ(bind_runtime(runtime, api_, args, nullptr, 0), 0);
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_GM_HEAP), fake_.gm_heap.size());
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_GM_SM), fake_.gm_sm.size());
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_RUNTIME_IMAGE), fake_.runtime_arena.size());
+    ASSERT_EQ(validate_runtime_impl(&runtime, &api_, 0), 0);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, LargestRingCountsOnlyReserveLayout) {
+    auto config = small_kernel_config();
+    PipelineContract small{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &small), 0);
+    config.runtime_env.ring_task_window[0] = uint64_t{1} << 30;
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r) {
+        config.runtime_env.ring_dep_pool[r] = INT32_MAX;
+    }
+    PipelineContract large{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &large), 0);
+    EXPECT_TRUE(is_valid_tmr_kernel_pipeline_contract(&large));
+    EXPECT_EQ(required_bytes(large, PTO_PIPELINE_GM_HEAP), required_bytes(small, PTO_PIPELINE_GM_HEAP));
+    EXPECT_GT(required_bytes(large, PTO_PIPELINE_GM_SM), required_bytes(small, PTO_PIPELINE_GM_SM));
+    EXPECT_GT(required_bytes(large, PTO_PIPELINE_RUNTIME_IMAGE), required_bytes(small, PTO_PIPELINE_RUNTIME_IMAGE));
+    EXPECT_EQ(fake_.setup_static_arena_count, 0);
+    EXPECT_EQ(fake_.device_malloc_count, 0);
+    EXPECT_EQ(fake_.copy_to_count, 0);
+}
+
+TEST(KernelPipelineBuilder, IndependentCallsCanInterleave) {
+    constexpr size_t count = 4;
+    std::array<CallConfig, count> configs;
+    std::array<PipelineContract, count> expected{};
+    std::array<std::thread, count> threads;
+    for (size_t i = 0; i < count; ++i) {
+        configs[i] = small_kernel_config();
+        configs[i].runtime_env.ring_task_window[0] = uint64_t{4} << i;
+        configs[i].runtime_env.ring_heap[0] = 1024 * (i + 1);
+        configs[i].runtime_env.ring_dep_pool[0] = 4 + i;
+        ASSERT_EQ(build_kernel_pipeline_contract_impl(&configs[i], &expected[i]), 0);
+    }
+    for (size_t i = 0; i < count; ++i) {
+        threads[i] = std::thread([&, i] {
+            const CallConfig config = configs[i];
+            for (int iteration = 0; iteration < 32; ++iteration) {
+                PipelineContract actual{};
+                EXPECT_EQ(build_kernel_pipeline_contract_impl(&config, &actual), 0);
+                expect_same_contract(actual, expected[i]);
+            }
+        });
+    }
+    for (auto &thread : threads)
+        thread.join();
 }

--- a/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
+++ b/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
@@ -221,6 +221,90 @@ TEST(PipelineContract, ShippedArenaTopologiesAreServiceable) {
     EXPECT_TRUE(has_serviceable_arena_topology(tmr));
 }
 
+PipelineContract kernel_contract() {
+    PipelineContract c{PTO_PIPELINE_CONTRACT_ABI_VERSION, 6, 1, {}};
+    for (uint32_t kind = PTO_PIPELINE_GM_HEAP; kind <= PTO_PIPELINE_RUNTIME_IMAGE; ++kind) {
+        c.resources[kind - 1] = {kind, PTO_PIPELINE_DEVICE_SCRATCH, 4096};
+    }
+    c.resources[3] = {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0};
+    c.resources[4] = {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0};
+    c.resources[5] = {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0};
+    return c;
+}
+
+TEST(PipelineContract, KernelByteRulesAreModeSpecific) {
+    auto c = kernel_contract();
+    EXPECT_TRUE(is_valid_pipeline_contract(&c, SIMPLER_MODE_KERNEL));
+    EXPECT_TRUE(is_valid_tmr_kernel_pipeline_contract(&c));
+    EXPECT_FALSE(is_valid_pipeline_contract(&c));
+    EXPECT_FALSE(is_valid_pipeline_contract(&c, 99u));
+    EXPECT_FALSE(is_valid_pipeline_contract(&c, UINT32_MAX));
+    EXPECT_FALSE(is_valid_pipeline_contract(nullptr, SIMPLER_MODE_KERNEL));
+    for (uint32_t i = 0; i < c.resource_count; ++i) {
+        auto invalid = c;
+        invalid.resources[i].bytes_per_copy = i < 3 ? 0 : 1;
+        EXPECT_FALSE(is_valid_pipeline_contract(&invalid, SIMPLER_MODE_KERNEL)) << i;
+    }
+}
+
+TEST(PipelineContract, KernelRequiresExactlyItsSupportedResourceShape) {
+    const auto c = kernel_contract();
+    for (uint32_t i = 0; i < c.resource_count; ++i) {
+        auto missing = c;
+        missing.resources[i] = missing.resources[--missing.resource_count];
+        EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&missing)) << i;
+        auto wrong_class = c;
+        wrong_class.resources[i].resource_class = (wrong_class.resources[i].resource_class + 1) % 3;
+        EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&wrong_class)) << i;
+        auto duplicate = c;
+        duplicate.resources[i] = duplicate.resources[(i + 1) % c.resource_count];
+        EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&duplicate)) << i;
+    }
+    auto invalid = c;
+    invalid.pipeline_depth = 2;
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&invalid));
+    invalid = c;
+    invalid.resource_count = PTO_PIPELINE_MAX_RESOURCES + 1;
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&invalid));
+    EXPECT_FALSE(has_serviceable_stream_topology(invalid));
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(nullptr));
+}
+
+TEST(PipelineContract, StreamServiceabilityDoesNotChangeStructuralRules) {
+    auto c = accepted_contract();
+    EXPECT_TRUE(has_serviceable_stream_topology(c));
+    c.pipeline_depth = 2;
+    EXPECT_TRUE(has_serviceable_stream_topology(c));
+    c.resources[3].kind = PTO_PIPELINE_AICPU_STREAM;
+    EXPECT_TRUE(is_valid_pipeline_contract(&c));
+    EXPECT_TRUE(has_serviceable_arena_topology(c));
+    EXPECT_FALSE(has_serviceable_stream_topology(c));
+    c = accepted_contract();
+    c.resources[2].resource_class = PTO_PIPELINE_HOST_PER_RUN;
+    EXPECT_FALSE(has_serviceable_stream_topology(c));
+    c.resource_count = 0;
+    EXPECT_TRUE(is_valid_pipeline_contract(&c));
+    EXPECT_FALSE(has_serviceable_stream_topology(c));
+}
+
+TEST(PipelineContract, CommonKernelAdmissionDoesNotRequireTmrResourceSet) {
+    const PipelineContract c{
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        4,
+        1,
+        {
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_HOST_PER_RUN, 4096},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_HOST_PER_RUN, 4096},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+    ASSERT_TRUE(is_valid_pipeline_contract(&c, SIMPLER_MODE_KERNEL));
+    EXPECT_TRUE(has_serviceable_arena_topology(c));
+    EXPECT_TRUE(has_serviceable_stream_topology(c));
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&c));
+}
+
 TEST(PipelineSlotPool, DepthOneKeepsLegacySingleSlotBehavior) {
     PipelineSlotPool pool(1);
     auto first = pool.try_acquire();

--- a/tests/ut/cpp/hierarchical/test_pipeline_contract_loader.cpp
+++ b/tests/ut/cpp/hierarchical/test_pipeline_contract_loader.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <dlfcn.h>
+#include <stdexcept>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "chip_worker.h"
+#include "chip_run_lane.h"
+#include "pipeline_contract.h"
+
+namespace {
+
+template <typename T>
+T symbol(void *handle, const char *name) {
+    dlerror();
+    void *result = dlsym(handle, name);
+    const char *error = dlerror();
+    if (error != nullptr || result == nullptr) {
+        throw std::runtime_error(error != nullptr ? error : name);
+    }
+    return reinterpret_cast<T>(result);
+}
+
+class LoadedRuntime {
+public:
+    explicit LoadedRuntime(const char *path, int flags = RTLD_NOW | RTLD_LOCAL) {
+        handle = dlopen(path, flags);
+        if (!handle) throw std::runtime_error(dlerror());
+    }
+    ~LoadedRuntime() { dlclose(handle); }
+    LoadedRuntime(const LoadedRuntime &) = delete;
+    LoadedRuntime &operator=(const LoadedRuntime &) = delete;
+    void *handle;
+};
+
+PipelineContract program_contract() {
+    return {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        2,
+        {
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+}
+
+void expect_factory_admission(const PipelineContract &contract, int expected_creates, const char *message) {
+    LoadedRuntime fixture(PIPELINE_FIXTURE_PATH);
+    auto set_contract = symbol<void (*)(const PipelineContract *)>(fixture.handle, "test_set_pipeline_contract");
+    auto create_count = symbol<int (*)()>(fixture.handle, "test_context_create_count");
+    set_contract(&contract);
+    {
+        ChipWorker worker;
+        try {
+            worker.init(PIPELINE_FIXTURE_PATH, "", "", "", 0);
+            FAIL() << "The fixture factory must fail after admission";
+        } catch (const std::runtime_error &error) {
+            EXPECT_STREQ(error.what(), message);
+        }
+    }
+    EXPECT_EQ(create_count(), expected_creates);
+}
+
+}  // namespace
+
+TEST(PipelineContractLoader, MissingOrMisclassifiedStreamsRejectBeforeCreatingContext) {
+    for (uint32_t index : {4u, 5u}) {
+        auto contract = program_contract();
+        contract.resources[index] = contract.resources[3];
+        ASSERT_TRUE(is_valid_pipeline_contract(&contract));
+        expect_factory_admission(contract, 0, "host runtime returned a PipelineContract this build cannot accept");
+        contract = program_contract();
+        contract.resources[index].resource_class = PTO_PIPELINE_HOST_PER_RUN;
+        expect_factory_admission(contract, 0, "host runtime returned a PipelineContract this build cannot accept");
+    }
+}
+
+TEST(PipelineContractLoader, LegalProgramDeclarationReachesRealFactoryCall) {
+    expect_factory_admission(program_contract(), 1, "create_device_context returned null");
+}
+
+TEST(KernelPipelineEntry, RealSimVariantsValidateWithoutClaimingOrCommitting) {
+    // Sim hooks must remain global for every host runtime loaded beneath them.
+    LoadedRuntime sim_context(SIM_CONTEXT_PATH, RTLD_NOW | RTLD_GLOBAL);
+    for (const char *arch : {"a2a3", "a5"}) {
+        for (const char *runtime : {"tensormap_and_ringbuffer", "host_build_graph"}) {
+            const std::string path =
+                std::string(RUNTIME_LIBRARY_ROOT) + "/" + arch + "/sim/" + runtime + "/libhost_runtime.so";
+            SCOPED_TRACE(path);
+            LoadedRuntime library(path.c_str());
+            auto create = symbol<decltype(&create_device_context)>(library.handle, "create_device_context");
+            auto destroy = symbol<decltype(&destroy_device_context)>(library.handle, "destroy_device_context");
+            auto init = symbol<decltype(&simpler_kernel_mode_init)>(library.handle, "simpler_kernel_mode_init");
+            auto supported =
+                symbol<decltype(&simpler_kernel_mode_supported)>(library.handle, "simpler_kernel_mode_supported");
+            auto launch = symbol<decltype(&simpler_kernel_mode_launch)>(library.handle, "simpler_kernel_mode_launch");
+            auto committed =
+                symbol<decltype(&committed_device_memory_ctx)>(library.handle, "committed_device_memory_ctx");
+            DeviceContextHandle ctx = create();
+            ASSERT_NE(ctx, nullptr);
+            CallConfig config;
+            auto invoke = [&](const CallConfig *input, uint64_t generation = 1) {
+                return init(ctx, 0, nullptr, 0, nullptr, 0, nullptr, 0, input, generation);
+            };
+            EXPECT_EQ(invoke(nullptr), PTO_RUNTIME_ERR_INTERNAL);
+            EXPECT_EQ(invoke(&config, 0), PTO_RUNTIME_ERR_INTERNAL);
+            const uint8_t binary = 0;
+            EXPECT_EQ(init(ctx, 0, &binary, 0, nullptr, 0, nullptr, 0, &config, 1), PTO_RUNTIME_ERR_INTERNAL);
+            EXPECT_EQ(init(ctx, 0, nullptr, 0, &binary, 0, nullptr, 0, &config, 1), PTO_RUNTIME_ERR_INTERNAL);
+            EXPECT_EQ(init(ctx, 0, nullptr, 0, nullptr, 0, &binary, 0, &config, 1), PTO_RUNTIME_ERR_INTERNAL);
+            config.runtime_env.ring_task_window[0] = 3;
+            EXPECT_EQ(
+                invoke(&config), std::string(runtime) == "tensormap_and_ringbuffer" ? PTO_RUNTIME_ERR_INTERNAL :
+                                                                                      PTO_RUNTIME_ERR_UNSUPPORTED
+            );
+            config.runtime_env.ring_task_window[0] = 0;
+            EXPECT_EQ(invoke(&config), PTO_RUNTIME_ERR_UNSUPPORTED);
+            EXPECT_EQ(supported(ctx), 0);
+            EXPECT_EQ(committed(ctx), 0u);
+            // A structurally valid launch still cannot run after unsupported init.
+            int caller_stream_token = 0;
+            EXPECT_EQ(launch(ctx, 0, &config, &caller_stream_token), PTO_RUNTIME_ERR_INVALID_STATE);
+            EXPECT_EQ(invoke(&config), PTO_RUNTIME_ERR_UNSUPPORTED);
+            EXPECT_EQ(committed(ctx), 0u);
+            destroy(ctx);
+        }
+    }
+}

--- a/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
+++ b/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "worker/runtime_c_api.h"
+#include "platform_comm/comm.h"
+#include "common/host_log_state.h"
+
+// Sequential loader fixture: only the declaration and factory counter are live.
+// Every loaded symbol uses its production signature; unexpected execution fails.
+namespace {
+PipelineContract contract{};
+int create_count = 0;
+}  // namespace
+extern "C" {
+void test_set_pipeline_contract(const PipelineContract *value) {
+    contract = *value;
+    create_count = 0;
+}
+int test_context_create_count() { return create_count; }
+int simpler_host_log_bind_state(SimplerHostLogState *) { return 0; }
+
+DeviceContextHandle create_device_context(void) {
+    ++create_count;
+    return nullptr;
+}
+
+void destroy_device_context(DeviceContextHandle ctx) {}
+
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) { return nullptr; }
+
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {}
+
+size_t committed_device_memory_ctx(DeviceContextHandle ctx) { return 0; }
+
+int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+size_t get_runtime_size(void) { return 0; }
+
+size_t get_runtime_alignment(void) { return 0; }
+
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *prewarm_config, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_run(
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_prepare_run(
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int supports_concurrent_native_prepare_ctx(DeviceContextHandle ctx) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+uint64_t get_arena_bank_gm_heap_base_ctx(DeviceContextHandle ctx, uint32_t bank_id) { return 0; }
+
+uint64_t get_retained_temp_addr_ctx(DeviceContextHandle ctx, uint32_t slot_id) { return 0; }
+
+const PipelineContract *get_pipeline_contract(void) { return &contract; }
+
+int simpler_unregister_callable(DeviceContextHandle ctx, int32_t callable_id) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+size_t get_aicpu_dlopen_count(DeviceContextHandle ctx) { return 0; }
+
+size_t get_host_dlopen_count(DeviceContextHandle ctx) { return 0; }
+
+size_t get_run_stream_set_create_count(DeviceContextHandle ctx) { return 0; }
+
+int finalize_device(DeviceContextHandle ctx) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int ensure_acl_ready_ctx(void *, int) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+void *create_comm_stream_ctx(void *) { return nullptr; }
+
+int destroy_comm_stream_ctx(void *, void *) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+CommHandle comm_init(int rank, int nranks, void *stream, const char *rootinfo_path) { return nullptr; }
+
+int comm_alloc_windows(CommHandle h, size_t win_size, uint64_t *device_ctx_out) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_get_local_window_base(CommHandle h, uint64_t *base_out) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_get_window_size(CommHandle h, size_t *size_out) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_derive_context(
+    CommHandle h, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank, size_t window_offset,
+    size_t window_size, uint64_t *device_ctx_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_alloc_domain_windows(
+    CommHandle h, uint64_t allocation_id, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank,
+    size_t window_size, uint64_t *device_ctx_out, uint64_t *local_window_base_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_global_domain_prepare(
+    uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile,
+    CommGlobalDomainDescriptor *descriptor_out, uint64_t *local_window_base_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_global_domain_import(
+    uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_global_domain_release(uint64_t domain_id) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_barrier(CommHandle h) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_destroy(CommHandle h) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_kernel_mode_supported(DeviceContextHandle ctx) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+}  // extern "C"

--- a/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
+++ b/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
@@ -167,7 +167,7 @@ int simpler_kernel_mode_init(
 }
 
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
     return PTO_RUNTIME_ERR_INTERNAL;
 }

--- a/tests/ut/cpp/types/test_callable_scalar_count.cpp
+++ b/tests/ut/cpp/types/test_callable_scalar_count.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// ChipCallable::scalar_count_ contract: the field is a cached derivation of
+// the signature's SCALAR entries (0 also meaning "not recorded"), the factory
+// validates range and signature agreement, the field occupies former header
+// padding only, and a blob written by a producer that predates the field
+// (whose padding make_callable zero-initialized) reads back as
+// scalar_count == 0.
+
+#include <cstddef>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "callable.h"
+
+namespace {
+
+// Builds a chip callable whose signature carries `scalar_entries` trailing
+// SCALAR entries after one IN and one OUT tensor, declaring `declared_count`
+// as its scalar count.
+std::vector<uint8_t> build_chip_callable(int32_t declared_count, int32_t scalar_entries) {
+    std::vector<ArgDirection> sig{ArgDirection::IN, ArgDirection::OUT};
+    for (int32_t i = 0; i < scalar_entries; ++i)
+        sig.push_back(ArgDirection::SCALAR);
+
+    ArgDirection core_sig[1] = {ArgDirection::IN};
+    const uint8_t kernel[] = {0x01, 0x02, 0x03, 0x04};
+    auto core = make_callable<CORE_MAX_TENSOR_ARGS>(core_sig, 1, kernel, sizeof(kernel));
+
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F'};
+    int32_t child_ids[1] = {3};
+    std::vector<uint8_t> children[1] = {std::move(core)};
+
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        sig.data(), static_cast<int32_t>(sig.size()), declared_count, "orch_fn", fake_orch_so, sizeof(fake_orch_so),
+        child_ids, children, 1, "cfg_name"
+    );
+}
+
+// scalar_count() reads 0 both for a scalar-free orchestration and for an
+// artifact built before the field existed, so the wire contract has a consumer
+// derive the effective count from the signature when the field is 0 rather
+// than subtracting it. This pins the answer the naive formula gets wrong, so a
+// consumer that reintroduces it fails here rather than on device.
+TEST(CallableScalarCount, SubtractingAnUnrecordedCountMiscountsScalarsAsTensors) {
+    auto buf = build_chip_callable(0, 9);
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    ASSERT_EQ(callable->sig_count(), 11);
+    ASSERT_EQ(callable->scalar_count(), 0);
+
+    int32_t signature_scalars = 0;
+    for (int32_t i = 0; i < callable->sig_count(); ++i) {
+        if (callable->sig(i) == ArgDirection::SCALAR) ++signature_scalars;
+    }
+    ASSERT_EQ(signature_scalars, 9);
+
+    const int32_t effective_scalars = callable->scalar_count() != 0 ? callable->scalar_count() : signature_scalars;
+    EXPECT_EQ(callable->sig_count() - effective_scalars, 2);
+    EXPECT_EQ(callable->sig_count() - callable->scalar_count(), 11);
+}
+
+}  // namespace
+
+TEST(CallableScalarCount, RoundTripsThroughFactory) {
+    for (int32_t count : {0, 1, 7, CHIP_MAX_SCALAR_ARGS}) {
+        auto buf = build_chip_callable(count, count);
+        const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+        EXPECT_EQ(callable->scalar_count(), count);
+        EXPECT_EQ(callable->sig_count(), 2 + count);
+    }
+}
+
+TEST(CallableScalarCount, RejectsOutOfRangeWithValueAndLimit) {
+    for (int32_t count : {-1, CHIP_MAX_SCALAR_ARGS + 1}) {
+        try {
+            (void)build_chip_callable(count, count > 0 ? count : 0);
+            FAIL() << "expected scalar count validation to fail for " << count;
+        } catch (const std::invalid_argument &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(std::to_string(count)), std::string::npos) << message;
+            EXPECT_NE(message.find(std::to_string(CHIP_MAX_SCALAR_ARGS)), std::string::npos) << message;
+        }
+    }
+}
+
+// A nonzero count is a cached derivation of the signature, so a value that
+// disagrees with the signature's SCALAR entries is rejected naming both
+// numbers. Zero stays valid with any signature (legacy "not recorded").
+TEST(CallableScalarCount, RejectsCountDisagreeingWithSignature) {
+    struct Case {
+        int32_t declared;
+        int32_t entries;
+    };
+    for (const Case &c : {Case{5, 0}, Case{3, 9}}) {
+        try {
+            (void)build_chip_callable(c.declared, c.entries);
+            FAIL() << "expected consistency validation to fail for declared=" << c.declared << " entries=" << c.entries;
+        } catch (const std::invalid_argument &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(std::to_string(c.declared)), std::string::npos) << message;
+            EXPECT_NE(message.find(std::to_string(c.entries)), std::string::npos) << message;
+        }
+    }
+    auto unrecorded = build_chip_callable(0, 9);
+    EXPECT_EQ(reinterpret_cast<const ChipCallable *>(unrecorded.data())->scalar_count(), 0);
+}
+
+// A legacy blob is byte-identical to a current one built with the same inputs
+// except that the four bytes now holding scalar_count_ were zero-initialized
+// padding. Zeroing them reproduces such a blob exactly.
+TEST(CallableScalarCount, LegacyBlobReadsZero) {
+    auto buf = build_chip_callable(9, 9);
+    std::memset(buf.data() + offsetof(ChipCallable, scalar_count_), 0, sizeof(int32_t));
+
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    EXPECT_EQ(callable->scalar_count(), 0);
+    EXPECT_EQ(callable->sig_count(), 11);
+    EXPECT_EQ(std::string(callable->func_name(), callable->func_name_len()), "orch_fn");
+    EXPECT_EQ(std::string(callable->config_name(), callable->config_name_len()), "cfg_name");
+    ASSERT_EQ(callable->child_count(), 1);
+    EXPECT_EQ(callable->child_func_id(0), 3);
+    EXPECT_EQ(callable->child(0).binary_size(), 4u);
+}
+
+// Two builds with the same signature that differ only in the declared count
+// (0 = "not recorded" vs the real derivation) must differ only in that
+// field's four bytes — every other header byte, the orchestration binary,
+// and the child payload keep their positions and values.
+TEST(CallableScalarCount, OnlyTheFieldBytesVary) {
+    auto unrecorded = build_chip_callable(0, 9);
+    auto nine = build_chip_callable(9, 9);
+    ASSERT_EQ(unrecorded.size(), nine.size());
+
+    constexpr size_t field_begin = offsetof(ChipCallable, scalar_count_);
+    constexpr size_t field_end = field_begin + sizeof(int32_t);
+    for (size_t i = 0; i < unrecorded.size(); ++i) {
+        if (i >= field_begin && i < field_end) continue;
+        ASSERT_EQ(unrecorded[i], nine[i]) << "byte " << i << " must not depend on scalar_count";
+    }
+    EXPECT_NE(std::memcmp(unrecorded.data() + field_begin, nine.data() + field_begin, sizeof(int32_t)), 0);
+}

--- a/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
+++ b/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
@@ -60,7 +60,7 @@ std::vector<uint8_t> build_test_chip_callable() {
     std::vector<uint8_t> children[2] = {std::move(core0), std::move(core1)};
 
     return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-        nullptr, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
+        nullptr, 0, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
     );
 }
 

--- a/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
+++ b/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
@@ -50,7 +50,7 @@ TEST(ChipMaxTensorArgs, ChipStorageHoldsCapacity) {
 TEST(ChipMaxTensorArgs, ChipCallableAcceptsCapacity) {
     std::vector<ArgDirection> signature(256, ArgDirection::IN);
     auto buffer = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-        signature.data(), static_cast<int32_t>(signature.size()), "composed", nullptr, 0, nullptr, nullptr, 0, ""
+        signature.data(), static_cast<int32_t>(signature.size()), 0, "composed", nullptr, 0, nullptr, nullptr, 0, ""
     );
 
     const auto &callable = *reinterpret_cast<const ChipCallable *>(buffer.data());
@@ -63,7 +63,7 @@ TEST(ChipMaxTensorArgs, ChipCallableOverflowReportsRequestedAndSupportedCounts) 
 
     try {
         (void)make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-            signature.data(), requested, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
+            signature.data(), requested, 0, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
         );
         FAIL() << "expected signature capacity validation to fail";
     } catch (const std::invalid_argument &error) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -11,7 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <cstring>
 
 #include "kernel_invocation_header.h"
@@ -21,18 +20,6 @@ namespace {
 TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
     EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
     EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
-}
-
-TEST(KernelInvocationHeaderWire, LayoutMatchesHostDeviceEnvelope) {
-    EXPECT_EQ(sizeof(SimplerKernelInvocationHeader), 40u);
-    EXPECT_EQ(alignof(SimplerKernelInvocationHeader), 8u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, mode), 0u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, callable_id), 4u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, generation), 8u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, payload_bytes), 16u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, tensor_count), 24u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, scalar_count), 28u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, host_copy_tensor_count), 32u);
 }
 
 TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <cstring>
 
 #include "kernel_invocation_header.h"
@@ -20,6 +21,18 @@ namespace {
 TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
     EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
     EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
+}
+
+TEST(KernelInvocationHeaderWire, LayoutMatchesHostDeviceEnvelope) {
+    EXPECT_EQ(sizeof(SimplerKernelInvocationHeader), 40u);
+    EXPECT_EQ(alignof(SimplerKernelInvocationHeader), 8u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, mode), 0u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, callable_id), 4u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, generation), 8u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, payload_bytes), 16u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, tensor_count), 24u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, scalar_count), 28u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, host_copy_tensor_count), 32u);
 }
 
 TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "kernel_invocation_header.h"
+
+namespace {
+
+TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
+    EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
+    EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
+}
+
+TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = 17;
+    header.generation = 0x1122334455667788ull;
+    header.payload_bytes = 4096;
+    header.tensor_count = 12;
+    header.scalar_count = 5;
+
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)];
+    std::memcpy(wire, &header, sizeof(header));
+    SimplerKernelInvocationHeader restored{};
+    std::memcpy(&restored, wire, sizeof(restored));
+
+    EXPECT_EQ(restored.mode, static_cast<uint32_t>(SIMPLER_MODE_KERNEL));
+    EXPECT_EQ(restored.callable_id, 17);
+    EXPECT_EQ(restored.generation, 0x1122334455667788ull);
+    EXPECT_EQ(restored.payload_bytes, 4096u);
+    EXPECT_EQ(restored.tensor_count, 12);
+    EXPECT_EQ(restored.scalar_count, 5);
+    EXPECT_EQ(restored.host_copy_tensor_count, 0);
+}
+
+TEST(KernelInvocationHeaderWire, ZeroInitializedBlobReadsAsEmpty) {
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)] = {};
+    SimplerKernelInvocationHeader header;
+    std::memcpy(&header, wire, sizeof(header));
+    EXPECT_EQ(header.mode, static_cast<uint32_t>(SIMPLER_MODE_PROGRAM));
+    EXPECT_EQ(header.payload_bytes, 0u);
+    EXPECT_EQ(header.tensor_count, 0);
+    EXPECT_EQ(header.scalar_count, 0);
+    EXPECT_EQ(header.host_copy_tensor_count, 0);
+}
+
+}  // namespace

--- a/tests/ut/cpp/types/test_kernel_invocation_validation.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_validation.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <limits>
+#include <vector>
+
+#include "kernel_invocation_validation.h"
+
+namespace {
+using namespace simpler::kernel;
+
+TEST(KernelInvocationValidation, EffectiveScalarCompatibilityAndFailureTransaction) {
+    const ArgDirection signature[] = {ArgDirection::IN, ArgDirection::OUT, ArgDirection::SCALAR};
+    int32_t tensors = -1, scalars = -1;
+    EXPECT_EQ(derive_invocation_counts(signature, 3, 0, &tensors, &scalars), InvocationStatus::Ok);
+    EXPECT_EQ(tensors, 2);
+    EXPECT_EQ(scalars, 1);
+    EXPECT_EQ(derive_invocation_counts(signature, 3, 1, &tensors, &scalars), InvocationStatus::Ok);
+    EXPECT_EQ(derive_invocation_counts(signature, 3, 2, &tensors, &scalars), InvocationStatus::InvalidSignature);
+    EXPECT_EQ(tensors, 2);
+    EXPECT_EQ(scalars, 1);
+    const ArgDirection interleaved[] = {ArgDirection::SCALAR, ArgDirection::IN};
+    EXPECT_EQ(derive_invocation_counts(interleaved, 2, 0, &tensors, &scalars), InvocationStatus::InvalidSignature);
+    const ArgDirection unknown[] = {static_cast<ArgDirection>(42)};
+    EXPECT_EQ(derive_invocation_counts(unknown, 1, 0, &tensors, &scalars), InvocationStatus::InvalidSignature);
+    EXPECT_EQ(derive_invocation_counts(nullptr, 0, 0, &tensors, &scalars), InvocationStatus::Ok);
+    EXPECT_EQ(tensors, 0);
+    EXPECT_EQ(scalars, 0);
+    EXPECT_EQ(derive_invocation_counts(signature, -1, 0, &tensors, &scalars), InvocationStatus::InvalidCounts);
+    EXPECT_EQ(derive_invocation_counts(signature, 257, 0, &tensors, &scalars), InvocationStatus::InvalidCounts);
+    EXPECT_EQ(derive_invocation_counts(signature, 3, -1, &tensors, &scalars), InvocationStatus::InvalidCounts);
+    EXPECT_EQ(derive_invocation_counts(nullptr, 1, 0, &tensors, &scalars), InvocationStatus::InvalidArgument);
+}
+
+TEST(KernelInvocationValidation, FramingRejectsBeforePayloadReadsAndPreservesOutput) {
+    const PreparedInvocationView prepared{2, 1, 1, 7};
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = prepared.callable_id;
+    header.generation = prepared.slot_generation;
+    header.tensor_count = 1;
+    header.scalar_count = 1;
+    std::vector<uint8_t> bytes(sizeof(header) + 1);
+    auto check = [&](InvocationStatus expected, size_t size = sizeof(SimplerKernelInvocationHeader)) {
+        std::memcpy(bytes.data() + 1, &header, sizeof(header));
+        SimplerKernelInvocationHeader out{};
+        out.callable_id = 31;
+        EXPECT_EQ(validate_invocation_header({bytes.data() + 1, size}, prepared, &out), expected);
+        if (expected != InvocationStatus::Ok) EXPECT_EQ(out.callable_id, 31);
+    };
+    check(InvocationStatus::Ok);
+    check(InvocationStatus::InvalidSize, sizeof(header) - 1);
+    header.payload_bytes = std::numeric_limits<uint64_t>::max();
+    check(InvocationStatus::InvalidSize);
+    header.payload_bytes = 0;
+    header.mode = SIMPLER_MODE_PROGRAM;
+    check(InvocationStatus::InvalidHeader);
+    header.mode = 99;
+    check(InvocationStatus::InvalidHeader);
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.tensor_count = -1;
+    check(InvocationStatus::InvalidCounts);
+    header.tensor_count = 256;
+    check(InvocationStatus::InvalidCounts);
+    header.tensor_count = 1;
+    header.scalar_count = -1;
+    check(InvocationStatus::InvalidCounts);
+    header.scalar_count = 129;
+    check(InvocationStatus::InvalidCounts);
+    header.scalar_count = 0;
+    check(InvocationStatus::InvalidCounts);
+    header.scalar_count = 1;
+    header.host_copy_tensor_count = 1;
+    check(InvocationStatus::InvalidCounts);
+    header.host_copy_tensor_count = -1;
+    check(InvocationStatus::InvalidCounts);
+    header.host_copy_tensor_count = 0;
+    header.generation = 8;
+    check(InvocationStatus::StaleCallable);
+    header.generation = 0;
+    check(InvocationStatus::InvalidHeader);
+    header.generation = 7;
+    header.callable_id = 64;
+    check(InvocationStatus::InvalidHeader);
+    header.callable_id = 3;
+    check(InvocationStatus::StaleCallable);
+}
+TEST(KernelInvocationValidation, RuntimePayloadIsOpaqueAndTrustedCountsAreRequired) {
+    const PreparedInvocationView prepared{5, 2, 1, 9};
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = prepared.callable_id;
+    header.generation = prepared.slot_generation;
+    header.tensor_count = prepared.tensor_count;
+    header.scalar_count = prepared.scalar_count;
+    header.payload_bytes = 13;
+    std::vector<uint8_t> packet(sizeof(header) + header.payload_bytes, 0xa5);
+    std::memcpy(packet.data(), &header, sizeof(header));
+    SimplerKernelInvocationHeader out{};
+    ASSERT_EQ(validate_invocation_header({packet.data(), packet.size()}, prepared, &out), InvocationStatus::Ok);
+    EXPECT_EQ(out.payload_bytes, 13u);
+
+    auto different = prepared;
+    different.tensor_count = 1;
+    EXPECT_EQ(
+        validate_invocation_header({packet.data(), packet.size()}, different, &out), InvocationStatus::InvalidCounts
+    );
+    EXPECT_EQ(out.tensor_count, prepared.tensor_count);
+    different = prepared;
+    different.slot_generation = 0;
+    EXPECT_EQ(
+        validate_invocation_header({packet.data(), packet.size()}, different, &out), InvocationStatus::InvalidArgument
+    );
+    EXPECT_EQ(out.generation, prepared.slot_generation);
+}
+}  // namespace

--- a/tests/ut/py/kernel_close_faults.cpp
+++ b/tests/ut/py/kernel_close_faults.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <array>
+#include <cstdio>
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include "common/host_log_state.h"
+
+namespace {
+int failure_kind = 0;
+int attempts = 0;
+bool pending = false;
+SimplerHostLogState test_log_state{};
+bool guard_acl = false;
+std::array<int, 6> forbidden_calls{};
+bool fake_device_drain = false;
+int device_drain_calls = 0;
+
+int forbidden(size_t index) {
+    ++forbidden_calls[index];
+    return -4322;
+}
+
+int destroy(const char *symbol, void *handle, int kind) {
+    if (failure_kind == kind) {
+        ++attempts;
+        if (pending) {
+            pending = false;
+            return -4321;
+        }
+    }
+    auto real_destroy = reinterpret_cast<int (*)(void *)>(dlsym(RTLD_NEXT, symbol));
+    return real_destroy(handle);
+}
+}  // namespace
+
+extern "C" void arm_destroy_failure(int kind) {
+    failure_kind = kind;
+    attempts = 0;
+    pending = true;
+}
+
+extern "C" int destroy_attempts() { return attempts; }
+
+extern "C" void arm_acl_guard() {
+    forbidden_calls.fill(0);
+    guard_acl = true;
+}
+extern "C" int acl_call_count(int index) { return forbidden_calls.at(index); }
+extern "C" void arm_fatal_drain() {
+    fake_device_drain = true;
+    device_drain_calls = 0;
+}
+extern "C" int fatal_drain_count() { return device_drain_calls; }
+
+extern "C" int aclInit(const char *config) {
+    if (guard_acl) return forbidden(0);
+    return reinterpret_cast<int (*)(const char *)>(dlsym(RTLD_NEXT, "aclInit"))(config);
+}
+extern "C" int aclrtSetDevice(int device) {
+    if (guard_acl) return forbidden(1);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "aclrtSetDevice"))(device);
+}
+extern "C" int aclrtResetDevice(int device) {
+    if (guard_acl) return forbidden(2);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "aclrtResetDevice"))(device);
+}
+extern "C" int aclrtResetDeviceForce(int device) {
+    if (guard_acl) return forbidden(3);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "aclrtResetDeviceForce"))(device);
+}
+extern "C" int aclFinalize() {
+    if (guard_acl) return forbidden(4);
+    return reinterpret_cast<int (*)()>(dlsym(RTLD_NEXT, "aclFinalize"))();
+}
+extern "C" int rtDeviceReset(int device) {
+    if (guard_acl) return forbidden(5);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "rtDeviceReset"))(device);
+}
+extern "C" int aclrtSynchronizeDeviceWithTimeout(int32_t timeout) {
+    if (fake_device_drain) {
+        ++device_drain_calls;
+        return 0;
+    }
+    return reinterpret_cast<int (*)(int32_t)>(dlsym(RTLD_NEXT, "aclrtSynchronizeDeviceWithTimeout"))(timeout);
+}
+
+// The ctypes loader has no ChipWorker to bind a process-owned logger sink.
+extern "C" int bind_test_log(void *runtime) {
+    test_log_state.threshold = 40;
+    test_log_state.sink_owner_pid = getpid();
+    test_log_state.sink_process_pid = getpid();
+    test_log_state.sink_context = &test_log_state;
+    test_log_state.sink_enqueue = [](void *, SimplerHostLogState *, const char *record, uint32_t size, int32_t) {
+        return std::fwrite(record, 1, size, stderr) == size ? 1 : 0;
+    };
+    auto bind = reinterpret_cast<SimplerHostLogBindStateFn>(dlsym(runtime, "simpler_host_log_bind_state"));
+    return bind == nullptr ? -1 : bind(&test_log_state);
+}
+
+extern "C" int rtStreamDestroy(void *stream) { return destroy("rtStreamDestroy", stream, 1); }
+extern "C" int aclrtDestroyEvent(void *event) { return destroy("aclrtDestroyEvent", event, 2); }
+
+extern "C" int aclrtCreateEventExWithFlag(void **event, uint32_t flag) {
+    if (failure_kind == 3 && pending) {
+        pending = false;
+        return -4321;
+    }
+    auto create = reinterpret_cast<int (*)(void **, uint32_t)>(dlsym(RTLD_NEXT, "aclrtCreateEventExWithFlag"));
+    return create(event, flag);
+}

--- a/tests/ut/py/kernel_prepare_orchestration.cpp
+++ b/tests/ut/py/kernel_prepare_orchestration.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Registration resolves this symbol but never invokes the orchestration.
+extern "C" void kernel_prepare_orchestration() {}

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -380,6 +380,33 @@ class TestChipWorkerPython:
         )
         assert expected_warning in capsys.readouterr().err
 
+    def test_public_wrapper_keeps_registries_when_native_finalize_fails(self):
+        from _task_interface import ChipCallable  # noqa: PLC0415
+        from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
+
+        class FakeImpl:
+            initialized = True
+            device_id = 0
+
+            def finalize(self):
+                raise RuntimeError("injected device teardown failure")
+
+        worker = ChipWorker()
+        worker._impl = FakeImpl()
+        worker._callable_registry[0] = ChipCallable.build(signature=[], func_name="test", binary=b"\x00", children=[])
+        worker._identity_registry[b"digest"] = object()
+        worker._live_handles[1] = b"digest"
+
+        with pytest.raises(RuntimeError, match="injected device teardown failure"):
+            worker.finalize()
+
+        # The registries name what the native side still holds. A teardown that
+        # did not complete leaves those resources alive, so dropping the
+        # registries would hide them from a retry and from the caller.
+        assert list(worker._callable_registry) == [0]
+        assert list(worker._identity_registry) == [b"digest"]
+        assert worker._live_handles == {1: b"digest"}
+
     def test_public_wrapper_flush_timeout_is_reported_with_loss_counters(self, monkeypatch, capsys):
         import simpler.task_interface as task_interface_mod  # noqa: PLC0415
         from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -23,6 +23,15 @@ _NEWLY_REQUIRED_PIPELINE_SYMBOLS = {
     "get_retained_temp_addr_ctx",
     "supports_concurrent_native_prepare_ctx",
 }
+# Kernel-mode lifecycle surface: every host-runtime component exports all of
+# these; components without kernel-mode support export validating stubs that
+# report unsupported rather than omitting the symbols.
+_KERNEL_MODE_SYMBOLS = {
+    "simpler_kernel_mode_init",
+    "simpler_kernel_mode_launch",
+    "simpler_kernel_mode_prepare_callable",
+    "simpler_kernel_mode_supported",
+}
 _REMOVED_AMBIENT_SELECTION_SYMBOLS = {
     "select_arena_bank_ctx",
     "select_pipeline_slot_ctx",
@@ -73,4 +82,5 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     symbols = _defined_external_symbols(runtime_path)
 
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
+    assert _KERNEL_MODE_SYMBOLS <= symbols, sorted(_KERNEL_MODE_SYMBOLS - symbols)
     assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -123,7 +123,7 @@ def test_execution_mode_headers_are_self_contained(language: str, standard: str,
     assert result.returncode == 0, result.stderr
 
 
-def test_pipeline_contract_has_no_invocation_header_dependency():
+def test_pipeline_contract_has_no_kernel_lifecycle_or_invocation_dependency():
     compiler = shutil.which("c++")
     assert compiler is not None, "Header dependency test requires c++"
     command = [compiler, "-x", "c++", "-std=c++17"]
@@ -135,4 +135,5 @@ def test_pipeline_contract_has_no_invocation_header_dependency():
     dependencies = subprocess.run(command + ["-M", "-"], input=source, capture_output=True, text=True, check=False)
     assert dependencies.returncode == 0, dependencies.stderr
     assert "execution_mode.h" in dependencies.stdout
-    assert "kernel_invocation_header.h" not in dependencies.stdout
+    for header in ("kernel_invocation_header.h", "kernel_execution_state.h", "execution_mode_latch.h"):
+        assert header not in dependencies.stdout

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -84,3 +85,54 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
     assert _KERNEL_MODE_SYMBOLS <= symbols, sorted(_KERNEL_MODE_SYMBOLS - symbols)
     assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)
+
+
+@pytest.mark.parametrize(("language", "standard", "compiler_name"), [("c", "c11", "cc"), ("c++", "c++17", "c++")])
+@pytest.mark.parametrize(
+    "headers",
+    [
+        ("execution_mode.h",),
+        ("kernel_invocation_header.h",),
+        ("execution_mode.h", "kernel_invocation_header.h"),
+        ("kernel_invocation_header.h", "execution_mode.h"),
+    ],
+)
+def test_execution_mode_headers_are_self_contained(language: str, standard: str, compiler_name: str, headers: tuple):
+    compiler = shutil.which(compiler_name)
+    assert compiler is not None, f"Header ABI tests require {compiler_name}"
+    includes = "\n".join(f'#include "{header}"' for header in headers)
+    source = includes + "\nSimplerExecutionMode mode = SIMPLER_MODE_KERNEL;\n"
+    assertion = "_Static_assert" if language == "c" else "static_assert"
+    source += f'{assertion}(SIMPLER_MODE_PROGRAM == 0 && SIMPLER_MODE_KERNEL == 1, "mode values");\n'
+    result = subprocess.run(
+        [
+            compiler,
+            "-x",
+            language,
+            f"-std={standard}",
+            "-I",
+            str(_PROJECT_ROOT / "src/common/task_interface"),
+            "-fsyntax-only",
+            "-",
+        ],
+        input=source,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_pipeline_contract_has_no_invocation_header_dependency():
+    compiler = shutil.which("c++")
+    assert compiler is not None, "Header dependency test requires c++"
+    command = [compiler, "-x", "c++", "-std=c++17"]
+    for directory in ("src/common", "src/common/task_interface", "src/common/platform/include"):
+        command.extend(["-I", str(_PROJECT_ROOT / directory)])
+    source = '#include "worker/pipeline_contract.h"\n'
+    result = subprocess.run(command + ["-fsyntax-only", "-"], input=source, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+    dependencies = subprocess.run(command + ["-M", "-"], input=source, capture_output=True, text=True, check=False)
+    assert dependencies.returncode == 0, dependencies.stderr
+    assert "execution_mode.h" in dependencies.stdout
+    assert "kernel_invocation_header.h" not in dependencies.stdout

--- a/tests/ut/py/test_kernel_mode_c_api.py
+++ b/tests/ut/py/test_kernel_mode_c_api.py
@@ -1,0 +1,475 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Kernel-mode C ABI driven through a real loaded host runtime.
+
+The class-level tests cover the state machines in isolation; these cover the
+glue no other test reaches — argument validation as the loaded component
+actually performs it, and, on hardware, the bring-up and teardown of a real
+kernel context.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+PTO_RUNTIME_ERR_INTERNAL = -1000
+PTO_RUNTIME_ERR_UNSUPPORTED = -1001
+PTO_RUNTIME_ERR_INVALID_STATE = -1003
+
+_ARCHES = ("a2a3", "a5")
+_RUNTIMES = ("host_build_graph", "tensormap_and_ringbuffer")
+_SIM_CASES = [pytest.param(arch, runtime, id=f"{arch}-sim-{runtime}") for arch in _ARCHES for runtime in _RUNTIMES]
+_ONBOARD_CASES = [
+    pytest.param(
+        arch,
+        runtime,
+        id=f"{arch}-onboard-{runtime}",
+        marks=[pytest.mark.requires_hardware, pytest.mark.platforms([arch])],
+    )
+    for arch in _ARCHES
+    for runtime in _RUNTIMES
+]
+
+
+@pytest.fixture(scope="module")
+def kernel_close_faults(tmp_path_factory):
+    output = tmp_path_factory.mktemp("kernel-close-faults") / "faults.so"
+    subprocess.run(
+        [
+            "c++",
+            "-shared",
+            "-fPIC",
+            "-I" + str(_PROJECT_ROOT / "src/common/log/include"),
+            str(Path(__file__).with_name("kernel_close_faults.cpp")),
+            "-ldl",
+            "-o",
+            str(output),
+        ],
+        check=True,
+    )
+    return output
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _ONBOARD_CASES)
+@pytest.mark.parametrize(
+    "scenario",
+    ["repeat_init", "init_failure", "stream_close", "event_close", "destroy_unclosed", "prepare", "fatal_device"],
+)
+def test_kernel_lifecycle_retry(arch, runtime, scenario, kernel_close_faults, request):
+    _binaries(arch, runtime)
+    device = str(request.config.getoption("--device")).split("-")[0].split(",")[0]
+    env = dict(os.environ)
+    env["LD_PRELOAD"] = str(kernel_close_faults) + (":" + env["LD_PRELOAD"] if env.get("LD_PRELOAD") else "")
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), arch, runtime, device, scenario],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    if scenario == "destroy_unclosed":
+        assert "refusing to destroy an unclosed kernel context" in result.stdout + result.stderr
+
+
+# RUNTIME_ENV_FIELD_GROUPS(3) * RUNTIME_ENV_RING_COUNT(4); the size assertion
+# below is what catches a layout change rather than this constant.
+_RUNTIME_ENV_UINT64_FIELDS = 12
+_OUTPUT_PREFIX_BYTES = 1024
+
+
+class CallConfig(ctypes.Structure):
+    """Mirror of the packed CallConfig the C ABI takes by pointer."""
+
+    _pack_ = 1
+    _fields_ = [
+        ("aicpu_thread_num", ctypes.c_int32),
+        ("enable_chip_swimlane", ctypes.c_int32),
+        ("enable_dump_args", ctypes.c_int32),
+        ("enable_pmu", ctypes.c_int32),
+        ("enable_dep_gen", ctypes.c_int32),
+        ("enable_scope_stats", ctypes.c_int32),
+        ("capture_clock_anchors", ctypes.c_int32),
+        ("runtime_env", ctypes.c_uint64 * _RUNTIME_ENV_UINT64_FIELDS),
+        ("output_prefix", ctypes.c_char * _OUTPUT_PREFIX_BYTES),
+    ]
+
+
+def _load(arch: str, variant: str, runtime: str) -> ctypes.CDLL:
+    path = _PROJECT_ROOT / "build" / "lib" / arch / variant / runtime / "libhost_runtime.so"
+    if not path.exists():
+        pytest.skip(f"{path} not built")
+    if variant == "sim":
+        # A simulated host runtime resolves its device entries against the
+        # simulator context, which the worker normally loads for it.
+        sim_context = _PROJECT_ROOT / "build" / "lib" / "libcpu_sim_context.so"
+        if not sim_context.exists():
+            pytest.skip(f"{sim_context} not built")
+        ctypes.CDLL(str(sim_context), mode=ctypes.RTLD_GLOBAL)  # its hooks resolve by dlsym(RTLD_DEFAULT)
+    # RTLD_LOCAL, as the worker loads it: two runtimes export the same entry
+    # names, so a globally-scoped load makes the second one's calls land in
+    # the first.
+    lib = ctypes.CDLL(str(path), mode=ctypes.RTLD_LOCAL)
+    lib.create_device_context.restype = ctypes.c_void_p
+    lib.create_device_context.argtypes = []
+    lib.destroy_device_context.argtypes = [ctypes.c_void_p]
+    lib.finalize_device.argtypes = [ctypes.c_void_p]
+    lib.finalize_device.restype = ctypes.c_int
+    lib.committed_device_memory_ctx.argtypes = [ctypes.c_void_p]
+    lib.committed_device_memory_ctx.restype = ctypes.c_size_t
+    lib.simpler_kernel_mode_supported.argtypes = [ctypes.c_void_p]
+    lib.simpler_kernel_mode_supported.restype = ctypes.c_int
+    lib.simpler_kernel_mode_init.argtypes = [
+        ctypes.c_void_p, ctypes.c_int,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.POINTER(CallConfig), ctypes.c_uint64,
+    ]  # fmt: skip
+    lib.simpler_kernel_mode_init.restype = ctypes.c_int
+    lib.simpler_kernel_mode_prepare_callable.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int32,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+    ]
+    lib.simpler_kernel_mode_prepare_callable.restype = ctypes.c_int
+    lib.simpler_kernel_mode_launch.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_void_p, ctypes.c_void_p]
+    lib.simpler_kernel_mode_launch.restype = ctypes.c_int
+    lib.simpler_init.argtypes = [
+        ctypes.c_void_p, ctypes.c_int,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.POINTER(CallConfig), ctypes.c_int, ctypes.c_void_p, ctypes.c_uint64,
+    ]  # fmt: skip
+    lib.simpler_init.restype = ctypes.c_int
+    return lib
+
+
+def _minimal_callable_image() -> bytes:
+    """A structurally valid ChipCallable image — the smallest input that gets
+    past argument validation and reaches the ordering verdict."""
+    import ctypes as _ctypes  # noqa: PLC0415
+
+    from simpler.task_interface import ArgDirection, ChipCallable  # noqa: PLC0415
+
+    chip = ChipCallable.build(signature=[ArgDirection.IN], func_name="f", binary=b"\x00", children=[])
+    return _ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+
+
+def _binaries(arch: str, runtime: str) -> tuple[bytes, bytes, bytes]:
+    base = _PROJECT_ROOT / "build" / "lib" / arch / "onboard" / runtime
+    dispatcher = _PROJECT_ROOT / "build" / "lib" / arch / "dispatcher" / "libsimpler_aicpu_dispatcher.so"
+    files = (base / "libaicpu_kernel.so", base / "aicore_kernel.o", dispatcher)
+    for path in files:
+        if not path.exists():
+            pytest.skip(f"{path} not built")
+    return tuple(path.read_bytes() for path in files)  # type: ignore[return-value]
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_kernel_init_rejects_malformed_arguments(arch: str, runtime: str):
+    """Every component runs the same structural validation before its verdict.
+
+    The checks live in one shared header precisely so a stub and a real
+    implementation accept and reject the same arguments; that parity is only
+    provable against the loaded component.
+    """
+    lib = _load(arch, "sim", runtime)
+    config = CallConfig()
+    payload = b"\x00\x01\x02\x03"
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        # A binary and its size describe one object, so a pointer without a
+        # size — or a size without a pointer — is structurally invalid.
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, None, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+            )
+            == PTO_RUNTIME_ERR_INTERNAL
+        )
+        # A negative device and a zero generation are both out of contract.
+        for device_id, generation in ((-1, 1), (0, 0)):
+            assert (
+                lib.simpler_kernel_mode_init(
+                    ctx,
+                    device_id,
+                    payload,
+                    len(payload),
+                    payload,
+                    len(payload),
+                    payload,
+                    len(payload),
+                    ctypes.byref(config),
+                    generation,
+                )  # fmt: skip
+                == PTO_RUNTIME_ERR_INTERNAL
+            )
+        # A null config is rejected before anything else is read.
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), None, 1
+            )
+            == PTO_RUNTIME_ERR_INTERNAL
+        )
+    finally:
+        lib.destroy_device_context(ctx)
+
+
+def _run_lifecycle_retry(arch, runtime, device, scenario):
+    lib = _load(arch, "onboard", runtime)
+    # Caller-owned binding precedes kernel init and the forbidden-call window.
+    lib.rtSetDevice.argtypes = [ctypes.c_int]
+    lib.rtSetDevice.restype = ctypes.c_int
+    assert lib.rtSetDevice(device) == 0
+    aicpu, aicore, dispatcher = _binaries(arch, runtime)
+    config = CallConfig()
+    ctx = lib.create_device_context()
+    init_args = (
+        ctx,
+        device,
+        aicpu,
+        len(aicpu),
+        aicore,
+        len(aicore),
+        dispatcher,
+        len(dispatcher),
+        ctypes.byref(config),
+        1,
+    )
+    faults = ctypes.CDLL(None)
+    faults.bind_test_log.argtypes = [ctypes.c_void_p]
+    faults.bind_test_log.restype = ctypes.c_int
+    assert faults.bind_test_log(lib._handle) == 0
+    faults.arm_destroy_failure.argtypes = [ctypes.c_int]
+    faults.destroy_attempts.restype = ctypes.c_int
+    lib.ensure_acl_ready_ctx.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    lib.ensure_acl_ready_ctx.restype = ctypes.c_int
+    faults.acl_call_count.argtypes = [ctypes.c_int]
+    faults.acl_call_count.restype = ctypes.c_int
+    faults.arm_acl_guard()
+    # Prove each interceptor counts and refuses calls before trusting zeros.
+    forbidden_args = (
+        ("aclInit", ctypes.c_char_p, None),
+        ("aclrtSetDevice", ctypes.c_int, device),
+        ("aclrtResetDevice", ctypes.c_int, device),
+        ("aclrtResetDeviceForce", ctypes.c_int, device),
+        ("aclFinalize", None, None),
+        ("rtDeviceReset", ctypes.c_int, device),
+    )
+    for i, (symbol, argtype, value) in enumerate(forbidden_args):
+        fn = getattr(faults, symbol)
+        fn.argtypes = [] if argtype is None else [argtype]
+        fn.restype = ctypes.c_int
+        assert (fn() if argtype is None else fn(value)) == -4322
+        assert faults.acl_call_count(i) == 1
+    faults.arm_acl_guard()
+    if scenario == "init_failure":
+        faults.arm_destroy_failure(3)
+    assert lib.simpler_kernel_mode_init(*init_args) == (-4321 if scenario == "init_failure" else 0)
+    try:
+        # These exported C++ methods use the Linux Itanium ABI. Resolve the
+        # actual runtime's methods rather than adding production test hooks.
+        force_reset = getattr(lib, "_ZN12DeviceRunner18force_reset_deviceEv")
+        force_reset.argtypes = [ctypes.c_void_p]
+        force_reset.restype = ctypes.c_int
+        assert force_reset(ctx) == PTO_RUNTIME_ERR_UNSUPPORTED
+        assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
+        if scenario == "fatal_device":
+            recover = getattr(lib, "_ZN12DeviceRunner31recover_device_or_mark_unusableEi")
+            recover.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            recover.restype = None
+            accepts = getattr(lib, "_ZNK12DeviceRunner14can_accept_runEv")
+            accepts.argtypes = [ctypes.c_void_p]
+            accepts.restype = ctypes.c_bool
+            assert accepts(ctx)
+            # Inject the drain result, not a real device fault or device reset.
+            # The real recovery method sets device_unusable_ and real finalize
+            # must then take the fatal-device branch.
+            faults.arm_fatal_drain()
+            recover(ctx, 507018)
+            assert faults.fatal_drain_count() == 1
+            assert not accepts(ctx)
+            assert force_reset(ctx) == PTO_RUNTIME_ERR_UNSUPPORTED
+            assert lib.finalize_device(ctx) == 0
+        elif scenario == "destroy_unclosed":
+            lib.destroy_device_context(ctx)
+            assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
+            assert lib.finalize_device(ctx) == 0
+        elif scenario == "prepare":
+            _check_prepare_reuse(lib, ctx, arch, runtime)
+        elif scenario in ("repeat_init", "init_failure"):
+            assert lib.simpler_kernel_mode_init(*init_args) == PTO_RUNTIME_ERR_INVALID_STATE
+            assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
+        else:
+            faults.arm_destroy_failure(1 if scenario == "stream_close" else 2)
+            assert lib.finalize_device(ctx) == -4321
+            first_attempts = faults.destroy_attempts()
+            assert first_attempts > 0
+            assert lib.finalize_device(ctx) == 0
+            assert faults.destroy_attempts() == first_attempts + 1
+    finally:
+        lib.finalize_device(ctx)
+        lib.destroy_device_context(ctx)
+        names = (
+            "aclInit",
+            "aclrtSetDevice",
+            "aclrtResetDevice",
+            "aclrtResetDeviceForce",
+            "aclFinalize",
+            "rtDeviceReset",
+        )
+        assert {name: faults.acl_call_count(i) for i, name in enumerate(names)} == dict.fromkeys(names, 0)
+
+
+def _check_prepare_reuse(lib, ctx, arch, runtime):
+    import tempfile  # noqa: PLC0415
+
+    from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+    from simpler_setup.kernel_compiler import KernelCompiler  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory(prefix="kernel-prepare-") as build_dir:
+        binary = KernelCompiler(arch).compile_orchestration(
+            runtime, str(Path(__file__).with_name("kernel_prepare_orchestration.cpp")), build_dir=build_dir
+        )
+    chip = ChipCallable.build(signature=[], func_name="kernel_prepare_orchestration", binary=binary, children=[])
+    image = ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+    before = lib.committed_device_memory_ctx(ctx)
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == 0
+    prepared = lib.committed_device_memory_ctx(ctx)
+    assert prepared > before
+    # Duplicate registration is rejected; it must not disturb the first ID.
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) != 0
+    assert lib.committed_device_memory_ctx(ctx) == prepared
+    # Identical bytes deduplicate the callable upload. The second ID also
+    # reuses the context's persistent argument blocks, so neither adds GM.
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 1, image, len(image)) == 0
+    assert lib.committed_device_memory_ctx(ctx) == prepared
+    assert lib.finalize_device(ctx) == 0
+    assert lib.committed_device_memory_ctx(ctx) == 0
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 2, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_kernel_entries_reject_a_context_with_no_kernel_claim(arch: str, runtime: str):
+    """Structurally valid calls on a context that never claimed kernel mode
+    are an ordering error, not an argument error."""
+    lib = _load(arch, "sim", runtime)
+    image = _minimal_callable_image()
+    stream = ctypes.byref((ctypes.c_uint8 * 8)())
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        assert lib.simpler_kernel_mode_supported(ctx) == 0
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+        assert lib.simpler_kernel_mode_launch(ctx, 0, image, stream) == PTO_RUNTIME_ERR_INVALID_STATE
+        # An out-of-range callable id and a truncated image are argument
+        # errors, so the structural checks run before the ordering one.
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, -1, image, len(image)) == PTO_RUNTIME_ERR_INTERNAL
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, 1) == PTO_RUNTIME_ERR_INTERNAL
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image) - 1) == PTO_RUNTIME_ERR_INTERNAL
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+        assert lib.simpler_kernel_mode_launch(ctx, 0, image, None) == PTO_RUNTIME_ERR_INTERNAL
+    finally:
+        lib.destroy_device_context(ctx)
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_simulated_components_report_kernel_mode_unsupported(arch: str, runtime: str):
+    """A component without kernel-mode execution still validates first, then
+    reports unsupported — it never claims a mode it cannot honor."""
+    lib = _load(arch, "sim", runtime)
+    config = CallConfig()
+    payload = b"\x00"
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+            )
+            == PTO_RUNTIME_ERR_UNSUPPORTED
+        )
+        # The refused init took no claim, so the context is still free.
+        image = _minimal_callable_image()
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+    finally:
+        lib.destroy_device_context(ctx)
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _ONBOARD_CASES)
+def test_kernel_context_brings_up_and_closes_on_a_borrowed_device(arch: str, runtime: str, request):
+    """A kernel context comes up on a device the caller owns, refuses the
+    program-mode entry for the rest of its life, and releases everything it
+    created on close."""
+    lib = _load(arch, "onboard", runtime)
+    aicpu, aicore, dispatcher = _binaries(arch, runtime)
+    config = CallConfig()
+    device_id = int(str(request.config.getoption("--device")).split("-")[0].split(",")[0])
+    lib.rtSetDevice.argtypes = [ctypes.c_int]
+    lib.rtSetDevice.restype = ctypes.c_int
+    assert lib.rtSetDevice(device_id) == 0
+
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx,
+                device_id,
+                aicpu,
+                len(aicpu),
+                aicore,
+                len(aicore),
+                dispatcher,
+                len(dispatcher),
+                ctypes.byref(config),
+                1,
+            )  # fmt: skip
+            == 0
+        )
+        # The claim is exclusive for the context's whole life.
+        assert (
+            lib.simpler_init(
+                ctx,
+                device_id,
+                aicpu,
+                len(aicpu),
+                aicore,
+                len(aicore),
+                dispatcher,
+                len(dispatcher),
+                ctypes.byref(config),
+                0,
+                None,
+                0,
+            )  # fmt: skip
+            == PTO_RUNTIME_ERR_INVALID_STATE
+        )
+        assert lib.finalize_device(ctx) == 0
+    finally:
+        # Destroying after a clean close is allowed; an unclosed kernel
+        # context would be refused and leaked instead.
+        lib.destroy_device_context(ctx)
+
+
+if __name__ == "__main__":
+    _run_lifecycle_retry(sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4])

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -1406,6 +1406,67 @@ class TestChipCallable:
         assert "sig_count=2" in r
         assert "child_count=1" in r
 
+    def test_scalar_count_defaults_to_zero(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN],
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert chip.scalar_count == 0
+
+    def test_scalar_count_keyword_round_trip(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN, ArgDirection.OUT] + [ArgDirection.SCALAR] * 5,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+            scalar_count=5,
+        )
+        assert chip.scalar_count == 5
+
+    def test_scalar_count_survives_from_bytes(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 7,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+            scalar_count=7,
+        )
+        raw = ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+        clone = ChipCallable.from_bytes(raw)
+        assert clone.scalar_count == 7
+
+    def test_scalar_count_out_of_range_reports_value_and_limit(self):
+        for bad in (-1, 129):
+            with pytest.raises(ValueError, match=rf"{bad}.*128"):
+                ChipCallable.build(
+                    signature=[],
+                    func_name="test_func",
+                    binary=b"\x00",
+                    children=[],
+                    scalar_count=bad,
+                )
+
+    def test_scalar_count_disagreeing_with_signature_rejected(self):
+        """A nonzero count is a cached derivation of the signature; zero also
+        means "not recorded" and stays valid with any signature."""
+        with pytest.raises(ValueError, match=r"5.*0.*SCALAR"):
+            ChipCallable.build(
+                signature=[ArgDirection.IN, ArgDirection.OUT],
+                func_name="test_func",
+                binary=b"\x00",
+                children=[],
+                scalar_count=5,
+            )
+        unrecorded = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 3,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert unrecorded.scalar_count == 0
+
 
 # ============================================================================
 # ChipTensor.child_memory

--- a/tools/cann-examples/tmr-invocation-snapshot/device/CMakeLists.txt
+++ b/tools/cann-examples/tmr-invocation-snapshot/device/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+
+cmake_minimum_required(VERSION 3.16)
+project(snapshot_probe_device LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+add_library(snapshot_probe_device SHARED snapshot.cpp)
+target_include_directories(snapshot_probe_device PRIVATE
+    "${ROOT}/src/common" "${ROOT}/src/common/task_interface"
+)
+target_compile_options(snapshot_probe_device PRIVATE -Wall -Wextra -O2 -fPIC)
+target_link_options(snapshot_probe_device PRIVATE -Wl,--build-id)

--- a/tools/cann-examples/tmr-invocation-snapshot/device/snapshot.cpp
+++ b/tools/cann-examples/tmr-invocation-snapshot/device/snapshot.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstring>
+#include <ctime>
+#include "../protocol.h"
+#include "tensormap_and_ringbuffer/kernel_invocation_args.h"
+
+namespace {
+SnapshotProbeInit fixture{};
+uint32_t next_result = 0;
+}  // namespace
+
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_init(void *args) {
+    if (args == nullptr) return 1;
+    std::memcpy(&fixture, args, sizeof(fixture));
+    next_result = 0;
+    return 0;
+}
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *) { return 1; }
+
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_kernel_exec(void *args) {
+    using namespace simpler::tmr;
+    if (args == nullptr || fixture.results_addr == 0 || next_result >= fixture.capacity) return 1;
+    if (fixture.gate_addr == 0) return 1;
+    timespec started{};
+    if (clock_gettime(CLOCK_MONOTONIC, &started) != 0) return 1;
+    // The host releases this test-only gate after destroying every packet.
+    // No invocation bytes are read while the gate is closed.
+    while (*reinterpret_cast<volatile uint32_t *>(fixture.gate_addr) == 0) {
+        timespec now{};
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0 || now.tv_sec - started.tv_sec > 30) return 1;
+    }
+    SimplerKernelInvocationHeader header{};
+    std::memcpy(&header, args, sizeof(header));
+    const auto callable = snapshot_probe_callable(header.callable_id);
+    size_t bytes = 0;
+    auto status = tmr_invocation_size(callable, &bytes);
+    TmrInvocationView view;
+    const TmrExecutionBindingView binding{fixture.results_addr, fixture.context_generation};
+    // The formal host adapter submits exactly the independently derived size.
+    // This CPU entry has no API for observing CANN's actual readable byte count.
+    if (status == InvocationStatus::Ok)
+        status = decode_tmr_invocation({static_cast<const uint8_t *>(args), bytes}, callable, binding, &view);
+    uint64_t sum = 0;
+    if (status == InvocationStatus::Ok) {
+        EntryArgsStorage storage{};
+        status = materialize_tmr_entry_args(view, &storage);
+        for (int i = 0; i < storage.tensor_count(); ++i)
+            sum += storage.tensor(i).buffer.addr + storage.tensor(i).numel();
+        for (int i = 0; i < storage.scalar_count(); ++i)
+            sum += storage.scalar(i);
+    }
+    auto *results = reinterpret_cast<volatile SnapshotProbeResult *>(fixture.results_addr);
+    const auto index = next_result++;
+    results[index].sum = sum;
+    results[index].callable_id = header.callable_id;
+    results[index].status = static_cast<int32_t>(status);
+    return status == InvocationStatus::Ok ? 0 : 1;
+}

--- a/tools/cann-examples/tmr-invocation-snapshot/host/CMakeLists.txt
+++ b/tools/cann-examples/tmr-invocation-snapshot/host/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+
+cmake_minimum_required(VERSION 3.16)
+project(snapshot_probe LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+if(NOT ASCEND_HOME_PATH)
+    message(FATAL_ERROR "ASCEND_HOME_PATH must be set")
+endif()
+include("${ROOT}/cmake/host_log_sources.cmake")
+add_executable(snapshot_probe probe.cpp
+    "${ROOT}/src/common/aicpu_loader/host/load_aicpu_op.cpp"
+    "${ROOT}/src/common/task_interface/assert_compat.cpp"
+    ${SIMPLER_HOST_LOG_SOURCES}
+)
+target_include_directories(snapshot_probe PRIVATE
+    "${ROOT}/src/common" "${ROOT}/src/common/task_interface"
+    "${ROOT}/src/common/worker" "${ROOT}/src/common/platform/include"
+    "${ROOT}/src/common/log/include" "${ROOT}/src/a2a3/platform/include"
+    "${ASCEND_HOME_PATH}/include" "${ASCEND_HOME_PATH}/pkg_inc"
+    "${ASCEND_HOME_PATH}/pkg_inc/runtime" "${ASCEND_HOME_PATH}/pkg_inc/runtime/runtime"
+    "${ASCEND_HOME_PATH}/pkg_inc/profiling"
+)
+target_link_directories(snapshot_probe PRIVATE "${ASCEND_HOME_PATH}/lib64")
+target_link_libraries(snapshot_probe PRIVATE ascendcl runtime pthread dl)
+target_compile_options(snapshot_probe PRIVATE -Wall -Wextra)

--- a/tools/cann-examples/tmr-invocation-snapshot/host/probe.cpp
+++ b/tools/cann-examples/tmr-invocation-snapshot/host/probe.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <acl/acl.h>
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../protocol.h"
+#include "platform/onboard/host/tmr_kernel_invocation.h"
+
+namespace {
+void check(int code, const char *operation) {
+    if (code != 0) throw std::runtime_error(std::string(operation) + ": " + std::to_string(code));
+}
+std::vector<uint8_t> read_binary(const char *path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) throw std::runtime_error(std::string("cannot open ") + path);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+}  // namespace
+
+// Standalone process: owns its ACL setup and result buffer. No TMR execution
+// resources or production registry are created by this transport-only probe.
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        std::fprintf(stderr, "usage: snapshot_probe DEVICE DISPATCHER_SO PROBE_SO\n");
+        return 2;
+    }
+    try {
+        const int device = std::stoi(argv[1]);
+        const auto dispatcher = read_binary(argv[2]);
+        const auto binary = read_binary(argv[3]);
+        check(aclInit(nullptr), "aclInit");
+        check(aclrtSetDevice(device), "aclrtSetDevice");
+        aclrtStream stream = nullptr;
+        check(aclrtCreateStream(&stream), "create stream");
+        aclrtStream release_stream = nullptr;
+        check(aclrtCreateStream(&release_stream), "create release stream");
+        constexpr uint32_t count = 24;
+        void *results = nullptr;
+        check(aclrtMalloc(&results, count * sizeof(SnapshotProbeResult), ACL_MEM_MALLOC_HUGE_FIRST), "alloc results");
+        check(
+            aclrtMemset(results, count * sizeof(SnapshotProbeResult), 0xff, count * sizeof(SnapshotProbeResult)),
+            "initialize result sentinels"
+        );
+        void *gate = nullptr;
+        check(aclrtMalloc(&gate, sizeof(uint32_t), ACL_MEM_MALLOC_HUGE_FIRST), "alloc test gate");
+        check(aclrtMemset(gate, sizeof(uint32_t), 0, sizeof(uint32_t)), "close test gate");
+        {
+            host::LoadAicpuOp loader;
+            check(
+                loader.BootstrapDispatcher(
+                    dispatcher.data(), dispatcher.size(), binary.data(), binary.size(), stream, device
+                ),
+                "bootstrap"
+            );
+            check(loader.Init({simpler::tmr::TmrKernelInvocationName}), "register entries");
+            SnapshotProbeInit init{reinterpret_cast<uint64_t>(results), 13, reinterpret_cast<uint64_t>(gate), count};
+            check(loader.LaunchBuiltInOp(stream, &init, sizeof(init), 1, "simpler_aicpu_init"), "init fixture");
+            check(aclrtSynchronizeStream(stream), "sync prepare");
+
+            std::vector<SnapshotProbeResult> expected;
+            simpler::tmr::TmrEncodingCache caches[3];
+            const simpler::tmr::TmrExecutionBindingView binding{init.results_addr, init.context_generation};
+            for (uint32_t i = 0; i < count; ++i) {
+                const auto callable = snapshot_probe_callable(static_cast<int32_t>(i % 3));
+                ChipStorageTaskArgs args{};
+                uint64_t sum = 0;
+                for (int t = 0; t < callable.tensor_count; ++t) {
+                    const uint32_t shape[] = {1};
+                    const uint64_t addr = init.results_addr + (i % count) * sizeof(SnapshotProbeResult);
+                    args.add_tensor(make_tensor_external(
+                        reinterpret_cast<void *>(addr), shape, 1, DataType::FLOAT32, AddressSpace::DEVICE
+                    ));
+                    sum += addr + 1;
+                }
+                if (callable.scalar_count != 0) {
+                    args.add_scalar(i * 17 + 5);
+                    sum += i * 17 + 5;
+                }
+                simpler::tmr::TmrEncodingCandidate candidate;
+                auto status = simpler::tmr::encode_tmr_invocation(args, callable, binding, caches[i % 3], &candidate);
+                if (status != simpler::kernel::InvocationStatus::Ok) throw std::runtime_error("encode failed");
+                check(
+                    simpler::tmr::enqueue_tmr_invocation_aicpu(loader, stream, 1, candidate, callable, binding),
+                    "enqueue snapshot"
+                );
+                caches[i % 3].commit(std::move(candidate));
+                const auto packet = candidate.packet();
+                std::memset(const_cast<uint8_t *>(packet.data), 0xa5, packet.size);
+                args = {};
+                expected.push_back({sum, callable.callable_id, 0});
+            }
+            check(aclrtMemsetAsync(gate, sizeof(uint32_t), 1, sizeof(uint32_t), release_stream), "release test gate");
+            check(aclrtSynchronizeStream(stream), "sync invocations");
+            check(aclrtSynchronizeStream(release_stream), "sync release");
+            std::vector<SnapshotProbeResult> actual(count);
+            check(
+                aclrtMemcpy(
+                    actual.data(), actual.size() * sizeof(actual[0]), results, actual.size() * sizeof(actual[0]),
+                    ACL_MEMCPY_DEVICE_TO_HOST
+                ),
+                "read results"
+            );
+            for (uint32_t i = 0; i < count; ++i) {
+                if (actual[i].sum != expected[i].sum || actual[i].callable_id != expected[i].callable_id ||
+                    actual[i].status != 0)
+                    throw std::runtime_error("snapshot mismatch at " + std::to_string(i));
+            }
+            std::printf(
+                "PASS: %u gated asynchronous snapshots, minimum/maximum packets, host overwrite+release\n", count
+            );
+        }
+        check(aclrtFree(results), "free results");
+        check(aclrtFree(gate), "free test gate");
+        check(aclrtDestroyStream(release_stream), "destroy release stream");
+        check(aclrtDestroyStream(stream), "destroy stream");
+        check(aclrtResetDevice(device), "reset device");
+        check(aclFinalize(), "aclFinalize");
+        return 0;
+    } catch (const std::exception &error) {
+        std::fprintf(stderr, "FAIL: %s\n", error.what());
+        return 1;
+    }
+}

--- a/tools/cann-examples/tmr-invocation-snapshot/protocol.h
+++ b/tools/cann-examples/tmr-invocation-snapshot/protocol.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+#include <cstdint>
+#include <type_traits>
+#include "task_interface/kernel_invocation_validation.h"
+
+// Test fixtures, published by a separate init task before any invocation.
+struct SnapshotProbeInit {
+    uint64_t results_addr;
+    uint64_t context_generation;
+    uint64_t gate_addr;
+    uint32_t capacity;
+};
+struct SnapshotProbeResult {
+    uint64_t sum;
+    int32_t callable_id;
+    int32_t status;
+};
+static_assert(std::is_trivially_copyable_v<SnapshotProbeInit> && std::is_standard_layout_v<SnapshotProbeInit>);
+static_assert(std::is_trivially_copyable_v<SnapshotProbeResult> && std::is_standard_layout_v<SnapshotProbeResult>);
+
+inline simpler::kernel::PreparedInvocationView snapshot_probe_callable(int32_t id) {
+    switch (id) {
+    case 0:
+        return {0, 0, 0, 1};
+    case 1:
+        return {1, 1, 1, 2};
+    case 2:
+        return {2, CHIP_MAX_TENSOR_ARGS, 0, 3};
+    default:
+        return {-1, 0, 0, 0};
+    }
+}


### PR DESCRIPTION

> **Depends on #2064, #2177 and #2176 — keep this PR in Draft. Align and revalidate against the merged prerequisites before merging.** See [#2064](https://github.com/hw-native-sys/simpler/pull/2064), [#2177](https://github.com/hw-native-sys/simpler/pull/2177), and [#2176](https://github.com/hw-native-sys/simpler/pull/2176).
>
> Based on #2177 at `2153406a0420e8de17cf7397d30864939b1bca0c`, whose K1 baseline is `dc1268cd55405fc56137eb16d04227ea797a419f`. The original K4 foundation is [3e822453](https://github.com/Leaf-Salix/simpler/commit/3e822453fe1fba6e9ffec9c79893e190f460b878). The follow-up [b0943525](https://github.com/Leaf-Salix/simpler/commit/b0943525dd8eaeb486bca92bbf5480a37eb61fcb) integrates K2's `48b120b15cbcc7ea1f28ae36ec3403e17cfe48b1` with K4 admission/transport/consumption interfaces. K2 is included as source changes, not as a merge parent; the combined diff must not be attributed entirely to K4. The HBG/2b stack is not included.

## Motivation

TMR (`tensormap_and_ringbuffer`) kernel mode needs a per-invocation argument snapshot that remains independent of mutable Host inputs and later calls. Reusing program bind/staging or overwriting a shared Runtime to pass each invocation would couple parameter lifetime to execution resources and make asynchronous submission difficult to reason about.

This PR provides **shared invocation validation → TMR snapshot encoding/decoding → a native CPU transport adapter**, with explicit interfaces for trusted resource metadata:

```text
Prepared callable metadata + stable execution-binding view
  + current ChipStorageTaskArgs
  → validate and encode an independently owned candidate packet
  → native CPU submission adapter
  → CANN-owned argument copy
  → bounded TMR decoding and caller-owned EntryArgsStorage

Host template cache:
  updated only after the owner reports successful complete enqueue
```

This is **K4 foundation plus K2 integration, not the complete kernel execution path**. Onboard TMR init/prepare/close can exercise K2 resources, and real prepare consumes the shared callable admission checks. Sim init retains `UNSUPPORTED` after contract validation; HBG kernel init remains unsupported without 2b. `simpler_kernel_mode_supported()` remains `0`, and public launch remains fail-closed rather than reaching the adapter. Stable execution-binding and residency-generation providers, the production device dispatch, and the complete submission binder remain dependencies. The included transport probe uses explicitly test-only metadata.

## Invocation contract and adaptation

### Shared validation without a shared runtime payload

`src/common/task_interface/kernel_invocation_validation.h` provides:

- `PreparedInvocationView`: trusted callable ID, effective tensor/scalar counts, and callable residency generation.
- `derive_invocation_counts()`: validates the signature and derives effective counts. A nonzero cached scalar count must agree with the signature; zero uses the signature-derived value.
- `validate_invocation_header()`: checks the formal K9 framing, kernel mode, callable ID range, count limits, payload length against the supplied readable span, and identity/count agreement with the trusted callable.
- `host_copy_tensor_count != 0` is rejected.

These checks do not interpret TMR payload contents. HBG can reuse the common admission rules while retaining its own graph/blob validation. A trusted callable view must come from an independently validated, live registration; constructing it from the packet being checked would not establish trust.

No public C query or lifecycle API is added. The combined branch adopts K2's four-argument `simpler_kernel_mode_prepare_callable(ctx, cid, callable, callable_size)` signature; prepare no longer receives a caller stream. This is an intentional prerequisite ABI alignment from the original K4 baseline, not a claim that all old signatures remain unchanged. Execution-mode definitions and formal K9 layout remain unchanged.

`src/common/platform/include/host/kernel_entry_validation.h` consumes the shared effective-count rules in real onboard/sim prepare admission. It also checks canonical callable names, child counts, alignment, offsets and complete variable-length storage bounds before hashing, registration or state mutation. These checks are kernel-prepare-only; program registration does not acquire this new validation path. Combined onboard init preserves 2a's builder/contract admission before mode latch, executor replacement or context resource creation.

### TMR-specific wire and consumption

`src/common/tensormap_and_ringbuffer/kernel_invocation.h` defines the runtime-specific binding reference and bounded decoder. The packet layout is:

```text
SimplerKernelInvocationHeader
TmrBindingRef { device_binding_addr, context_generation }
ChipTensor[tensor_count]
uint64_t[scalar_count]
```

The packet length is derived from the formal types and trusted effective counts:

```cpp
sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef)
    + tensor_count * sizeof(ChipTensor)
    + scalar_count * sizeof(uint64_t)
```

The inherited K9 is currently 40 bytes; `TmrBindingRef` is 16 bytes, with size/offset assertions. Packets contain descriptors and scalar bits, **not Tensor data, callable binaries, Host pointers, STL objects, or an entire Runtime**. No global maximum-sized Host packet is allocated.

The two version fields protect different resources:

| Field | Meaning and provider |
| --- | --- |
| K9 `generation` / `PreparedInvocationView::slot_generation` | Callable residency version, supplied by the prepared-callable owner |
| `TmrBindingRef::context_generation` | Stable execution-binding/context version, supplied by the execution-resource owner |

`device_binding_addr` is opaque to the codec. The provider owns the referenced binding's format, capacity validation, publication, and lifetime. A nonzero address or a matching generation does not independently prove that resources exist or remain alive.

Encoding normalizes Tensor fields, excludes padding and unused dimensions from identity, and accepts only Device Tensor descriptors. Nonempty tensors undergo extent/backing and arithmetic checks. Empty tensors follow the existing boundary-conversion behavior; this is not a promise that arbitrary operators support empty inputs.

Decoding uses a pointer-plus-length `ByteSpan`, validates exact TMR size and trusted bindings, and reads unaligned input through bounded copies. Failure leaves the previous output unchanged. The resulting view borrows immutable packet storage.

`kernel_invocation_args.h` provides `consume_tmr_invocation(packet, trusted_callable, trusted_binding, out)`: decode and validate before materializing into consumer-owned `EntryArgsStorage`, preserving `out` on rejection. It is an explicit consumption interface, not a registered production AICPU dispatch. It does not call program `Runtime::set_orch_args()` or overwrite dynamic arguments in a persistent Runtime. Storage must remain alive through the last config/orchestration access and every derived Tensor reference.

### Host templates and native transport

`src/common/worker/tmr_kernel_invocation.h` provides one Host encoding-cache object per prepared callable and independently owned candidates:

- The structural template excludes Tensor addresses and scalar values, while retaining scope, generations, geometry, offsets, and backing sizes.
- A cache hit still validates current inputs and fills current addresses/scalars.
- Encoding or submission failure must leave the previous cache in place. Cache commit is explicit and non-throwing; the owner calls it only after the **complete enqueue sequence** succeeds.
- Cache storage does not grow with invocation count. In-flight task/graph copies have a separate owner and lifetime.

`src/common/platform/onboard/host/tmr_kernel_invocation.{h,cpp}` provides `enqueue_tmr_invocation_aicpu(DeviceRunnerBase&, ...)`. It revalidates the candidate's owned length and trusted metadata, then calls the initialized runner's `launch_aicpu_payload()` CPU transport. The implementation is compiled into both architecture-specific onboard targets. The direct `LoadAicpuOp` overload remains available for the isolated transport probe. The owner supplies the dedicated AICPU stream and establishes the complete event ordering outside this adapter; linking the adapter does not wire public launch or install a device consumer.

The adapter targets the kernel-specific `simpler_aicpu_kernel_exec` symbol, **not** the existing program `KernelArgs*` entry. The production symbol/consumer is not registered by this PR; it exists in the isolated probe for transport validation.

This does not require TMR and HBG to use the same SDK launch API. The common requirement is task-owned argument-copy semantics with a valid Host buffer until the native copy returns. The TMR probe exercises the existing `rtsLaunchCpuKernel` path, not an assumed `WithHostArgs` replacement.

## Lifecycle and program-path impact

**Submission transaction:** The owner must protect the entire sequence, not just individual accessor calls:

```text
enter owner submission protection
  → acquire trusted callable and binding views
  → validate and encode a private candidate
  → perform the complete native enqueue sequence
  → commit the template on success
  → release Host packet
leave owner submission protection
```

The same protection must coordinate with prepare replacement and close. K4 introduces no independent cache mutex or parallel resource registry. Independent callers may use independent caches/outputs; shared-cache access requires owner serialization.

**Ownership:** K4 owns the Host packet until the native API completes its copy. Native success means enqueue, not device completion. CANN owns the task/graph argument copy; the resource providers keep callable and stable execution resources alive. Generation validation does not replace lifetime management. Partial enqueue failure and already-submitted work require binder error handling; leaving the Host cache unchanged does not cancel device work.

**Alignment with other modules:** The K2 stream/persistent-argument owner is included, not duplicated. Its arbitrary-payload transport is the runner adapter's integration point. The included K2 snapshot owns a private AICPU stream, a hidden AICore stream and five context events; this must not be described as proof of two-hidden-stream capture. K3/K5/K10 must provide actual trusted views; K4 does not substitute fixed generations, fake addresses, or the program Runtime. No cache sidecar or second registry is attached to context/callable state before a real owner consumes it.

**Program-path impact:** K4 does not redirect program bind, staging, Runtime upload or per-run cleanup through invocation snapshots. However, the combined diff includes K2 changes in shared platform, device-runner and worker code, so it is not accurate to say no existing production source is modified. It also includes two shared buffer-pool lint fixes: remove unspecified pointer-address ordering while retaining collect/deduplicate-before-release behavior, and use a single-mutex `scoped_lock` with the same notify lifetime. A regression test covers release-once and queue clearing; no warning suppression is added.

**Left to follow-up PRs:** Trusted Host/device provider publication; capacity establishment and callable residency; complete stream/event submission and cancellation; production device dispatch; Torch/taskQueue/storage retention; ACLGraph capture/replay; and close/graph quiescence. Host concurrency tests do not establish safety for device execution, replay, or close races.

## Tests

Evidence is separated below between the original `3e822453` foundation and the combined K2/K4 source snapshot. Neither is a claim that the full CI matrix or the complete kernel pipeline has passed.

### Coverage added in this PR

- `tests/ut/cpp/types/test_kernel_invocation_validation.cpp`: **3 cases** covering effective scalar rules, invalid signatures/counts/modes/IDs/generations, unaligned framing, output preservation, and acceptance of opaque non-TMR payloads with independently trusted counts.
- `tests/ut/cpp/common/test_tmr_kernel_invocation.cpp`: **11 cases** covering round-trip conversion, cache identity and dynamic patching, unchanged cache/output on failure, canonical padding, stale bindings, short/corrupt packets, self-consistent K9 lengths that still violate exact TMR size, tensor arithmetic/Device-only rules, empty boundary conversion, minimum/maximum/scalar-only packets, and independent/owner-serialized concurrent calls.
- `tools/cann-examples/tmr-invocation-snapshot/`: A committed, standalone Host/device probe using the actual CPU loader and packet layout. It submits **24 asynchronous packets**, overwrites and releases Host packet storage, and verifies copied values only after a test-only device-read gate is released. Result buffers start with failure sentinels. The gate has a timeout and is not part of production execution.

The combined update adds prepare signature/FAM rejection cases, real sim prepare entry coverage, trusted-view consumption/output-preservation cases, and 10,000 repeated encodes showing bounded logical template bytes. The latter is not an RSS, peak-heap or CANN task-memory measurement. It also includes K2's lifecycle tests and a buffer-pool release regression.

### Original foundation results (`3e822453`)

| Validation | Result and scope |
| --- | --- |
| New K4 C++ UT | **14 cases passed in 2 targets**, on the local Host and hwServer |
| Targeted C++ regression | **9/9 CTest targets passed** locally and on hwServer, including the two K4 targets plus inherited K1/2a contract, loader, entry, state, wire, and both architecture-specific TMR maker targets |
| ASan/UBSan | **2/2 K4 targets passed locally**; not counted as a remote sanitizer run |
| Python sim ABI | **13 passed, 4 onboard parameterizations deselected**, locally and on hwServer; deselected cases are not passes |
| Program sim smoke | TMR/HBG vector on both `a2a3sim` and `a5sim`: **4 passed on hwServer** |
| Native CPU snapshot probe | A2/A3 hardware, CANN 9.0.0, exclusive device 3: **24 gated packets passed**, process exit `0` |
| Build and lint | Isolated rebuilds with explicit ccache and four-way parallelism; all applicable incremental pre-commit hooks passed for the committed files |

The hwServer run used a fixed archive of the pushed commit in a new isolated directory. Archive hashes matched; post-test comparison found no source-content differences. Python/native imports were verified against this snapshot. Existing Torch dependencies were reused read-only; no Torch installation or shared-environment modification was performed.

### Combined K2/K4 results (2026-09-10)

| Validation | Result and scope |
| --- | --- |
| Targeted C++ regression | **11/11 targets passed**, locally and on hwServer, including K1/2a, K2 persistent args, K4 validation/codec and both TMR makers |
| ASan/UBSan | **3 targeted admission/K4 targets passed locally** |
| Python sim ABI and prepare admission | **25 passed, 36 deselected**, locally and on hwServer |
| Program sim smoke | Both architectures, TMR/HBG vector: **4 passed on hwServer** |
| K2 onboard lifecycle | A2/A3 TMR borrowed-device init/close and prepare/reuse/close: **2 passed**, exclusive device 3 |
| Runtime build | **All eight hwServer components rebuilt**; both onboard TMR libraries link the runner adapter |
| Subsequent shared-header lint fix | Buffer-pool/profiler tests passed locally before and after the fix; both targets also passed ASan/UBSan |
| Incremental pre-commit | All applicable checks passed for the complete modified set, including the new adapter `.cpp`; no bypass or suppression |

The remote combined source archive SHA-256 is `e9b0fe33f0ae5fc4bef96124384ffdb6ca3959289f298056d790d9333812c1b2`. That archive predates the final buffer-pool lint-only fix, which has separate local rebuild/test/sanitizer evidence. The original 24-packet probe was not rerun on this combined snapshot. K2 lifecycle success is not K4 invocation execution or capture/replay evidence. No Torch installation was performed.

The old #2180 network1 failure at `3e822453` was investigated separately: the CI daemon could not bind its occupied port, and tests reached a different daemon. This was not a K4 regression; no CI/daemon changes or rerun were made for that incident. The combined branch's future CI result is not inferred from that diagnosis.

The native probe is **eager CPU transport evidence**, not formal TMR executor, A5 hardware, or ACLGraph capture/replay evidence. Test-only callable/binding metadata does not establish production provider correctness. Program smoke does not establish kernel-mode execution support. Local and remote runs of the same tests are not summed as unique cases.

Main reproduction commands, after isolated installation and building the targets according to the repository testing guide:

```bash
ctest --test-dir tests/ut/cpp/build --output-on-failure \
  -R '^(test_kernel_invocation_validation|test_tmr_kernel_invocation|test_pipeline_contract|test_pipeline_contract_loader|test_kernel_entry_validation|test_kernel_execution_state|test_kernel_persistent_args|test_hbg_kernel_persistent_args|test_kernel_invocation_header|test_trb_runtime_temp_buffer|test_a5_trb_runtime_temp_buffer)$'

python -m pytest tests/ut/py/test_host_runtime_abi.py tests/ut/py/test_kernel_mode_c_api.py \
  -k 'not onboard' -v --forked

for arch in a2a3 a5; do
  python -m pytest "examples/$arch/tensormap_and_ringbuffer/vector_example" \
    --platform "${arch}sim" --manual include --pto-session-timeout 600 -v --forked
  python -m pytest "tests/st/$arch/host_build_graph/vector_example" \
    --platform "${arch}sim" --manual include --pto-session-timeout 600 -v --forked
done

# Build the probe's host/device CMake projects with the CANN toolchain.
# Run under an exclusive device lock; TASK_DEVICE is assigned by the queue.
<host-build>/snapshot_probe "$TASK_DEVICE" \
  <a2a3-dispatcher>/libsimpler_aicpu_dispatcher.so \
  <device-build>/libsnapshot_probe_device.so
```

**Not validated or not implemented:** Full UT/ST suites, A5 hardware execution, empty-Tensor program execution against the baseline, production metadata/binding providers and device consumption, capture/replay, alternating captured graphs, asynchronous cancellation, and close/resource-reclamation races.

## Commits

The branch retains the original foundation and adds the combined integration on top of #2177:

1. `3e822453` — `Add: TMR kernel invocation snapshots and transport adapter`: Shared validation, TMR wire/codec, transactional Host templates, native adapter, argument conversion, unit tests, and the standalone transport probe.
2. `b0943525` — `Add: integrate TMR snapshots with kernel context resources`: K2 `48b120b15` resource lifecycle, 2a admission-preserving init integration, shared kernel prepare validation, runner transport adapter, explicit TMR consumption, regression tests and shared-header lint fixes. K2 human authorship is preserved in the commit trailer.

**Prerequisite order: #2064 → {#2177 (2a), #2176 (K2)} → this K4 PR.** This is a dependency set, not a requirement that 2a and K2 merge in a specific order relative to each other. Later execution integration must consume the remaining resource/provider/binder modules; this PR neither replaces them nor declares their work complete.

## 中文总结

- **合并依赖：** 基于 #2177 的 `2153406a`，保留 `3e822453`，叠加 K2 `48b120b15` 并完成组合接线；等待 #2064、#2177、#2176 合并后对齐复验，保持 Draft。
- **交付内容：** 公共 K9/callable 校验、TMR 定长快照、Host 模板缓存、真实 prepare 准入、runner CPU adapter 和显式消费接口；不是完整 kernel executor，公开 launch 未接通，supported 仍为 `0`。onboard TMR init/prepare/close 可测试，不再笼统描述所有 init 都 unsupported。
- **ABI 与解耦：** prepare 对齐 K2 四参数 ABI；共用外层准入，不统一 HBG/TMR payload，只消费可信只读 view，不复制 K2/K3/K5/K10 owner。K4 不改 program 参数生命周期，但组合 diff 确实包含 K2 共享平台改动及公共 lint 修复。
- **生命周期：** 每次独立 packet；owner 保护从获取视图到完整 enqueue/缓存提交，并与 close 协调。callable 驻留 generation 与 context generation 分开，版本检查不能替代保活。
- **组合验证：** 本地/远端 11 组 C++ target、25 项 sim ABI/准入通过；本地 3 组准入/K4 sanitizer 通过；远端四项 program smoke、两项 A2/A3 K2 生命周期通过。后续 buffer-pool lint 修复另有本地两组普通/sanitizer 及完整增量 pre-commit 证据。原版 24 包 probe 未在组合版本重跑，不混算。未安装 Torch。
- **未完成范围：** 真实 provider/设备消费、ACLGraph capture/replay、两图交替、异步取消及 close/graph 生命周期仍需后续集成，不以 UT 或测试 fixture 代替。
