### PR TITLE
Add: [Binder] standalone three-stream kernel submission

### DIFF
--- a/docs/kernel-launch-binder.md
+++ b/docs/kernel-launch-binder.md
@@ -1,0 +1,101 @@
+# Kernel launch submission module
+
+This module implements the three-stream submission and failure-compensation part
+of the [v9 design](https://icc.gt.tc/vllm-pto?i=1#v9-design). It compiles on main
+without K1 or HBG headers. All interfaces are internal C++ types in
+`simpler::kernel_launch`; no public C ABI or runtime packet layout is introduced.
+
+## Owner contract
+
+`launch_bound_kernel(binding, caller, gate, ops)` consumes a readable Host packet,
+trusted placeholder descriptors and prepared stream/event handles. The native
+variant also consumes registered function handles, prepared AICore/HostArgs
+buffers and clear/cancel regions. Nothing is allocated or registered in launch.
+
+`KernelLaunchGateOps::acquire` obtains an exclusive submission lease and validates
+context phase, current device, callable registration/generation, frozen capacity,
+packet ABI and runtime-specific bindings. It returns a `KernelLaunchAdmission`
+snapshot with the two internal streams, five events, previous caller identity
+and whether preparation is pending. Acquisition failure retains no lease and
+must leave persistent context state unchanged.
+
+Every successful acquisition is paired with exactly one `finish(result)`:
+
+| Result | Owner action before releasing the lease |
+| ------ | --------------------------------------- |
+| Success | Store caller identity and consume the pending preparation dependency |
+| Rejection before enqueue | Preserve phase, previous caller and preparation state |
+| Enqueue failure | Poison context; retain submission and compensation errors separately |
+
+The owner serializes preparation, close and submission through this lease. It
+must not call binder recursively. Neither owner callback may allocate, enqueue,
+synchronize or query capture. The native adapter performs its argument checks
+inside the lease and releases it even if native preflight rejects the packet.
+Native tail queries use `aclrtQueryEventStatus`; the injected query callback is
+used only by the generic entry.
+
+Preparation records `PrepareTail` after initialization and slot registration;
+ready publication means submitted, not completed. Events must be created outside
+launch with `ACL_EVENT_SYNC`; AICPU is a dedicated **non-hidden** stream and AICore
+is **hidden**. Caller is borrowed, and all three handles must differ. The binder
+validates distinct/non-null handles but cannot establish their creation flags.
+
+The owner retains device resources and function/stream/event handles until all
+executions and captured graphs end and external quiescence is established.
+HostArgs is writable exclusive staging. CANN copies it into task-owned storage
+before returning; the adapter restores zero placeholders for reuse. Runtime
+validation must reject placeholders that overlap its metadata, because this
+module only checks descriptor agreement, zero addresses and buffer bounds.
+
+## Submission order
+
+A caller change queries the previous SerialTail before any enqueue. Not-ready or
+query failure rejects without poisoning. Same-caller submission neither queries
+nor waits on old tail; caller FIFO and the branch joins provide serialization.
+Not-ready/distinct-handle rejection uses the existing
+`PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE`; a future public owner maps its API status.
+
+| Stream | Operations in Host submission order |
+| ------ | ----------------------------------- |
+| caller | Optionally wait PrepareTail, asynchronously clear prepared launch/handshake/report regions, record Start |
+| hidden AICore | Wait Start, launch AICore, record AicoreDone |
+| non-hidden AICPU | Wait Start, launch with HostArgs, record AicpuDone |
+| caller | Wait AicpuDone, wait AicoreDone, record SerialTail |
+
+AICore-first avoids a waiting AICPU scheduler obstructing its AICore SQE and
+permits pre-AICPU cancellation after checking the core branch submissions.
+Both branches remain gated by Start. Host success means submission only.
+
+## Failure behavior
+
+Every failure after entry into the enqueue sequence tells the owner to poison.
+Before successful AICore launch, stop. Failure recording AicoreDone cancels the
+waiting core, retries the record once, then joins and records SerialTail.
+AICPU Start-wait failure cancels and joins core. AICPU launch failure additionally
+records/joins the already-forked AICPU wait branch. Cancellation is one all-ones
+async fill of the prepared 32-bit cancel words, publishing `UINT32_MAX`.
+After successful AICPU launch, stop on errors without Host cancel.
+
+Compensation stops on its first error. `cleanup_status` never replaces the
+original `status`, and `tail_recorded` identifies whether a tail was established.
+Failed compensation can leave no provable join and an uncancelled waiter; this
+is a terminal execution failure requiring external quiescence/reset ownership,
+not permission for binder to synchronize, reset or reuse the context.
+
+## Integration and tests
+
+The module does not provide K1 context/resource ownership, callable residency,
+HBG packet/slot validation, or a public launch entry. Those owner adapters remain
+with the separate integration work and must be connected after prerequisites
+land. The context adapter must apply the finish table above, reject prepare and
+launch after poison, and retain resources through graph destruction. There is
+no duplicate context phase machine in this module.
+
+Fake-owner tests verify acquire/finish pairing, same/cross-caller behavior,
+concurrent submission rejection and all enqueue/compensation failure positions.
+The SDK-enabled native unit target uses real CANN declarations and fake symbols.
+Source guards reject forbidden ACL/RTS operations and dependency guards prevent
+importing the unmerged K1/HBG interfaces. These tests establish Host protocol
+behavior, not real capture/replay, event flags, precision or performance. The
+native owner, event Probe B and mixed-operator device tests remain prerequisites
+for that claim. Program-mode execution is unchanged.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,7 @@ nav:
       - TPUSH/TPOP: tpush-tpop.md
   - Launch and linking:
       - AICPU Kernel Launch: aicpu-kernel-launch-mechanisms.md
+      - Kernel Launch Binder: kernel-launch-binder.md
       - Dynamic Linking: dynamic-linking.md
       - Callable Identity: callable-identity-registration.md
       - Callable IPC Registration: callable-ipc-dynamic-register.md

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -78,6 +78,8 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_launch_binder.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_launch_native.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -83,6 +83,8 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_launch_binder.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_launch_native.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"

--- a/src/common/platform/include/host/kernel_launch_binder.h
+++ b/src/common/platform/include/host/kernel_launch_binder.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "worker/runtime_c_api.h"
+
+namespace simpler::kernel_launch {
+
+struct KernelInvocationPlaceholder {
+    uint32_t address_offset;
+    uint32_t data_offset;
+};
+
+// Runtime wire validation belongs to the owner. Packet and placeholder storage
+// remain exclusively leased until finish; task-owned copies outlive submission.
+struct KernelInvocationBinding {
+    const uint8_t *packet{nullptr};
+    size_t packet_bytes{0};
+    const KernelInvocationPlaceholder *placeholders{nullptr};
+    size_t placeholder_count{0};
+};
+
+struct KernelLaunchOps {
+    void *context{nullptr};
+    int (*wait_event)(void *, void *stream, void *event) noexcept {nullptr};
+    int (*memset_handshake)(void *, void *stream) noexcept {nullptr};
+    int (*record_event)(void *, void *event, void *stream) noexcept {nullptr};
+    int (*launch_aicpu)(void *, void *stream) noexcept {nullptr};
+    int (*launch_aicore)(void *, void *stream) noexcept {nullptr};
+    int (*cancel_waiting_aicore)(void *, void *stream) noexcept {nullptr};
+    bool valid() const {
+        return wait_event && memset_handshake && record_event && launch_aicpu && launch_aicore && cancel_waiting_aicore;
+    }
+};
+
+struct KernelLaunchHandles {
+    void *caller{nullptr};
+    void *aicpu{nullptr};
+    void *aicore{nullptr};
+    void *prepare_tail{nullptr};
+    void *start{nullptr};
+    void *aicore_done{nullptr};
+    void *aicpu_done{nullptr};
+    void *serial_tail{nullptr};
+    bool consume_prepare_tail{false};
+
+    bool valid() const {
+        if (!caller || !aicpu || !aicore || caller == aicpu || caller == aicore || aicpu == aicore) return false;
+        const void *events[] = {prepare_tail, start, aicore_done, aicpu_done, serial_tail};
+        for (size_t i = 0; i < 5; ++i) {
+            if (!events[i]) return false;
+            for (size_t j = 0; j < i; ++j)
+                if (events[i] == events[j]) return false;
+        }
+        return true;
+    }
+};
+
+enum class KernelLaunchStep : uint8_t {
+    Validate,
+    QueryTail,
+    PrepareWait,
+    Clear,
+    Start,
+    AicoreWait,
+    AicoreLaunch,
+    AicoreDone,
+    AicpuWait,
+    AicpuLaunch,
+    AicpuDone,
+    JoinAicpu,
+    JoinAicore,
+    SerialTail
+};
+
+struct KernelLaunchResult {
+    int status{0};
+    int cleanup_status{0};
+    KernelLaunchStep failed_step{KernelLaunchStep::Validate};
+    bool enqueue_started{false};
+    bool tail_recorded{false};
+};
+
+struct KernelLaunchAdmission {
+    KernelLaunchHandles handles;
+    uintptr_t previous_caller_identity{0};
+};
+
+// acquire is read-only apart from acquiring an exclusive owner submission lease:
+// it checks context phase, device/registration affinity, frozen capacity, packet
+// ABI and runtime bindings, and returns handles plus prior submission state.
+// Failure retains no lease. Success is paired with exactly one finish call.
+// finish commits caller/tail/prepare state on success, poisons on enqueue failure,
+// preserves clean rejections, and releases the lease. Neither callback enqueues,
+// allocates, synchronizes, or queries capture. The owner also serializes close.
+struct KernelLaunchGateOps {
+    void *context{nullptr};
+    int (*acquire)(void *, const KernelInvocationBinding &, void *caller, KernelLaunchAdmission *) noexcept {nullptr};
+    void (*finish)(void *, const KernelLaunchResult &) noexcept {nullptr};
+    int (*query_tail)(void *, void *event, bool *complete) noexcept {nullptr};
+    bool valid() const { return acquire && finish && query_tail; }
+};
+
+KernelLaunchResult launch_bound_kernel(
+    const KernelInvocationBinding &binding, void *caller_stream, const KernelLaunchGateOps &gate,
+    const KernelLaunchOps &ops
+);
+
+}  // namespace simpler::kernel_launch

--- a/src/common/platform/onboard/host/kernel_launch_binder.cpp
+++ b/src/common/platform/onboard/host/kernel_launch_binder.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "host/kernel_launch_binder.h"
+
+#include "kernel_launch_sequence.h"
+
+namespace simpler::kernel_launch {
+
+KernelLaunchResult launch_bound_kernel(
+    const KernelInvocationBinding &binding, void *caller_stream, const KernelLaunchGateOps &gate,
+    const KernelLaunchOps &ops
+) {
+    KernelLaunchResult result;
+    result.status = PTO_RUNTIME_ERR_INTERNAL;
+    if (!gate.valid() || !ops.valid() || !caller_stream || !binding.packet || !binding.packet_bytes) return result;
+    KernelLaunchAdmission admission;
+    result.status = gate.acquire(gate.context, binding, caller_stream, &admission);
+    if (result.status != 0) return result;
+    auto finish = [&](KernelLaunchResult out) {
+        gate.finish(gate.context, out);
+        return out;
+    };
+    // The caller argument is authoritative; the owner cannot replace it.
+    admission.handles.caller = caller_stream;
+    if (!admission.handles.valid()) {
+        result.status = PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+        return finish(result);
+    }
+    if (admission.previous_caller_identity != 0 &&
+        admission.previous_caller_identity != reinterpret_cast<uintptr_t>(caller_stream)) {
+        bool complete = false;
+        result.failed_step = KernelLaunchStep::QueryTail;
+        result.status = gate.query_tail(gate.context, admission.handles.serial_tail, &complete);
+        if (result.status != 0) return finish(result);
+        if (!complete) {
+            result.status = PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+            return finish(result);
+        }
+    }
+    return finish(enqueue_kernel_launch_sequence(ops, admission.handles));
+}
+
+}  // namespace simpler::kernel_launch

--- a/src/common/platform/onboard/host/kernel_launch_native.cpp
+++ b/src/common/platform/onboard/host/kernel_launch_native.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "kernel_launch_native.h"
+
+#include <cstring>
+
+namespace simpler::kernel_launch {
+
+namespace {
+struct NativeCall {
+    const KernelNativeInvocation &native;
+    const KernelLaunchGateOps &owner;
+};
+const KernelNativeInvocation &get(void *context) noexcept { return static_cast<NativeCall *>(context)->native; }
+
+bool span(const void *ptr, size_t bytes) noexcept {
+    return ptr && bytes && bytes <= UINTPTR_MAX - reinterpret_cast<uintptr_t>(ptr);
+}
+int validate(void *context, const KernelInvocationBinding &binding) noexcept {
+    const auto &n = get(context);
+    if (!n.aicore || !n.aicpu || !n.aicore_blocks || !n.aicpu_blocks || !span(n.aicore_args, n.aicore_args_bytes) ||
+        n.aicpu_args != binding.packet || n.aicpu_args_bytes != binding.packet_bytes || !n.clear_regions ||
+        !n.clear_region_count || !span(n.cancel.address, n.cancel.bytes) || n.cancel.bytes % sizeof(uint32_t) != 0 ||
+        reinterpret_cast<uintptr_t>(n.cancel.address) % alignof(uint32_t) != 0 ||
+        n.placeholder_count != binding.placeholder_count ||
+        (n.placeholder_count && (!n.placeholders || !binding.placeholders)) ||
+        n.placeholder_count > n.aicpu_args_bytes / sizeof(uint64_t))
+        return PTO_RUNTIME_ERR_INTERNAL;
+    bool cancel_cleared = false;
+    for (size_t i = 0; i < n.clear_region_count; ++i) {
+        const auto &r = n.clear_regions[i];
+        if (!span(r.address, r.bytes)) return PTO_RUNTIME_ERR_INTERNAL;
+        const auto base = reinterpret_cast<uintptr_t>(r.address);
+        const auto cancel = reinterpret_cast<uintptr_t>(n.cancel.address);
+        cancel_cleared |= cancel >= base && cancel - base <= r.bytes && n.cancel.bytes <= r.bytes - (cancel - base);
+    }
+    if (!cancel_cleared) return PTO_RUNTIME_ERR_INTERNAL;
+    for (size_t i = 0; i < n.placeholder_count; ++i) {
+        const auto &p = n.placeholders[i];
+        if (p.addrOffset != binding.placeholders[i].address_offset ||
+            p.dataOffset != binding.placeholders[i].data_offset || p.addrOffset > n.aicpu_args_bytes ||
+            sizeof(uint64_t) > n.aicpu_args_bytes - p.addrOffset || p.dataOffset >= n.aicpu_args_bytes)
+            return PTO_RUNTIME_ERR_INTERNAL;
+        uint64_t address = 0;
+        std::memcpy(&address, static_cast<const uint8_t *>(n.aicpu_args) + p.addrOffset, sizeof(address));
+        if (address != 0) return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    return 0;
+}
+int acquire(void *context, const KernelInvocationBinding &binding, void *caller, KernelLaunchAdmission *out) noexcept {
+    const auto &owner = static_cast<NativeCall *>(context)->owner;
+    const int admitted = owner.acquire(owner.context, binding, caller, out);
+    if (admitted != 0) return admitted;
+    const int rc = validate(context, binding);
+    if (rc != 0) {
+        KernelLaunchResult rejected;
+        rejected.status = rc;
+        owner.finish(owner.context, rejected);
+    }
+    return rc;
+}
+void finish(void *context, const KernelLaunchResult &result) noexcept {
+    const auto &owner = static_cast<NativeCall *>(context)->owner;
+    owner.finish(owner.context, result);
+}
+int query(void *, void *event, bool *complete) noexcept {
+    aclrtEventRecordedStatus status{};
+    const int rc = aclrtQueryEventStatus(event, &status);
+    *complete = rc == 0 && status == ACL_EVENT_RECORDED_STATUS_COMPLETE;
+    return rc;
+}
+int wait(void *, void *stream, void *event) noexcept { return aclrtStreamWaitEvent(stream, event); }
+int record(void *, void *event, void *stream) noexcept { return aclrtRecordEvent(event, stream); }
+int clear(void *context, void *stream) noexcept {
+    const auto &n = get(context);
+    for (size_t i = 0; i < n.clear_region_count; ++i) {
+        const auto &r = n.clear_regions[i];
+        const int rc = aclrtMemsetAsync(r.address, r.bytes, 0, r.bytes, stream);
+        if (rc != 0) return rc;
+    }
+    return 0;
+}
+int cancel(void *context, void *stream) noexcept {
+    const auto &r = get(context).cancel;
+    // Every pre-window cancel word remains UINT32_MAX until the AICore tail.
+    return aclrtMemsetAsync(r.address, r.bytes, 0xff, r.bytes, stream);
+}
+int core(void *context, void *stream) noexcept {
+    const auto &n = get(context);
+    return aclrtLaunchKernel(n.aicore, n.aicore_blocks, n.aicore_args, n.aicore_args_bytes, stream);
+}
+int cpu(void *context, void *stream) noexcept {
+    const auto &n = get(context);
+    const int rc = aclrtLaunchKernelWithHostArgs(
+        n.aicpu, n.aicpu_blocks, stream, n.aicpu_config, n.aicpu_args, n.aicpu_args_bytes, n.placeholders,
+        n.placeholder_count
+    );
+    // HostArgs has copied task-owned storage before returning. Writable staging
+    // retains zero placeholders for reuse; the immutable template is untouched.
+    for (size_t i = 0; i < n.placeholder_count; ++i) {
+        const uint64_t zero = 0;
+        std::memcpy(static_cast<uint8_t *>(n.aicpu_args) + n.placeholders[i].addrOffset, &zero, sizeof(zero));
+    }
+    return rc;
+}
+}  // namespace
+
+KernelLaunchResult launch_bound_kernel_native(
+    const KernelInvocationBinding &binding, const KernelNativeInvocation &native, void *caller_stream,
+    const KernelLaunchGateOps &owner
+) {
+    if (!owner.acquire || !owner.finish) {
+        KernelLaunchResult rejected;
+        rejected.status = PTO_RUNTIME_ERR_INTERNAL;
+        return rejected;
+    }
+    NativeCall call{native, owner};
+    const KernelLaunchGateOps gate{&call, acquire, finish, query};
+    const KernelLaunchOps ops{&call, wait, clear, record, cpu, core, cancel};
+    return launch_bound_kernel(binding, caller_stream, gate, ops);
+}
+
+}  // namespace simpler::kernel_launch

--- a/src/common/platform/onboard/host/kernel_launch_native.h
+++ b/src/common/platform/onboard/host/kernel_launch_native.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include <acl/acl_rt.h>
+
+#include "host/kernel_launch_binder.h"
+
+namespace simpler::kernel_launch {
+
+struct KernelClearRegion {
+    void *address{nullptr};
+    size_t bytes{0};
+};
+
+// Prepared, context-pinned platform arguments. This is never decoded from an
+// invocation packet. Owners retain handles, buffers and device execution state
+// through every captured graph and external quiescence, not just this call.
+struct KernelNativeInvocation {
+    aclrtFuncHandle aicore{nullptr};
+    aclrtFuncHandle aicpu{nullptr};
+    uint32_t aicore_blocks{0};
+    uint32_t aicpu_blocks{0};
+    const void *aicore_args{nullptr};
+    size_t aicore_args_bytes{0};
+    void *aicpu_args{nullptr};
+    size_t aicpu_args_bytes{0};
+    aclrtPlaceHolderInfo *placeholders{nullptr};
+    size_t placeholder_count{0};
+    aclrtLaunchKernelCfg *aicpu_config{nullptr};
+    const KernelClearRegion *clear_regions{nullptr};
+    size_t clear_region_count{0};
+    KernelClearRegion cancel;
+};
+
+KernelLaunchResult launch_bound_kernel_native(
+    const KernelInvocationBinding &binding, const KernelNativeInvocation &native, void *caller_stream,
+    const KernelLaunchGateOps &owner
+);
+
+}  // namespace simpler::kernel_launch

--- a/src/common/platform/onboard/host/kernel_launch_sequence.h
+++ b/src/common/platform/onboard/host/kernel_launch_sequence.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#pragma once
+
+#include "host/kernel_launch_binder.h"
+
+namespace simpler::kernel_launch {
+
+inline KernelLaunchResult
+enqueue_kernel_launch_sequence(const KernelLaunchOps &ops, const KernelLaunchHandles &h) noexcept {
+    KernelLaunchResult result;
+    if (!ops.valid() || !h.valid()) {
+        result.status = PTO_RUNTIME_ERR_INTERNAL;
+        return result;
+    }
+    auto step = [&](KernelLaunchStep at, int rc) {
+        if (rc == 0) return true;
+        result.status = rc;
+        result.failed_step = at;
+        return false;
+    };
+    // Compensation never replaces the original error. A failed cancel or retry
+    // leaves no provable caller join; external quiescence is then mandatory.
+    auto compensate = [&](bool retry_core_done, bool join_cpu_wait) {
+        auto cleanup = [&](int rc) {
+            if (rc == 0) return true;
+            result.cleanup_status = rc;
+            return false;
+        };
+        if (!cleanup(ops.cancel_waiting_aicore(ops.context, h.caller))) return;
+        if (retry_core_done && !cleanup(ops.record_event(ops.context, h.aicore_done, h.aicore))) return;
+        if (join_cpu_wait) {
+            if (!cleanup(ops.record_event(ops.context, h.aicpu_done, h.aicpu))) return;
+            if (!cleanup(ops.wait_event(ops.context, h.caller, h.aicpu_done))) return;
+        }
+        if (!cleanup(ops.wait_event(ops.context, h.caller, h.aicore_done))) return;
+        if (!cleanup(ops.record_event(ops.context, h.serial_tail, h.caller))) return;
+        result.tail_recorded = true;
+    };
+    result.enqueue_started = true;
+    if (h.consume_prepare_tail &&
+        !step(KernelLaunchStep::PrepareWait, ops.wait_event(ops.context, h.caller, h.prepare_tail)))
+        return result;
+    if (!step(KernelLaunchStep::Clear, ops.memset_handshake(ops.context, h.caller))) return result;
+    if (!step(KernelLaunchStep::Start, ops.record_event(ops.context, h.start, h.caller))) return result;
+
+    // AICore-first avoids the scheduler cycle when an AICPU startup waiter
+    // blocks a later AICore SQE. It also checks the hidden branch's submissions
+    // before admitting AICPU, allowing cancel while no AICPU writes handshake.
+    // Both device branches remain gated by the caller's Start event.
+    if (!step(KernelLaunchStep::AicoreWait, ops.wait_event(ops.context, h.aicore, h.start))) return result;
+    if (!step(KernelLaunchStep::AicoreLaunch, ops.launch_aicore(ops.context, h.aicore))) return result;
+    if (!step(KernelLaunchStep::AicoreDone, ops.record_event(ops.context, h.aicore_done, h.aicore))) {
+        compensate(true, false);
+        return result;
+    }
+    if (!step(KernelLaunchStep::AicpuWait, ops.wait_event(ops.context, h.aicpu, h.start))) {
+        compensate(false, false);
+        return result;
+    }
+    if (!step(KernelLaunchStep::AicpuLaunch, ops.launch_aicpu(ops.context, h.aicpu))) {
+        compensate(false, true);
+        return result;
+    }
+    // Once AICPU is resident, Host cancel could overwrite its live handshake.
+    // Completion/join errors stop enqueue and poison; there is no Host reset.
+    if (!step(KernelLaunchStep::AicpuDone, ops.record_event(ops.context, h.aicpu_done, h.aicpu))) return result;
+    if (!step(KernelLaunchStep::JoinAicpu, ops.wait_event(ops.context, h.caller, h.aicpu_done))) return result;
+    if (!step(KernelLaunchStep::JoinAicore, ops.wait_event(ops.context, h.caller, h.aicore_done))) return result;
+    if (!step(KernelLaunchStep::SerialTail, ops.record_event(ops.context, h.serial_tail, h.caller))) return result;
+    result.tail_recorded = true;
+    return result;
+}
+
+}  // namespace simpler::kernel_launch

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -500,6 +500,19 @@ set_tests_properties(test_native_run_acceptance PROPERTIES LABELS "no_hardware")
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)
 
+add_executable(test_kernel_launch_binder
+    common/test_kernel_launch_binder.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host/kernel_launch_binder.cpp
+)
+target_include_directories(test_kernel_launch_binder PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${GTEST_INCLUDE_DIRS}
+)
+target_link_libraries(test_kernel_launch_binder PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_launch_binder COMMAND test_kernel_launch_binder)
+set_tests_properties(test_kernel_launch_binder PROPERTIES LABELS "no_hardware")
+
 # Runtime extension payloads are per-run state even though the collector's
 # shared-memory resources remain resident across runs.
 add_executable(test_chip_swimlane_collector
@@ -1472,6 +1485,23 @@ if(SIMPLER_ENABLE_HARDWARE_TESTS)
             ${ASCEND_HOME_PATH}/runtime/lib64
             ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/lib64
         NO_DEFAULT_PATH REQUIRED)
+
+    # SDK declarations with fake ACL symbols: execution needs no device.
+    add_executable(test_kernel_launch_native
+        common/test_kernel_launch_native.cpp
+        ${PROJECT_ROOT}/src/common/platform/onboard/host/kernel_launch_binder.cpp
+        ${PROJECT_ROOT}/src/common/platform/onboard/host/kernel_launch_native.cpp
+    )
+    target_include_directories(test_kernel_launch_native PRIVATE
+        ${PROJECT_ROOT}/src/common
+        ${PROJECT_ROOT}/src/common/platform/include
+        ${PROJECT_ROOT}/src/common/platform/onboard/host
+        ${ASCEND_HOME_PATH}/include
+        ${GTEST_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_kernel_launch_native PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+    add_test(NAME test_kernel_launch_native COMMAND test_kernel_launch_native)
+    set_tests_properties(test_kernel_launch_native PROPERTIES LABELS "no_hardware")
 
     # Black-box lifecycle UT for the comm_* C API on Path D. See the file
     # header for the contract it pins down.

--- a/tests/ut/cpp/common/kernel_binder_test_support.h
+++ b/tests/ut/cpp/common/kernel_binder_test_support.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <array>
+#include <future>
+#include <mutex>
+#include <vector>
+
+#include "host/kernel_launch_binder.h"
+
+namespace kernel_binder_test {
+using namespace simpler::kernel_launch;
+using Step = KernelLaunchStep;
+constexpr Step Cancel = static_cast<Step>(100);
+inline void *ptr(uintptr_t n) { return reinterpret_cast<void *>(n); }
+
+struct Fake {
+    std::mutex mutex;
+    bool ready{true}, frozen{true}, poisoned{false}, complete{true}, pending_prepare{true};
+    uintptr_t previous_caller{0};
+    void *candidate_caller{nullptr};
+    int calls{0}, fail_at{0}, second_fail_at{0}, query_error{0}, validation_error{0};
+    int queries{0}, acquisitions{0}, finishes{0}, runtime_error{0}, cleanup_error{0};
+    std::vector<Step> trace;
+    std::promise<void> *entered{nullptr};
+    std::shared_future<void> release;
+    KernelLaunchHandles handles{nullptr, ptr(1), ptr(2), ptr(3), ptr(4), ptr(5), ptr(6), ptr(7), true};
+    Fake() { trace.reserve(128); }
+    int append(Step step) noexcept {
+        trace.push_back(step);
+        ++calls;
+        return calls == fail_at || calls == second_fail_at ? -1700 - calls : 0;
+    }
+    KernelLaunchGateOps gate() {
+        return {
+            this,
+            [](void *p, const KernelInvocationBinding &, void *caller, KernelLaunchAdmission *out) noexcept -> int {
+                auto &f = *static_cast<Fake *>(p);
+                if (!f.mutex.try_lock()) return PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+                if (!f.ready || !f.frozen || f.poisoned || f.validation_error) {
+                    f.mutex.unlock();
+                    return f.validation_error ? f.validation_error : PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE;
+                }
+                ++f.acquisitions;
+                f.candidate_caller = caller;
+                *out = {f.handles, f.previous_caller};
+                out->handles.consume_prepare_tail = f.pending_prepare;
+                if (f.entered) {
+                    f.entered->set_value();
+                    f.release.wait();
+                }
+                return 0;
+            },
+            [](void *p, const KernelLaunchResult &result) noexcept {
+                auto &f = *static_cast<Fake *>(p);
+                ++f.finishes;
+                if (result.status == 0) {
+                    f.previous_caller = reinterpret_cast<uintptr_t>(f.candidate_caller);
+                    f.pending_prepare = false;
+                } else if (result.enqueue_started) {
+                    f.poisoned = true;
+                    f.runtime_error = result.status;
+                    f.cleanup_error = result.cleanup_status;
+                }
+                f.mutex.unlock();
+            },
+            [](void *p, void *, bool *complete) noexcept {
+                auto &f = *static_cast<Fake *>(p);
+                ++f.queries;
+                *complete = f.complete;
+                return f.query_error;
+            }
+        };
+    }
+    KernelLaunchOps ops() {
+        return {
+            this,
+            [](void *p, void *stream, void *event) noexcept {
+                auto &f = *static_cast<Fake *>(p);
+                const auto step = event == ptr(3) ? Step::PrepareWait :
+                                  event == ptr(4) ? (stream == ptr(2) ? Step::AicoreWait : Step::AicpuWait) :
+                                  event == ptr(6) ? Step::JoinAicpu :
+                                                    Step::JoinAicore;
+                return f.append(step);
+            },
+            [](void *p, void *) noexcept {
+                return static_cast<Fake *>(p)->append(Step::Clear);
+            },
+            [](void *p, void *event, void *) noexcept {
+                return static_cast<Fake *>(p)->append(
+                    event == ptr(4) ? Step::Start :
+                    event == ptr(5) ? Step::AicoreDone :
+                    event == ptr(6) ? Step::AicpuDone :
+                                      Step::SerialTail
+                );
+            },
+            [](void *p, void *) noexcept {
+                return static_cast<Fake *>(p)->append(Step::AicpuLaunch);
+            },
+            [](void *p, void *) noexcept {
+                return static_cast<Fake *>(p)->append(Step::AicoreLaunch);
+            },
+            [](void *p, void *) noexcept {
+                return static_cast<Fake *>(p)->append(Cancel);
+            }
+        };
+    }
+    void clear_trace() {
+        trace.clear();
+        calls = 0;
+    }
+};
+
+const std::vector<Step> success{Step::PrepareWait,  Step::Clear,      Step::Start,      Step::AicoreWait,
+                                Step::AicoreLaunch, Step::AicoreDone, Step::AicpuWait,  Step::AicpuLaunch,
+                                Step::AicpuDone,    Step::JoinAicpu,  Step::JoinAicore, Step::SerialTail};
+struct Fixture {
+    Fake fake;
+    std::array<uint64_t, 10> packet{};
+    KernelInvocationBinding binding;
+    void initialize() { binding = {reinterpret_cast<const uint8_t *>(packet.data()), sizeof(packet)}; }
+    KernelLaunchResult launch(void *caller = ptr(100)) {
+        return launch_bound_kernel(binding, caller, fake.gate(), fake.ops());
+    }
+};
+}  // namespace kernel_binder_test

--- a/tests/ut/cpp/common/test_kernel_launch_binder.cpp
+++ b/tests/ut/cpp/common/test_kernel_launch_binder.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "kernel_binder_test_support.h"
+
+namespace kernel_binder_test {
+TEST(KernelBinder, ThreeStreamSuccessAndSteadyStateHaveExactTrace) {
+    Fixture f;
+    ASSERT_NO_FATAL_FAILURE(f.initialize());
+    ASSERT_EQ(f.launch().status, 0);
+    EXPECT_EQ(f.fake.trace, success);
+    for (int i = 0; i < 10; ++i) {
+        f.fake.clear_trace();
+        const auto result = f.launch();
+        EXPECT_EQ(result.status, 0);
+        EXPECT_TRUE(result.tail_recorded);
+        EXPECT_EQ(f.fake.trace, (std::vector<Step>(success.begin() + 1, success.end())));
+    }
+    EXPECT_EQ(f.fake.queries, 0);
+    EXPECT_EQ(f.fake.acquisitions, 11);
+    EXPECT_EQ(f.fake.finishes, 11);
+}
+
+TEST(KernelBinder, StreamSwitchQueriesButNeverWaitsOldTail) {
+    Fixture f;
+    ASSERT_NO_FATAL_FAILURE(f.initialize());
+    ASSERT_EQ(f.launch().status, 0);
+    f.fake.clear_trace();
+    f.fake.complete = false;
+    EXPECT_NE(f.launch(ptr(101)).status, 0);
+    EXPECT_TRUE(f.fake.trace.empty());
+    EXPECT_FALSE(f.fake.poisoned);
+    f.fake.complete = true;
+    f.fake.query_error = -22;
+    EXPECT_EQ(f.launch(ptr(101)).status, -22);
+    EXPECT_TRUE(f.fake.trace.empty());
+    f.fake.query_error = 0;
+    EXPECT_EQ(f.launch(ptr(101)).status, 0);
+    EXPECT_EQ(f.fake.queries, 3);
+    EXPECT_EQ(f.fake.trace, (std::vector<Step>(success.begin() + 1, success.end())));
+    f.fake.clear_trace();
+    EXPECT_EQ(f.launch(ptr(101)).status, 0);
+    EXPECT_EQ(f.fake.queries, 3);
+}
+
+TEST(KernelBinder, ReadOnlyRejectionsReleaseOwnerAndPreservePrepareDependency) {
+    for (int fault = 0; fault < 10; ++fault) {
+        SCOPED_TRACE(fault);
+        Fixture f;
+        f.initialize();
+        auto gate = f.fake.gate();
+        auto ops = f.fake.ops();
+        auto binding = f.binding;
+        void *caller = ptr(100);
+        switch (fault) {
+        case 0:
+            f.fake.validation_error = -1234;
+            break;
+        case 1:
+            f.fake.ready = false;
+            break;
+        case 2:
+            f.fake.frozen = false;
+            break;
+        case 3:
+            f.fake.handles.aicpu_done = nullptr;
+            break;
+        case 4:
+            f.fake.handles.aicpu_done = ptr(5);
+            break;
+        case 5:
+            caller = ptr(1);
+            break;
+        case 6:
+            binding.packet_bytes = 0;
+            break;
+        case 7:
+            gate.acquire = nullptr;
+            break;
+        case 8:
+            gate.finish = nullptr;
+            break;
+        case 9:
+            ops.launch_aicore = nullptr;
+            break;
+        }
+        EXPECT_NE(launch_bound_kernel(binding, caller, gate, ops).status, 0);
+        EXPECT_TRUE(f.fake.trace.empty());
+        EXPECT_FALSE(f.fake.poisoned);
+        EXPECT_EQ(f.fake.acquisitions, f.fake.finishes);
+        EXPECT_EQ(f.fake.previous_caller, 0u);
+        EXPECT_TRUE(f.fake.pending_prepare);
+        f.fake.validation_error = 0;
+        f.fake.ready = f.fake.frozen = true;
+        f.fake.handles.aicpu_done = ptr(6);
+        EXPECT_EQ(f.launch().status, 0);
+        EXPECT_EQ(f.fake.trace, success);
+    }
+}
+
+TEST(KernelBinder, EveryEnqueueFailurePoisonsWithExactCompensationTrace) {
+    for (int fail = 1; fail <= static_cast<int>(success.size()); ++fail) {
+        SCOPED_TRACE(fail);
+        Fixture f;
+        ASSERT_NO_FATAL_FAILURE(f.initialize());
+        f.fake.fail_at = fail;
+        const auto result = f.launch();
+        EXPECT_EQ(result.status, -1700 - fail);
+        EXPECT_EQ(result.failed_step, success[fail - 1]);
+        auto expected = std::vector<Step>(success.begin(), success.begin() + fail);
+        if (fail == 6) expected.insert(expected.end(), {Cancel, Step::AicoreDone, Step::JoinAicore, Step::SerialTail});
+        if (fail == 7) expected.insert(expected.end(), {Cancel, Step::JoinAicore, Step::SerialTail});
+        if (fail == 8)
+            expected.insert(
+                expected.end(), {Cancel, Step::AicpuDone, Step::JoinAicpu, Step::JoinAicore, Step::SerialTail}
+            );
+        EXPECT_EQ(f.fake.trace, expected);
+        EXPECT_TRUE(f.fake.poisoned);
+        EXPECT_EQ(f.fake.runtime_error, result.status);
+        f.fake.clear_trace();
+        EXPECT_NE(f.launch().status, 0);
+        EXPECT_TRUE(f.fake.trace.empty());
+        EXPECT_EQ(f.fake.acquisitions, f.fake.finishes);
+    }
+}
+
+TEST(KernelBinder, CompensationFailuresKeepBothErrorsAndStopAtFailure) {
+    for (int primary : {6, 7, 8}) {
+        const int cleanup_steps = primary == 6 ? 4 : primary == 7 ? 3 : 5;
+        for (int step = 1; step <= cleanup_steps; ++step) {
+            SCOPED_TRACE(primary * 100 + step);
+            Fixture f;
+            ASSERT_NO_FATAL_FAILURE(f.initialize());
+            f.fake.fail_at = primary;
+            f.fake.second_fail_at = primary + step;
+            const auto result = f.launch();
+            EXPECT_EQ(result.status, -1700 - primary);
+            EXPECT_EQ(result.cleanup_status, -1700 - primary - step);
+            EXPECT_FALSE(result.tail_recorded);
+            EXPECT_EQ(f.fake.calls, primary + step);
+            EXPECT_EQ(f.fake.runtime_error, result.status);
+            EXPECT_EQ(f.fake.cleanup_error, result.cleanup_status);
+            EXPECT_EQ(f.fake.acquisitions, f.fake.finishes);
+        }
+    }
+}
+
+TEST(KernelBinder, ConcurrentHostLaunchIsRejectedWithoutTouchingArgs) {
+    Fixture f;
+    ASSERT_NO_FATAL_FAILURE(f.initialize());
+    std::promise<void> entered, release;
+    f.fake.entered = &entered;
+    f.fake.release = release.get_future().share();
+    auto first = std::async(std::launch::async, [&] {
+        return f.launch();
+    });
+    entered.get_future().wait();
+    auto second = f.launch();
+    EXPECT_NE(second.status, 0);
+    EXPECT_FALSE(second.enqueue_started);
+    release.set_value();
+    EXPECT_EQ(first.get().status, 0);
+    EXPECT_EQ(f.fake.acquisitions, 1);
+    EXPECT_EQ(f.fake.finishes, 1);
+}
+
+TEST(KernelBinder, NewPrepareTailIsConsumedExactlyOnce) {
+    Fixture f;
+    ASSERT_NO_FATAL_FAILURE(f.initialize());
+    ASSERT_EQ(f.launch().status, 0);
+    f.fake.pending_prepare = true;
+    f.fake.clear_trace();
+    EXPECT_EQ(f.launch().status, 0);
+    EXPECT_EQ(f.fake.trace, success);
+}
+}  // namespace kernel_binder_test

--- a/tests/ut/cpp/common/test_kernel_launch_native.cpp
+++ b/tests/ut/cpp/common/test_kernel_launch_native.cpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "kernel_binder_test_support.h"
+#include "kernel_launch_native.h"
+
+#include <array>
+#include <cstring>
+
+namespace {
+using namespace kernel_binder_test;
+struct NativeFake {
+    Fixture fixture;
+    std::array<uint64_t, 10> packet{};
+    std::array<uint32_t, 4> handshake{};
+    KernelInvocationPlaceholder descriptor{64, 72};
+    aclrtPlaceHolderInfo placeholder{64, 72};
+    KernelClearRegion clear{handshake.data(), sizeof(handshake)};
+    KernelNativeInvocation native;
+    std::vector<std::vector<uint8_t>> copies;
+    std::vector<int> memset_values;
+    void initialize() {
+        fixture.initialize();
+        fixture.binding.packet = reinterpret_cast<const uint8_t *>(packet.data());
+        fixture.binding.packet_bytes = sizeof(packet);
+        fixture.binding.placeholders = &descriptor;
+        fixture.binding.placeholder_count = 1;
+        native.aicore = ptr(200);
+        native.aicpu = ptr(201);
+        native.aicore_blocks = 24;
+        native.aicpu_blocks = 6;
+        native.aicore_args = handshake.data();
+        native.aicore_args_bytes = sizeof(handshake);
+        native.aicpu_args = packet.data();
+        native.aicpu_args_bytes = sizeof(packet);
+        native.placeholders = &placeholder;
+        native.placeholder_count = 1;
+        native.clear_regions = &clear;
+        native.clear_region_count = 1;
+        native.cancel = {handshake.data(), sizeof(handshake)};
+    }
+    KernelLaunchResult launch(void *caller = ptr(100)) {
+        return launch_bound_kernel_native(fixture.binding, native, caller, fixture.fake.gate());
+    }
+};
+NativeFake *active = nullptr;
+}  // namespace
+
+extern "C" aclError aclrtQueryEventStatus(aclrtEvent event, aclrtEventRecordedStatus *status) {
+    EXPECT_EQ(event, ptr(7));
+    auto &f = active->fixture.fake;
+    ++f.queries;
+    *status = f.complete ? ACL_EVENT_RECORDED_STATUS_COMPLETE : ACL_EVENT_RECORDED_STATUS_NOT_READY;
+    return f.query_error;
+}
+extern "C" aclError aclrtStreamWaitEvent(aclrtStream stream, aclrtEvent event) {
+    if (event == ptr(4)) {
+        EXPECT_TRUE(stream == ptr(1) || stream == ptr(2));
+    } else {
+        EXPECT_EQ(stream, ptr(100));
+    }
+    const auto ops = active->fixture.fake.ops();
+    return ops.wait_event(ops.context, stream, event);
+}
+extern "C" aclError aclrtRecordEvent(aclrtEvent event, aclrtStream stream) {
+    EXPECT_EQ(stream, event == ptr(5) ? ptr(2) : event == ptr(6) ? ptr(1) : ptr(100));
+    const auto ops = active->fixture.fake.ops();
+    return ops.record_event(ops.context, event, stream);
+}
+extern "C" aclError aclrtMemsetAsync(void *address, size_t maximum, int32_t value, size_t count, aclrtStream stream) {
+    EXPECT_EQ(address, active->handshake.data());
+    EXPECT_EQ(maximum, sizeof(active->handshake));
+    EXPECT_EQ(count, maximum);
+    EXPECT_EQ(stream, ptr(100));
+    active->memset_values.push_back(value);
+    return active->fixture.fake.append(value == 0xff ? Cancel : Step::Clear);
+}
+extern "C" aclError
+aclrtLaunchKernel(aclrtFuncHandle function, uint32_t blocks, const void *args, size_t bytes, aclrtStream stream) {
+    EXPECT_EQ(function, ptr(200));
+    EXPECT_EQ(blocks, 24u);
+    EXPECT_EQ(args, active->handshake.data());
+    EXPECT_EQ(bytes, sizeof(active->handshake));
+    EXPECT_EQ(stream, ptr(2));
+    return active->fixture.fake.append(Step::AicoreLaunch);
+}
+extern "C" aclError aclrtLaunchKernelWithHostArgs(
+    aclrtFuncHandle function, uint32_t blocks, aclrtStream stream, aclrtLaunchKernelCfg *, void *args, size_t bytes,
+    aclrtPlaceHolderInfo *placeholders, size_t count
+) {
+    EXPECT_EQ(function, ptr(201));
+    EXPECT_EQ(blocks, 6u);
+    EXPECT_EQ(stream, ptr(1));
+    EXPECT_EQ(count, 1u);
+    auto *first = static_cast<uint8_t *>(args);
+    active->copies.emplace_back(first, first + bytes);
+    auto &copy = active->copies.back();
+    const uint64_t address = reinterpret_cast<uintptr_t>(copy.data()) + placeholders[0].dataOffset;
+    std::memcpy(copy.data() + placeholders[0].addrOffset, &address, sizeof(address));
+    std::memcpy(first + placeholders[0].addrOffset, &address, sizeof(address));
+    return active->fixture.fake.append(Step::AicpuLaunch);
+}
+
+TEST(KernelNativeBinder, RoutesThreeStreamsAndCopiesIndependentHostArgs) {
+    NativeFake f;
+    active = &f;
+    f.initialize();
+    f.packet[9] = 17;
+    ASSERT_EQ(f.launch().status, 0);
+    EXPECT_EQ(f.fixture.fake.trace, success);
+    EXPECT_EQ(f.packet[8], 0u);
+    f.packet[9] = 29;
+    ASSERT_EQ(f.launch().status, 0);
+    ASSERT_EQ(f.copies.size(), 2u);
+    uint64_t payload = 0;
+    std::memcpy(&payload, f.copies[0].data() + 72, 8);
+    EXPECT_EQ(payload, 17u);
+    std::memcpy(&payload, f.copies[1].data() + 72, 8);
+    EXPECT_EQ(payload, 29u);
+    EXPECT_EQ(f.memset_values, (std::vector<int>{0, 0}));
+    EXPECT_EQ(f.fixture.fake.queries, 0);
+    f.fixture.fake.complete = false;
+    EXPECT_NE(f.launch(ptr(101)).status, 0);
+    EXPECT_EQ(f.fixture.fake.queries, 1);
+}
+
+TEST(KernelNativeBinder, AicpuFailureCancelsWithSingleAllOnesFillAndRestoresPlaceholder) {
+    NativeFake f;
+    active = &f;
+    f.initialize();
+    f.fixture.fake.fail_at = 8;
+    const auto result = f.launch();
+    EXPECT_EQ(result.status, -1708);
+    EXPECT_EQ(result.cleanup_status, 0);
+    EXPECT_TRUE(result.tail_recorded);
+    EXPECT_EQ(f.packet[8], 0u);
+    EXPECT_EQ(f.memset_values, (std::vector<int>{0, 0xff}));
+    EXPECT_TRUE(f.fixture.fake.poisoned);
+}
+
+TEST(KernelNativeBinder, InvalidPreparedArgumentsRejectBeforeAnyEnqueue) {
+    for (int fault = 0; fault < 10; ++fault) {
+        SCOPED_TRACE(fault);
+        NativeFake f;
+        active = &f;
+        f.initialize();
+        switch (fault) {
+        case 0:
+            f.native.aicore = nullptr;
+            break;
+        case 1:
+            f.native.aicpu_args_bytes -= 8;
+            break;
+        case 2:
+            f.native.cancel.bytes -= 1;
+            break;
+        case 3:
+            f.native.cancel.address = ptr(4096);
+            break;
+        case 4:
+            f.placeholder.addrOffset = 0;
+            break;
+        case 5:
+            f.placeholder.dataOffset = sizeof(f.packet);
+            break;
+        case 6:
+            f.packet[8] = 1;
+            break;
+        case 7:
+            f.native.placeholder_count = 0;
+            break;
+        case 8:
+            f.fixture.fake.validation_error = -99;
+            break;
+        case 9:
+            f.native.clear_regions = nullptr;
+            break;
+        }
+        EXPECT_NE(f.launch().status, 0);
+        EXPECT_TRUE(f.fixture.fake.trace.empty());
+        EXPECT_TRUE(f.copies.empty());
+        EXPECT_FALSE(f.fixture.fake.poisoned);
+        EXPECT_EQ(f.fixture.fake.acquisitions, f.fixture.fake.finishes);
+    }
+}

--- a/tests/ut/py/test_kernel_launch_source_guard.py
+++ b/tests/ut/py/test_kernel_launch_source_guard.py
@@ -1,0 +1,91 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Keep kernel submission within the v9 capture-safe operation vocabulary."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+SOURCES = (
+    "src/common/platform/onboard/host/kernel_launch_binder.cpp",
+    "src/common/platform/onboard/host/kernel_launch_native.cpp",
+    "src/common/platform/onboard/host/kernel_launch_sequence.h",
+)
+ALLOWED_ACL = {
+    "aclrtQueryEventStatus",
+    "aclrtStreamWaitEvent",
+    "aclrtRecordEvent",
+    "aclrtMemsetAsync",
+    "aclrtLaunchKernel",
+    "aclrtLaunchKernelWithHostArgs",
+}
+
+
+def violations(source):
+    code = re.sub(r"/\*.*?\*/|//[^\n]*", "", source, flags=re.S)
+    calls = set(re.findall(r"\b((?:aclrt|acl|rt)[A-Z]\w*)\s*\(", code))
+    banned = re.findall(
+        r"\b(?:malloc|calloc|realloc|free|make_graph_host_args|submit_graph_template)\s*\("
+        r"|\b(?:new|delete)\b|std::(?:vector|make_unique|make_shared)\b",
+        code,
+    )
+    return sorted(calls - ALLOWED_ACL) + banned
+
+
+@pytest.mark.parametrize("path", SOURCES)
+def test_kernel_submission_has_no_allocation_sync_or_capture_query(path):
+    assert not violations((ROOT / path).read_text())
+
+
+def test_binder_has_one_enqueue_composition():
+    source = (ROOT / SOURCES[0]).read_text()
+    assert len(re.findall(r"\benqueue_kernel_launch_sequence\s*\(", source)) == 1
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "aclrtSynchronizeStream(stream);",
+        "rtStreamAddToModel(stream, model);",
+        "rtStreamSynchronize(stream);",
+        "rtMalloc(&ptr, bytes, policy);",
+        "aclInit(nullptr);",
+        "aclFinalize();",
+        "aclrtStreamGetCaptureInfo(stream);",
+        "aclrtMalloc(&ptr, bytes, policy);",
+        "aclrtCreateEvent(&event);",
+        "aclrtDestroyStream(stream);",
+        "aclrtModelExecuteAsync(model, stream);",
+        "malloc(bytes);",
+        "new int(1);",
+        "std::vector<int> data;",
+        "make_graph_host_args(source, args);",
+    ],
+)
+def test_guard_rejects_forbidden_submission_operations(operation):
+    assert violations(operation)
+
+
+def test_submission_module_does_not_import_unmerged_context_or_hbg_interfaces():
+    paths = (
+        *SOURCES,
+        "src/common/platform/include/host/kernel_launch_binder.h",
+        "src/common/platform/onboard/host/kernel_launch_native.h",
+    )
+    forbidden = (
+        "kernel_execution_state.h",
+        "kernel_device_resources.h",
+        "kernel_invocation_validation.h",
+        "host_build_graph/",
+    )
+    for path in paths:
+        includes = re.findall(r'^#include\s+[<"]([^>"]+)', (ROOT / path).read_text(), re.M)
+        assert not [include for include in includes if any(item in include for item in forbidden)], path


### PR DESCRIPTION
A prepared kernel invocation needs a bounded three-stream submission protocol. This draft adds a **standalone binder submission module directly on main**, with no unmerged K1/HBG code or prerequisite commits in the diff.

### Scope

One commit, 14 files, +1,175 lines:

| Area | Lines |
| --- | ---: |
| Core C++ submission interfaces/implementation | 434 |
| Unit tests and test fixtures | 605 |
| Build entries and docs navigation | 35 |
| Documentation | 101 |

This is not a squash of the previous dependency stack. The K1 context/ABI/resource implementation and H1-H4 changes have been removed from this PR entirely.

### Behavior

- Acquire a prepared owner lease; validate distinct caller/AICPU/AICore streams and five event handles. The native adapter checks argument buffers, placeholder agreement/bounds and prepared clear/cancel regions inside that lease.
- Consume the owner's pending PrepareTail, clear launch/handshake/report state, record Start, submit hidden AICore first, submit dedicated **non-hidden AICPU** with HostArgs, join both Done events on caller and record SerialTail.
- Same-caller submission skips old-tail query/wait. A caller change queries the previous tail before enqueue and rejects not-ready/error cleanly.
- Pair every successful acquire with exactly one finish, including native preflight, tail-query and partial-enqueue failures. Return the original error and compensation error separately. The owner applies poison after enqueue failure; no Host cancel follows successful AICPU submission.
- Use pre-existing registered handles, HostArgs and cancel storage; no allocation, synchronization, capture query or model attachment in the submission path.

### Owner boundary / deferred integration

Internal C++ types live in `simpler::kernel_launch`. There is no new public C ABI, assumed invocation wire layout or duplicate context phase machine.

`acquire` must validate real context phase, device/callable generation, frozen capacity, packet ABI and runtime bindings, and hold the submission lease against concurrent prepare/close. `finish` applies success state updates, preserves clean rejection state, or poisons partial submission, then releases the lease. Unit tests use a fake owner to exercise this contract; they do not supply a production K1/HBG adapter.

The previous complete integration snapshot is retained on [codex/kernel-binder-integration-backup](https://github.com/TaoZQY/simpler/tree/codex/kernel-binder-integration-backup). After prerequisite PRs merge, port its context/resource and HBG packet/slot checks into the owner adapter. No prerequisite code is imported here merely to satisfy a missing header.

### Validation

- Direct main-based runtime rebuild passed, including the real CANN adapter sources.
- All 141 no-hardware C++ executables passed. Final namespace/lease-assertion changes were additionally rebuilt and all seven binder cases passed.
- Three native-adapter cases passed against installed CANN declarations with fake ACL symbols.
- 20 source/dependency guard cases passed, including the earlier raw RTS/ACL lifecycle guard fix.
- Binder ASan with leak detection passed.
- Full a2a3sim and a5sim regression sweeps passed (all runtimes, exclude level 4).
- All applicable pre-commit checks and strict docs build passed.
- No hardware tests: the read-only device query showed nonzero HBM on all devices. No native capture/replay, accuracy or performance claim.

### Before end-to-end acceptance

- [ ] Connect production context/callable/resource ownership and HBG packet/slot validation through the owner interface.
- [ ] Connect native HBG device restore/retirement and the public kernel entry.
- [ ] Verify ACL_EVENT_SYNC creation, wrong-event-flag rejection and three-stream event Probe B on device.
- [ ] Verify mixed-operator capture/replay, pristine restore, numerical accuracy and performance.

These items remain separate integration work. Program-mode execution is unchanged. The design basis remains the saved September 8 v9 final-decision table; the live design site could not be refreshed from this environment.

### Submission stage

**Binder (pipeline step 9)**. This draft remains one standalone commit directly on main. The commit title now identifies its stage; the tree is unchanged. No prerequisite commits or HBG integration code have been added.
