### PR TITLE
Add: TMR kernel resident arguments and invocation isolation（K5）

### DIFF
--- a/.github/workflows/_ut-npu-a5.yml
+++ b/.github/workflows/_ut-npu-a5.yml
@@ -46,6 +46,15 @@ jobs:
           system-site-packages: "true"
           source-cann: "false"
 
+      # Needs the onboard DSO and CANN headers, but interposes transport and
+      # never touches an NPU. Keep it out of the hardware task queue.
+      - name: Run a5 host topology lifecycle fault injection
+        run: |
+          source .venv/bin/activate
+          cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
+          cmake --build tests/ut/cpp/build --target test_a5_kernel_topology_lifecycle --parallel 4
+          ctest --test-dir tests/ut/cpp/build -R '^test_a5_kernel_topology_lifecycle$' --output-on-failure --timeout 300
+
       - name: Run Python hardware unit tests (a5)
         run: |
           source .venv/bin/activate

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -304,7 +304,9 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
            simpler_unregister_callable, get_pipeline_contract,
            supports_concurrent_native_prepare_ctx,
            get_arena_bank_gm_heap_base_ctx, get_retained_temp_addr_ctx,
-           finalize_device
+           finalize_device, simpler_kernel_mode_supported,
+           simpler_kernel_mode_init, simpler_kernel_mode_prepare_callable,
+           simpler_kernel_mode_launch
     create_device_context() → DeviceContextHandle
     allocate zeroed, aligned, stable native-run storage per pipeline slot
     simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size, ...)

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -107,12 +107,17 @@ ChipCallable.build(
     func_name="my_orchestration",     # the exported orchestration symbol
     binary=orch_bytes,
     children=[(func_id, core_callable), ...],
+    scalar_count=0,                   # scalar arguments the orchestration expects
 )
 ```
 
 `ArgDirection` is `SCALAR`, `IN`, `OUT`, or `INOUT`. The signature list is
 positional and defines the task-arg order. `func_id` must match the id the
-orchestration submits. `ChipCallable` exposes `binary_size`.
+orchestration submits. `ChipCallable` exposes `binary_size` and
+`scalar_count`. `scalar_count` is a cached derivation of the signature: a
+nonzero value must equal the signature's `SCALAR` entry count or `build`
+raises, while 0 also means "not recorded" — an artifact built before the
+count existed or an orchestration that takes no scalars.
 
 Public `Worker` calls use `TaskArgs` containing address-free `Tensor` views at
 every level. The L2 leaf resolves those views into the internal

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2690,7 +2690,8 @@ NB_MODULE(_task_interface, m) {
         .def_static(
             "build",
             [](std::vector<ArgDirection> signature, std::string func_name, nb::bytes binary,
-               std::vector<std::tuple<int32_t, PyCoreCallable>> children, std::string config_name) -> PyChipCallable {
+               std::vector<std::tuple<int32_t, PyCoreCallable>> children, std::string config_name,
+               int32_t scalar_count) -> PyChipCallable {
                 auto bin_ptr = reinterpret_cast<const void *>(binary.c_str());
                 auto bin_size = static_cast<uint32_t>(binary.size());
                 auto child_count = static_cast<int32_t>(children.size());
@@ -2703,14 +2704,16 @@ NB_MODULE(_task_interface, m) {
                 }
 
                 auto buf = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-                    signature.data(), static_cast<int32_t>(signature.size()), func_name.c_str(), bin_ptr, bin_size,
-                    func_ids.data(), child_bufs.data(), child_count, config_name.c_str()
+                    signature.data(), static_cast<int32_t>(signature.size()), scalar_count, func_name.c_str(), bin_ptr,
+                    bin_size, func_ids.data(), child_bufs.data(), child_count, config_name.c_str()
                 );
                 return PyChipCallable{std::move(buf)};
             },
             nb::arg("signature"), nb::arg("func_name"), nb::arg("binary"), nb::arg("children"),
-            nb::arg("config_name") = "",
-            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children."
+            nb::arg("config_name") = "", nb::arg("scalar_count") = 0,
+            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children. "
+            "scalar_count caches the signature's SCALAR entry count; a nonzero value that disagrees with the "
+            "signature raises, and 0 also means the count is not recorded."
         )
 
         .def_static(
@@ -2776,6 +2779,15 @@ NB_MODULE(_task_interface, m) {
                 return std::string(c.config_name(), c.config_name_len());
             },
             "The optional orchestration config function name."
+        )
+
+        .def_prop_ro(
+            "scalar_count",
+            [](const PyChipCallable &self) -> int32_t {
+                return self.get().scalar_count();
+            },
+            "Number of scalar arguments the orchestration expects. 0 also for "
+            "legacy artifacts built before the count was recorded."
         )
 
         .def_prop_ro(

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -1457,12 +1457,17 @@ class ChipWorker:
                 raise RuntimeError("ChipWorker.finalize() cannot run while ChipWorker.init() is in progress")
         try:
             self._impl.finalize()
-        finally:
+        except BaseException:
+            # The registries name what the native side still holds. A teardown
+            # that did not complete leaves those resources alive, so dropping
+            # the registries would hide them from a retry and from the caller.
             _flush_host_log_or_warn("ChipWorker.finalize()")
-            with self._registry_lock:
-                self._callable_registry.clear()
-                self._identity_registry.clear()
-                self._live_handles.clear()
+            raise
+        _flush_host_log_or_warn("ChipWorker.finalize()")
+        with self._registry_lock:
+            self._callable_registry.clear()
+            self._identity_registry.clear()
+            self._live_handles.clear()
 
     def _allocate_slot_locked(self) -> int:
         for slot_id in range(MAX_REGISTERED_CALLABLE_IDS):

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -64,6 +64,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -79,6 +79,9 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_platform_ops.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_persistent_args.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/tmr_kernel_invocation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -148,6 +148,20 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // A kernel-mode context borrows the caller's device and ACL context, so
+    // the ACL lifecycle (aclInit / aclrtSetDevice / aclrtResetDevice[Force] /
+    // aclFinalize) belongs to the caller. Every call site of those APIs falls
+    // into one of three classes: (a) the aclInit / aclrtSetDevice below this
+    // guard, (b) calls inside force_reset_device(), behind its own
+    // kernel-mode guard, or (c) calls gated on acl_ready_, which only the
+    // path below this guard sets. finalize()'s rt-layer device reset on the
+    // acl_ready_ == false path is intercepted by the kernel-mode branch
+    // inside finalize(). Together these keep the caller's device and ACL
+    // state unreachable in kernel mode.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("ensure_acl_ready: refused — a kernel-mode context does not own the caller's ACL lifecycle");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
 
     // aclInit is process-wide; CANN returns ACL_ERROR_REPEAT_INITIALIZE if it
     // has already been initialized (possibly by another owner), which we
@@ -857,6 +871,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -1071,10 +1093,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup performance profiling (including a2a3's dep_gen). Normally
@@ -1121,6 +1148,10 @@ int DeviceRunner::finalize() {
                 if (rc == 0) rc = finalize_rc;
             }
             acl_ready_ = false;
+        } else if (execution_mode_latch().is_kernel()) {
+            // A kernel-mode context borrows the caller's device; the device
+            // reset belongs to the caller, so the healthy close path releases
+            // only context-owned resources.
         } else {
             int reset_rc = rtDeviceReset(device_id_);
             if (reset_rc != 0) {

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -136,6 +136,27 @@ int kernel_args_init_ffts_base_addr(KernelArgsHelper &helper) {
 // DeviceRunner Implementation
 // =============================================================================
 
+int DeviceRunner::fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) {
+    if (args == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    int rc = init_aicore_register_addresses(&args->regs, device_id, mem_alloc_, AicoreRegKind::Ctrl);
+    if (rc != 0) {
+        LOG_ERROR("fill_persistent_arch_fields: init_aicore_register_addresses(Ctrl) failed: %d", rc);
+        return rc;
+    }
+
+    uint32_t ffts_len = 0;
+    rc = rtGetC2cCtrlAddr(&args->ffts_base_addr, &ffts_len);
+    if (rc != 0) {
+        LOG_ERROR("fill_persistent_arch_fields: rtGetC2cCtrlAddr failed: %d", rc);
+        (void)mem_alloc_.free(reinterpret_cast<void *>(args->regs));
+        args->regs = 0;
+        args->ffts_base_addr = 0;
+        return rc;
+    }
+    return 0;
+}
+
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 // `setup_static_arena`, `create_thread`, `attach_current_thread`,
@@ -1050,13 +1071,20 @@ int DeviceRunner::finalize() {
         // (verified on a2a3). An SDMA-provisioned card gets a single attempt:
         // there a non-confirming reset already blocks on the driver's
         // remote-event timeout, which a retry only multiplies.
+        // A kernel-mode context owns neither the device nor its ACL state, so
+        // force_reset_device() refuses. Asking anyway would log that refusal
+        // once per attempt and then report a reset that "did not confirm
+        // clean", which reads as a failed reset rather than the designed
+        // refusal it is.
+        const bool owns_device_reset = !execution_mode_latch().is_kernel();
         constexpr int kFatalResetAttempts = 3;
-        int reset_rc = attempt_fatal_reset(
-            [this]() {
-                return force_reset_device();
-            },
-            sdma_provisioned ? 1 : kFatalResetAttempts
-        );
+        int reset_rc = owns_device_reset ? attempt_fatal_reset(
+                                               [this]() {
+                                                   return force_reset_device();
+                                               },
+                                               sdma_provisioned ? 1 : kFatalResetAttempts
+                                           ) :
+                                           0;
         const bool reset_confirmed = reset_rc == 0;
         if (!reset_confirmed) {
             LOG_ERROR(
@@ -1119,6 +1147,7 @@ int DeviceRunner::finalize() {
     // mem_alloc_.finalize(), and cached arena sizes.
     rc = finalize_common();
     if (rc == 0) rc = stream_rc;
+    if (rc != 0 && execution_mode_latch().is_kernel()) return rc;
 
     // Reset device AFTER all device memory is freed. Two paths:
     //

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -149,8 +149,6 @@ int DeviceRunner::fill_persistent_arch_fields(KernelArgs *args, uint64_t device_
     rc = rtGetC2cCtrlAddr(&args->ffts_base_addr, &ffts_len);
     if (rc != 0) {
         LOG_ERROR("fill_persistent_arch_fields: rtGetC2cCtrlAddr failed: %d", rc);
-        (void)mem_alloc_.free(reinterpret_cast<void *>(args->regs));
-        args->regs = 0;
         args->ffts_base_addr = 0;
         return rc;
     }
@@ -253,6 +251,56 @@ void DeviceRunner::set_dep_gen_enabled(bool enable) {
     dep_gen_host_graph_set_enabled(enable);
 }
 
+int DeviceRunner::prepare_aicpu_affinity(Runtime &runtime, int requested, rtStream_t control_stream) {
+    (void)control_stream;
+    {
+        std::vector<pto::a2a3::AicpuLogicalCpu> user_cpus;
+        std::vector<int32_t> allowed;
+        runtime.set_aicpu_allowed_cpu_count(0);
+        runtime.set_aicpu_launch_count(0);
+        if (!pto::a2a3::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
+            LOG_ERROR("A2A3 AICPU topology probe failed; cannot configure affinity gate");
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        int resolved_aicpu =
+            resolve_aicpu_thread_num(requested, static_cast<int>(user_cpus.size()), PLATFORM_DEFAULT_AICPU_THREAD_NUM);
+        if (resolved_aicpu < 0) return PTO_RUNTIME_ERR_INTERNAL;
+        if (!pto::a2a3::compute_allowed_cpus(user_cpus, resolved_aicpu, allowed)) {
+            LOG_ERROR(
+                "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(), resolved_aicpu
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        runtime.set_aicpu_thread_num(resolved_aicpu);
+        const size_t cap = runtime.aicpu_allowed_cpus_capacity();
+        if (allowed.size() > cap) {
+            LOG_ERROR("A2A3 compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
+        for (size_t i = 0; i < allowed.size(); ++i)
+            allowed_cpus[i] = allowed[i];
+        runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
+        int32_t launch_n = static_cast<int32_t>(user_cpus.size());
+        if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
+            launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+        }
+        runtime.set_aicpu_launch_count(launch_n);
+
+        std::string dump;
+        for (size_t i = 0; i < allowed.size(); ++i) {
+            if (i) dump += ", ";
+            dump += std::to_string(allowed[i]);
+            if (i + 1 == allowed.size()) dump += "(last)";
+        }
+        LOG_INFO(
+            "A2A3 AICPU ALLOWED_CPUS = [%s] (active=%d, launch=%d, user_cpus=%zu)", dump.c_str(),
+            runtime.get_aicpu_thread_num(), runtime.get_aicpu_launch_count(), user_cpus.size()
+        );
+    }
+    return 0;
+}
+
 int DeviceRunner::prepare_execution(
     Runtime &runtime, const CallConfig &config, uint32_t pipeline_slot, const NativeRunIdentity &identity,
     std::unique_ptr<PreparedExecution> *prepared
@@ -338,57 +386,9 @@ int DeviceRunner::prepare_execution(
 
     resolve_task_binary_addrs(runtime);
 
-    // a2a3 onboard now uses the same host-computed, device-filtered affinity
-    // shape as a5. Host probes the AICPU user pool once, chooses the active
-    // cpu_ids deterministically, writes them into Runtime, and the AICPU-side
-    // gate only matches sched_getcpu() against this table.
-    {
-        std::vector<pto::a2a3::AicpuLogicalCpu> user_cpus;
-        std::vector<int32_t> allowed;
-        runtime.set_aicpu_allowed_cpu_count(0);
-        runtime.set_aicpu_launch_count(0);
-        if (!pto::a2a3::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
-            LOG_ERROR("A2A3 AICPU topology probe failed; cannot configure affinity gate");
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        int resolved_aicpu = resolve_aicpu_thread_num(
-            runtime.get_aicpu_thread_num(), static_cast<int>(user_cpus.size()), PLATFORM_DEFAULT_AICPU_THREAD_NUM
-        );
-        if (resolved_aicpu < 0) return PTO_RUNTIME_ERR_INTERNAL;
-        if (!pto::a2a3::compute_allowed_cpus(user_cpus, resolved_aicpu, allowed)) {
-            LOG_ERROR(
-                "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(), resolved_aicpu
-            );
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        runtime.set_aicpu_thread_num(resolved_aicpu);
-        launch_aicpu_num = resolved_aicpu;
-        const size_t cap = runtime.aicpu_allowed_cpus_capacity();
-        if (allowed.size() > cap) {
-            LOG_ERROR("A2A3 compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
-        for (size_t i = 0; i < allowed.size(); ++i)
-            allowed_cpus[i] = allowed[i];
-        runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
-        int32_t launch_n = static_cast<int32_t>(user_cpus.size());
-        if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
-            launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-        }
-        runtime.set_aicpu_launch_count(launch_n);
-
-        std::string dump;
-        for (size_t i = 0; i < allowed.size(); ++i) {
-            if (i) dump += ", ";
-            dump += std::to_string(allowed[i]);
-            if (i + 1 == allowed.size()) dump += "(last)";
-        }
-        LOG_INFO(
-            "A2A3 AICPU ALLOWED_CPUS = [%s] (active=%d, launch=%d, user_cpus=%zu)", dump.c_str(),
-            runtime.get_aicpu_thread_num(), runtime.get_aicpu_launch_count(), user_cpus.size()
-        );
-    }
+    rc = prepare_aicpu_affinity(runtime, runtime.get_aicpu_thread_num(), stream_aicpu_);
+    if (rc != 0) return rc;
+    launch_aicpu_num = runtime.get_aicpu_thread_num();
 
     // Initialize per-subsystem shared memory.
     //

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -83,6 +83,7 @@ class DeviceRunner : public DeviceRunnerBase {
 public:
     DeviceRunner() = default;
     ~DeviceRunner();
+    int prepare_aicpu_affinity(Runtime &runtime, int requested, rtStream_t control_stream) override;
 
     // `setup_static_arena`, `allocate_tensor`, `free_tensor`,
     // `copy_to_device`, `copy_from_device`,

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -135,6 +135,13 @@ public:
      */
     int finalize() override;
 
+    /**
+     * a2a3 fills the AIC_CTRL per-core register table and the FFTS base
+     * address. The register table is allocated on `mem_alloc_`; the FFTS
+     * address is a query result and owns nothing.
+     */
+    int fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) override;
+
     // `upload_chip_callable_buffer` is inherited from `DeviceRunnerBase`.
 
     /**

--- a/src/a2a3/platform/onboard/host/host_regs.cpp
+++ b/src/a2a3/platform/onboard/host/host_regs.cpp
@@ -225,10 +225,11 @@ int init_aicore_register_addresses(
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 
+    *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
     int ret = rtMemcpy(reg_ptr, regs_size, host_regs.data(), regs_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (ret != 0) {
         LOG_ERROR("Failed to copy %s register addresses to device (rc=%d)", kind_to_name(kind), ret);
-        allocator.free(reg_ptr);
+        if (allocator.free(reg_ptr) == 0) *runtime_regs_ptr = 0;
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -92,6 +92,8 @@ static_assert(
     "host-side C API codes must stay below the negation of every latched device code"
 );
 
+int configure_kernel_runtime_impl(Runtime &, bool) { return PTO_RUNTIME_ERR_UNSUPPORTED; }
+
 extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *, PipelineContract *) {
     return PTO_RUNTIME_ERR_UNSUPPORTED;
 }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -76,6 +76,7 @@
 #include "common/unified_log.h"
 #include "host_log.h"
 #include "host/raii_scope_guard.h"
+#include "host/kernel_pipeline_contract.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -90,6 +91,10 @@ static_assert(
         PTO_RUNTIME_ERR_BASE < -PTO_RUNTIME_LATCHED_CODE_MAX,
     "host-side C API codes must stay below the negation of every latched device code"
 );
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *, PipelineContract *) {
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
 
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -62,6 +62,9 @@
 
 // Scheduler context class
 #include "scheduler/scheduler_context.h"
+#include "tensormap_and_ringbuffer/kernel_execution_inputs.h"
+
+using simpler::tmr::ExecutionInputs;
 
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's RuntimeContext into orchestration TLS
@@ -79,12 +82,7 @@ extern "C" void framework_bind_runtime(RuntimeContext *rt);
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
 
-static int32_t read_runtime_status(Runtime *runtime) {
-    if (runtime == nullptr) {
-        return 0;
-    }
-
-    void *sm = runtime->get_gm_sm_ptr();
+static int32_t read_runtime_status(void *sm) {
     if (sm == nullptr) {
         return 0;
     }
@@ -149,6 +147,7 @@ struct AicpuExecutor {
     // Entry-arg ChipTaskArgs built (via create_from_entry_storage) from get_orch_args()
     // before scheduler init; consumed by the (*p_func)(orch_args_cached_) below.
     ChipTaskArgs orch_args_cached_;
+    simpler::tmr::KernelInvocationState kernel_invocation_;
 
     // Per-callable_id table. Single orch thread today, so first-write/read
     // race is not possible; if multiple orch threads are ever introduced,
@@ -159,7 +158,7 @@ struct AicpuExecutor {
     SchedulerContext sched_ctx_;
 
     // ===== Methods =====
-    int32_t init(Runtime *runtime);
+    int32_t init(Runtime *runtime, const ExecutionInputs &inputs);
     // (Re)load a callable's orchestration SO into orch_so_table_[callable_id].
     // Register-only: the register_callable entry calls this to dlopen and
     // populate the slot. The run path never loads — it consumes an already
@@ -168,8 +167,8 @@ struct AicpuExecutor {
         int32_t callable_id, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size, const char *entry_symbol,
         const char *config_symbol, int32_t thread_idx
     );
-    int32_t run(Runtime *runtime);
-    void deinit(Runtime *runtime);
+    int32_t run(Runtime *runtime, const ExecutionInputs &inputs);
+    void deinit(Runtime *runtime, bool invalidate_host_image);
 
     ~AicpuExecutor() {
         // Process-wide teardown (the single static instance dies here). Every
@@ -196,7 +195,7 @@ static_assert(
 
 // ===== AicpuExecutor Method Implementations =====
 
-int32_t AicpuExecutor::init(Runtime *runtime) {
+int32_t AicpuExecutor::init(Runtime *runtime, const ExecutionInputs &inputs) {
     if (runtime == nullptr) {
         LOG_ERROR("runtime is nullptr");
         init_failed_.store(true, std::memory_order_release);
@@ -245,7 +244,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         serial_orch_sched_ = runtime->dev.serial_orch_sched;
 
         hs_arrived_.store(0, std::memory_order_relaxed);
-        if (sched_ctx_.pre_handshake_init(runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs()) != 0) {
+        if (sched_ctx_.pre_handshake_init(
+                runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs(), inputs.functions, inputs.sm
+            ) != 0) {
             init_failed_.store(true, std::memory_order_release);
             hs_setup_done_.store(true, std::memory_order_release);
             return -1;
@@ -327,7 +328,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     if (is_leader) {
         while (hs_arrived_.load(std::memory_order_acquire) < hs_nthreads) {}
         finished_count_.store(0, std::memory_order_release);
-        if (sched_ctx_.post_handshake_init(runtime) != 0) {
+        if (sched_ctx_.post_handshake_init(runtime, inputs.functions) != 0) {
             init_failed_.store(true, std::memory_order_release);
             init_done_.store(true, std::memory_order_release);
             return -1;
@@ -489,7 +490,7 @@ int32_t AicpuExecutor::load_orch_so(
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::run(Runtime *runtime) {
+int32_t AicpuExecutor::run(Runtime *runtime, const ExecutionInputs &inputs) {
     int32_t affinity_exec_idx = platform_aicpu_affinity_thread_idx();
     int32_t thread_idx = (affinity_exec_idx >= 0) ? affinity_exec_idx : (thread_idx_++);
     if (thread_idx < 0 || thread_idx >= aicpu_thread_num_ || thread_idx >= MAX_AICPU_THREADS) {
@@ -527,7 +528,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // register_callable entry. The run path only consumes it — it never
             // loads. A missing handle means run was reached without a prior
             // successful registration, which is a caller/scheduling bug.
-            const int32_t callable_id = runtime->get_active_callable_id();
+            const int32_t callable_id = inputs.callable_id;
             if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
                 LOG_ERROR(
                     "Thread %d: invalid callable_id %d (limit=%d)", thread_idx, callable_id, MAX_REGISTERED_CALLABLE_IDS
@@ -560,37 +561,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 p_bind = &entry.bind;
                 DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
 
-                // Build the entry-arg once per run; both the config call below and
-                // the orchestration entry (consumed at orch_args_cached_) use it.
-                orch_args_cached_.create_from_entry_storage(runtime->get_orch_args());
-
-                // Validate arg count on every run against the registered SO.
-                if (*p_config_func != nullptr) {
-                    OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
-                    LOG_DEBUG("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
-                    if (cfg.expected_arg_count > 0) {
-                        const simpler::tmr::EntryArgsStorage &args_validate = runtime->get_orch_args();
-                        int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
-                        if (actual_arg_count < cfg.expected_arg_count) {
-                            LOG_ERROR(
-                                "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
-                                cfg.expected_arg_count
-                            );
-                            // The registered SO is fine — these run args are
-                            // incompatible with it. Run only consumes the slot
-                            // (no reload), so leave the table intact and just
-                            // fail this run; unblock scheduler threads first so
-                            // they don't spin forever.
-                            runtime_init_ready_.store(true, std::memory_order_release);
-                            return -1;
-                        }
-                    }
+                if (!simpler::tmr::configure_orchestration_args(inputs, orch_args_cached_, *p_config_func)) {
+                    LOG_ERROR("Thread %d: invocation argument count does not match callable", thread_idx);
+                    runtime_init_ready_.store(true, std::memory_order_release);
+                    return -1;
                 }
 
                 // sm_handle / rt are bound to *this* run's memory and must be
                 // (re)created every run, regardless of whether the SO itself was
                 // reused above.
-                sm_ptr = runtime->get_gm_sm_ptr();
+                sm_ptr = inputs.sm;
             }
 
             // Prebuilt-arena fast path. Host uploads the runtime arena image
@@ -598,8 +578,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // re-wires arena-internal pointers to device addresses below.
             {
                 AicpuPhaseScope arena_wire(AicpuPhase::ArenaWire);
-                void *prebuilt_arena = runtime->get_prebuilt_arena_base();
-                size_t off_runtime = runtime->get_prebuilt_runtime_offset();
+                void *prebuilt_arena = inputs.arena;
+                size_t off_runtime = inputs.runtime_offset;
                 if (prebuilt_arena == nullptr) {
                     LOG_ERROR("Thread %d: prebuilt_arena_base is null", thread_idx);
                     runtime_init_ready_.store(true, std::memory_order_release);
@@ -894,7 +874,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // every subsequent run.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
-            const int32_t callable_id = runtime->get_active_callable_id();
+            const int32_t callable_id = inputs.callable_id;
             framework_bind_runtime(nullptr);
             if (callable_id >= 0 && callable_id < MAX_REGISTERED_CALLABLE_IDS) {
                 DeviceOrchestrationBindRuntimeFunc bind = orch_so_table_[callable_id].bind;
@@ -910,12 +890,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     return run_rc;
 }
 
-void AicpuExecutor::deinit(Runtime *runtime) {
+void AicpuExecutor::deinit(Runtime *runtime, bool invalidate_host_image) {
     // 1. Invalidate AICPU cache for the device-copied Runtime range (`dev`).
     //    Next round's Host DMA (rtMemcpy) writes fresh bytes to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from
     //    HBM. Only `dev` is uploaded, so only `dev` needs invalidation.
-    cache_invalidate_range(runtime, sizeof(runtime->dev));
+    if (invalidate_host_image) cache_invalidate_range(runtime, sizeof(runtime->dev));
 
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();
@@ -950,6 +930,39 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
+
+namespace simpler::tmr {
+
+InvocationStatus
+admit_kernel_execution(ByteSpan packet, const KernelCallableView &callable, const KernelBindingView &binding) noexcept {
+    return g_aicpu_executor.kernel_invocation_.admit(packet, callable, binding);
+}
+
+int32_t init_kernel_execution() {
+    const auto &state = g_aicpu_executor.kernel_invocation_;
+    if (!state.active()) return -1;
+    return g_aicpu_executor.init(state.resident(), state.inputs());
+}
+
+int32_t run_kernel_execution() {
+    const auto &state = g_aicpu_executor.kernel_invocation_;
+    if (!state.active()) return -1;
+    return g_aicpu_executor.run(state.resident(), state.inputs());
+}
+
+int32_t kernel_execution_status() {
+    const auto &state = g_aicpu_executor.kernel_invocation_;
+    return state.active() ? read_runtime_status(state.inputs().sm) : -1;
+}
+
+void release_kernel_execution() {
+    auto &state = g_aicpu_executor.kernel_invocation_;
+    if (!state.active()) return;
+    g_aicpu_executor.deinit(state.resident(), false);
+    state.clear();
+}
+
+}  // namespace simpler::tmr
 
 // ===== Public Entry Point =====
 
@@ -1008,7 +1021,7 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
         // init() barriers every thread internally until init is complete on the
         // leader (or a thread failed), then returns the status — so a non-zero
         // return is authoritative on all threads and no extra spin is needed.
-        if (g_aicpu_executor.init(runtime) != 0) {
+        if (g_aicpu_executor.init(runtime, simpler::tmr::program_execution_inputs(*runtime)) != 0) {
             LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
             return -1;
         }
@@ -1017,7 +1030,7 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     int32_t rc = 0;
     {
         AicpuPhaseScope graph_build(AicpuPhase::GraphBuild);
-        rc = g_aicpu_executor.run(runtime);
+        rc = g_aicpu_executor.run(runtime, simpler::tmr::program_execution_inputs(*runtime));
     }
     if (rc != 0) {
         LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
@@ -1031,11 +1044,11 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     // sched overlap into post_orch — inflating it well past the actual teardown.
     // read_runtime_status is two atomic loads every thread needs, so it
     // stays outside the scope.
-    int32_t runtime_rc = read_runtime_status(runtime);
+    int32_t runtime_rc = read_runtime_status(runtime->get_gm_sm_ptr());
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         AicpuPhaseScope post_orch(AicpuPhase::PostOrch);
         LOG_INFO("aicpu_execute: Last thread finished, cleaning up");
-        g_aicpu_executor.deinit(runtime);
+        g_aicpu_executor.deinit(runtime, true);
     }
 
     if (runtime_rc != 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -492,6 +492,11 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
     return true;
 }
 
+int configure_kernel_runtime_impl(Runtime &runtime, bool serial_orch_sched) {
+    runtime.dev.serial_orch_sched = serial_orch_sched;
+    return 0;
+}
+
 extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out) {
     if (config == nullptr || out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -52,6 +52,8 @@
 #include "common/strace.h"
 #include "common/unified_log.h"
 #include "host/platform_compile_info.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "host/raii_scope_guard.h"
 #include "common/host_api.h"
 #include "utils/device_arena.h"
@@ -488,6 +490,52 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
     }
     out->sm_size = SharedMemoryHandle::calculate_size_per_ring(sizing.task_window_sizes);
     return true;
+}
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out) {
+    if (config == nullptr || out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(
+            config->runtime_env.ring_task_window, config->runtime_env.ring_heap, config->runtime_env.ring_dep_pool,
+            &sizing
+        )) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    uint64_t total_window = 0;
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r)
+        total_window += sizing.task_window_sizes[r];
+    // OrchestratorLayout stores the sum in int32_t and asserts before narrowing.
+    if (total_window > static_cast<uint64_t>(INT32_MAX)) return PTO_RUNTIME_ERR_INTERNAL;
+
+    // Layout has a fixed number of regions; window/dep counts are int32-bounded.
+    // Their reserve-only size arithmetic requires the platform's 64-bit size_t.
+    static_assert(sizeof(size_t) == sizeof(uint64_t));
+    ArenaStaticSizes sizes;
+    if (!derive_arena_static_sizes(sizing, &sizes)) return PTO_RUNTIME_ERR_INTERNAL;
+    constexpr size_t max_usable = std::numeric_limits<size_t>::max() - (DeviceArena::kDefaultBaseAlign - 1);
+    if (sizes.total_heap > max_usable || sizes.sm_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+    DeviceArena arena;
+    const auto layout =
+        runtime_reserve_layout(arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
+    if (layout.offsets.arena_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+
+    const PipelineContract candidate = {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        1,
+        {
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, sizes.total_heap},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, sizes.sm_size},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, layout.offsets.arena_size},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+    if (!is_valid_tmr_kernel_pipeline_contract(&candidate)) return PTO_RUNTIME_ERR_INTERNAL;
+    *out = candidate;
+    return 0;
 }
 
 // per-run: the only signature-aware step. Copy the orch args, replacing each

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1109,6 +1109,17 @@ int32_t SchedulerContext::pre_handshake_init(
     Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base
 ) {
     always_assert(runtime != nullptr);
+    return pre_handshake_init(
+        runtime, aicpu_thread_num, sched_thread_num, regs_base, {runtime->dev.func_id_to_addr_, RUNTIME_MAX_FUNC_ID},
+        runtime->get_gm_sm_ptr()
+    );
+}
+
+int32_t SchedulerContext::pre_handshake_init(
+    Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base,
+    simpler::tmr::CallableTableView functions, void *sm
+) {
+    always_assert(runtime != nullptr);
 
     // Zero all per-core execution state before handshake
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
@@ -1191,14 +1202,14 @@ int32_t SchedulerContext::pre_handshake_init(
     // released to dispatch.
     completed_tasks_.store(0, std::memory_order_release);
     orchestrator_done_.store(false, std::memory_order_release);
-    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    functions_ = functions;
 
     // total_tasks_ must be read before hs_setup_done_ is published: on the
     // decoupled path the orchestrator resets the SM as soon as it observes
     // hs_setup_done_, which zeroes these ring counters, so the read completes here
     // (on the leader, before any thread is released) rather than post-handshake.
-    if (runtime->get_gm_sm_ptr()) {
-        auto *header = static_cast<SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
+    if (sm) {
+        auto *header = static_cast<SharedMemoryHeader *>(sm);
         int64_t window_tasks = 0;
         for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
@@ -1214,6 +1225,10 @@ int32_t SchedulerContext::pre_handshake_init(
 }
 
 int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
+    return post_handshake_init(runtime, {runtime->dev.func_id_to_addr_, RUNTIME_MAX_FUNC_ID});
+}
+
+int32_t SchedulerContext::post_handshake_init(Runtime *runtime, simpler::tmr::CallableTableView functions) {
     if (handshake_failed_.load(std::memory_order_acquire)) {
         emergency_shutdown(runtime);
         return -1;
@@ -1321,7 +1336,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         }
     }
 
-    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    functions_ = functions;
 
     return 0;
 }
@@ -1381,7 +1396,7 @@ void SchedulerContext::deinit() {
     regs_ = 0;
     sched_ = nullptr;
     rt_ = nullptr;
-    func_id_to_addr_ = nullptr;
+    functions_ = {};
 }
 
 void SchedulerContext::bind_runtime(RuntimeContext *rt) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -615,6 +615,7 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
             // contention).
             uint64_t my_mask[EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
             for (int i = 0; i < handle_count; i++) {
+                if (!handles[i].valid) continue;
                 publish_subtask_to_core(handles[i], dispatch_ts, thread_idx);
                 if (gated) {
                     int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -32,6 +32,8 @@
 #endif
 
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
+#include "tensormap_and_ringbuffer/callable_table_view.h"
+
 class Runtime;
 struct Handshake;
 struct RuntimeContext;
@@ -67,6 +69,10 @@ public:
     // success, negative on failure.
     int32_t
     pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
+    int32_t pre_handshake_init(
+        Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base,
+        simpler::tmr::CallableTableView functions, void *sm
+    );
     // All threads: handshake this thread's contiguous slice [lo, hi) of cores
     // (partitioned by tidx/nthreads). Each core is touched by exactly one thread.
     void handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads);
@@ -90,6 +96,7 @@ public:
     // Leader-only, after the handshake barrier: build worker-id lists, assign
     // cores, init profiling subsystems, read task counts, init payloads.
     int32_t post_handshake_init(Runtime *runtime);
+    int32_t post_handshake_init(Runtime *runtime, simpler::tmr::CallableTableView functions);
 
     // Reset all SchedulerContext-owned state to its post-construction defaults.
     // Called by AicpuExecutor::deinit() during per-run teardown.
@@ -183,7 +190,7 @@ private:
     // and return gate for the rest of the run; every other path leaves both
     // alone. Indexed by core id, reset in pre_handshake_init.
     std::atomic<bool> core_retired_[PLATFORM_MAX_CORES];
-    uint64_t *func_id_to_addr_{nullptr};
+    simpler::tmr::CallableTableView functions_{};
 
     // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};
@@ -259,7 +266,7 @@ private:
         ChipReadyQueue *queues, ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
     );
 
-    void build_payload(
+    bool build_payload(
         DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, SubtaskSlot subslot, int32_t block_idx,
         bool force_gate
     );
@@ -279,6 +286,7 @@ private:
         int32_t core_offset;
         uint64_t *dispatch_timestamp_slot;
         int32_t task_timing_slot;  // TASK_TIMING_SLOT_NONE unless the task is tagged
+        bool valid{false};
     };
 
     PublishHandle prepare_subtask_to_core(
@@ -289,6 +297,7 @@ private:
     // `thread_idx` is the publishing Scheduler thread's index, used to select the
     // per-thread task-timing record; every call site already has it in scope.
     inline void publish_subtask_to_core(const PublishHandle &h, uint64_t dispatch_ts, int32_t thread_idx) {
+        if (!h.valid) return;
         if (h.dispatch_timestamp_slot != nullptr) {
             *h.dispatch_timestamp_slot = dispatch_ts;
         }
@@ -551,11 +560,5 @@ private:
     // Small inline helpers
     // =========================================================================
 
-    uint64_t get_function_bin_addr(int func_id) const {
-        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-            LOG_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
-            return 0;
-        }
-        return func_id_to_addr_[func_id];
-    }
+    uint64_t get_function_bin_addr(int func_id) const { return functions_.lookup(func_id); }
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -121,13 +121,15 @@ int SchedulerContext::pop_ready_tasks_batch(
     return count;
 }
 
-void SchedulerContext::build_payload(
+bool SchedulerContext::build_payload(
     DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, SubtaskSlot subslot, int32_t block_idx,
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
     uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+    if (callable_addr == 0 || callable_addr % alignof(CoreCallable) != 0) return false;
     const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
+    if (callable->resolved_addr() == 0) return false;
     dispatch_payload.function_bin_addr = callable->resolved_addr();
     auto &payload = *slot_state.payload;
     // A claimed early-stage range stays gated even if producer completion flips
@@ -160,6 +162,7 @@ void SchedulerContext::build_payload(
     // [PAYLOAD_GLOBAL_CONTEXT_INDEX] are per-(core, buf_idx) constants, also
     // prefilled in init().
     dispatch_payload.local_context.async_ctx.task_token = slot_state.task->task_id;
+    return true;
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
@@ -187,7 +190,13 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
     // deferred completion (count > 0), which is rare. A non-deferred task never
     // touches count/error_code, so the slab stays clean without a per-dispatch
     // write — keeping this cold per-core line off the dispatch path.
-    build_payload(payload, slot_state, subslot, block_idx, force_gate);
+    if (!build_payload(payload, slot_state, subslot, block_idx, force_gate)) {
+        int32_t expected = SIMPLER_ERROR_NONE;
+        sched_->sm_header->sched_error_code.compare_exchange_strong(
+            expected, SIMPLER_ERROR_INVALID_ARGS, std::memory_order_acq_rel
+        );
+        return {};
+    }
 
     if (to_pending) {
         core_exec_state.pending_subslot = subslot;
@@ -231,9 +240,12 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
     }
 #endif
 
-    return PublishHandle{
-        core_exec_state.reg_addr, reg_task_id, core_offset, dispatch_timestamp_slot, slot_state.task_attrs.timing_slot()
-    };
+    return PublishHandle{core_exec_state.reg_addr,
+                         reg_task_id,
+                         core_offset,
+                         dispatch_timestamp_slot,
+                         slot_state.task_attrs.timing_slot(),
+                         true};
 }
 
 int SchedulerContext::prepare_block_for_dispatch(
@@ -655,6 +667,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
     if (n > 0) {
         wmb();
         for (int i = 0; i < n; i++) {
+            if (!handles[i].valid) continue;
             publish_subtask_to_core(handles[i], early_dispatch_ts, thread_idx);
             int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
             sched_->early_dispatch_doorbell_table[cid].addr = handles[i].reg_addr;
@@ -684,6 +697,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
             }
         }
         for (int i = 0; i < n; i++) {
+            if (!handles[i].valid) continue;
             int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
             SchedulerState::ring_claimed_local_doorbell(
                 owned[cid >> 6], cid, handles[i].reg_addr, handles[i].reg_task_id

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -69,6 +69,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -84,6 +84,9 @@ list(APPEND HOST_RUNTIME_SOURCES
 # Add common/platform/onboard/host sources (shared between a2a3 / a5 onboard).
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_helpers.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_platform_ops.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/kernel_persistent_args.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/tmr_kernel_invocation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_phase_capture.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/onboard/host/device_runner_base.cpp"

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -91,6 +91,16 @@ extern "C" __attribute__((weak, visibility("hidden"))) bool publish_runtime_chip
 // DeviceRunner Implementation
 // =============================================================================
 
+int DeviceRunner::fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) {
+    if (args == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    const int rc = init_aicore_register_addresses(&args->regs, device_id, mem_alloc_);
+    if (rc != 0) {
+        LOG_ERROR("fill_persistent_arch_fields: init_aicore_register_addresses failed: %d", rc);
+    }
+    return rc;
+}
+
 DeviceRunner::~DeviceRunner() { finalize(); }
 
 // `setup_static_arena`, `create_thread`, `attach_current_thread`,
@@ -941,12 +951,19 @@ int DeviceRunner::finalize() {
         // before abandon_common_after_device_failure() clears it.
         constexpr int kFatalResetAttempts = 3;
         const bool sdma_provisioned = dma_workspace_handle_ != nullptr;
-        int reset_rc = attempt_fatal_reset(
-            [this]() {
-                return force_reset_device();
-            },
-            sdma_provisioned ? 1 : kFatalResetAttempts
-        );
+        // A kernel-mode context owns neither the device nor its ACL state, so
+        // force_reset_device() refuses. Asking anyway would log that refusal
+        // once per attempt and then report a reset that "did not confirm
+        // clean", which reads as a failed reset rather than the designed
+        // refusal it is.
+        const bool owns_device_reset = !execution_mode_latch().is_kernel();
+        int reset_rc = owns_device_reset ? attempt_fatal_reset(
+                                               [this]() {
+                                                   return force_reset_device();
+                                               },
+                                               sdma_provisioned ? 1 : kFatalResetAttempts
+                                           ) :
+                                           0;
         const bool reset_confirmed = reset_rc == 0;
         if (!reset_confirmed) {
             LOG_ERROR(
@@ -998,6 +1015,7 @@ int DeviceRunner::finalize() {
     // chip-callable buffer pool, the three arenas, device_wall,
     // mem_alloc_.finalize(), and cached arena sizes.
     rc = finalize_common();
+    if (rc != 0 && execution_mode_latch().is_kernel()) return rc;
 
     // Reset device and finalize ACL AFTER all device memory is freed. When the
     // ACL layer was brought up (comm path), aclrtResetDevice supersedes

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -107,6 +107,20 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // A kernel-mode context borrows the caller's device and ACL context, so
+    // the ACL lifecycle (aclInit / aclrtSetDevice / aclrtResetDevice[Force] /
+    // aclFinalize) belongs to the caller. Every call site of those APIs falls
+    // into one of three classes: (a) the aclInit / aclrtSetDevice below this
+    // guard, (b) calls inside force_reset_device(), behind its own
+    // kernel-mode guard, or (c) calls gated on acl_ready_, which only the
+    // path below this guard sets. finalize()'s rt-layer device reset on the
+    // acl_ready_ == false path is intercepted by the kernel-mode branch
+    // inside finalize(). Together these keep the caller's device and ACL
+    // state unreachable in kernel mode.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("ensure_acl_ready: refused — a kernel-mode context does not own the caller's ACL lifecycle");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
 
     // aclInit is process-wide; CANN returns 100002 if it has already been
     // initialized (possibly by another owner), which we treat as success.
@@ -816,6 +830,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -956,10 +978,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup all profiling subsystems (free shm + per-buffer dev/host
@@ -990,6 +1017,10 @@ int DeviceRunner::finalize() {
             if (rc == 0) rc = finalize_rc;
         }
         acl_ready_ = false;
+    } else if (execution_mode_latch().is_kernel()) {
+        // A kernel-mode context borrows the caller's device; the device
+        // reset belongs to the caller, so the healthy close path releases
+        // only context-owned resources.
     } else {
         int reset_rc = rtDeviceReset(device_id_);
         if (reset_rc != 0) {

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -189,7 +189,8 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
     return 0;
 }
 
-int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &out) {
+int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &out, rtStream_t control_stream) {
+    if (kernel_topology_result_ != nullptr) return PTO_RUNTIME_ERR_INVALID_STATE;
     if (aicpu_device_occupancy_cached_) {
         out = aicpu_device_occupancy_;
         return 0;
@@ -201,8 +202,16 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
         return PTO_RUNTIME_ERR_INTERNAL;
     }
     auto result_cleanup = RAIIScopeGuard([&]() {
-        mem_alloc_.free(device_result);
+        if (execution_mode_latch().is_kernel()) {
+            if (kernel_topology_stream_ != nullptr) return;
+            const int free_rc = mem_alloc_.free(device_result);
+            if (free_rc == 0) kernel_topology_result_ = nullptr;
+            else kernel_execution_state().poison(free_rc);
+        } else {
+            mem_alloc_.free(device_result);
+        }
     });
+    if (execution_mode_latch().is_kernel()) kernel_topology_result_ = device_result;
     AicpuTopologyQueryResult zero{};
     int rc = rtMemcpy(device_result, sizeof(zero), &zero, sizeof(zero), RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
@@ -211,19 +220,23 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
     }
     AicpuTopologyQueryArgs args{};
     args.result_addr = reinterpret_cast<uint64_t>(device_result);
-    rc = launch_aicpu_payload(stream_aicpu_, &args, sizeof(args), kAicpuTopologyQueryName, /*aicpu_num=*/1);
+    if (execution_mode_latch().is_kernel()) kernel_topology_stream_ = control_stream;
+    rc = launch_aicpu_payload(control_stream, &args, sizeof(args), kAicpuTopologyQueryName, /*aicpu_num=*/1);
     if (rc != 0) {
         LOG_ERROR("AICPU device occupancy query launch failed: %d", rc);
-        recover_device_or_mark_unusable(rc);
+        if (execution_mode_latch().is_kernel()) kernel_execution_state().poison(rc);
+        else recover_device_or_mark_unusable(rc);
         return rc;
     }
-    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    rc = aclrtSynchronizeStreamWithTimeout(control_stream, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
     if (rc != 0) {
         LOG_ERROR("AICPU device occupancy query sync failed: %d", rc);
-        recover_device_or_mark_unusable(rc);
+        if (execution_mode_latch().is_kernel()) kernel_execution_state().poison(rc);
+        else recover_device_or_mark_unusable(rc);
         return rc;
     }
     AicpuTopologyQueryResult result{};
+    kernel_topology_stream_ = nullptr;
     rc = rtMemcpy(&result, sizeof(result), device_result, sizeof(result), RT_MEMCPY_DEVICE_TO_HOST);
     if (rc != 0) {
         LOG_ERROR("AICPU device occupancy query copy failed: %d", rc);
@@ -236,6 +249,15 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
         );
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    if (execution_mode_latch().is_kernel()) {
+        result_cleanup.dismiss();
+        rc = mem_alloc_.free(device_result);
+        if (rc != 0) {
+            kernel_execution_state().poison(rc);
+            return rc;
+        }
+        kernel_topology_result_ = nullptr;
+    }
     aicpu_device_occupancy_.occupy = result.occupy;
     aicpu_device_occupancy_.pf_occupy = result.pf_occupy;
     aicpu_device_occupancy_.os_sched = result.os_sched;
@@ -247,14 +269,14 @@ int DeviceRunner::query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &ou
     return 0;
 }
 
-int DeviceRunner::query_aicpu_topology(pto::a5::AicpuTopology &out) {
+int DeviceRunner::query_aicpu_topology(pto::a5::AicpuTopology &out, rtStream_t control_stream) {
     if (aicpu_topology_cached_) {
         out = aicpu_topology_;
         return 0;
     }
 
     pto::a5::AicpuDeviceOccupancy occupancy;
-    int rc = query_aicpu_device_occupancy(occupancy);
+    int rc = query_aicpu_device_occupancy(occupancy, control_stream);
     if (rc != 0) return rc;
 
     pto::a5::AicpuTopology topology;
@@ -280,6 +302,79 @@ void DeviceRunner::set_dep_gen_enabled(bool enable) {
     // device-orch one). The c_api latches the CallConfig before bind, and the
     // orchestration entry resets the graph before recording it.
     dep_gen_host_graph_set_enabled(enable);
+}
+
+int DeviceRunner::prepare_aicpu_affinity(Runtime &runtime, int requested, rtStream_t control_stream) {
+    {
+        pto::a5::AicpuTopology topology;
+        runtime.set_aicpu_allowed_cpu_count(0);
+        if (query_aicpu_topology(topology, control_stream) != 0) {
+            LOG_ERROR("AICPU topology probe failed; affinity gate will not launch");
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        pto::a5::AicpuLaunchPlan launch_plan;
+        std::string plan_error;
+        if (!pto::a5::build_aicpu_launch_plan(topology, requested, launch_plan, plan_error)) {
+            LOG_ERROR(
+                "cannot build AICPU launch plan: soc=%s scenario=%s occupy=0x%llx reason=%s",
+                topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
+                pto::a5::aicpu_scenario_name(topology.scenario_type),
+                static_cast<unsigned long long>(topology.device_occupancy.occupy), plan_error.c_str()
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+        const auto &allowed = launch_plan.allowed_cpus;
+        const int active_aicpu_num = launch_plan.effective_active_count;
+        runtime.set_aicpu_thread_num(active_aicpu_num);
+        {
+            const size_t cap = runtime.aicpu_allowed_cpus_capacity();
+            if (allowed.size() > cap) {
+                LOG_ERROR("AICPU selection returned %zu > cap %zu", allowed.size(), cap);
+                return PTO_RUNTIME_ERR_INTERNAL;
+            }
+            int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
+            for (size_t i = 0; i < allowed.size(); ++i)
+                allowed_cpus[i] = allowed[i];
+            runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
+            runtime.set_aicpu_launch_count(launch_plan.launch_count);
+            std::string dump;
+            for (size_t i = 0; i < allowed.size(); ++i) {
+                if (i) dump += ", ";
+                dump += std::to_string(allowed[i]);
+                if (i + 1 == allowed.size()) dump += "(orch)";
+            }
+            if (launch_plan.warn_cpu_topology_unavailable) {
+                LOG_WARN(
+                    "AICPU CPU_TOPO unavailable; using %s: soc=%s occupy=0x%llx "
+                    "stable_reachable=%d requested=%d effective=%d affinity=[%s]%s",
+                    pto::a5::aicpu_topology_source_name(topology.source),
+                    topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
+                    static_cast<unsigned long long>(topology.device_occupancy.occupy),
+                    launch_plan.stable_reachable_count, requested, active_aicpu_num, dump.c_str(),
+                    topology.source == pto::a5::AicpuTopologySource::kOccupyFallback ?
+                        "; physical/SMT/cluster/die placement is unknown" :
+                        ""
+                );
+            }
+            if (launch_plan.warn_stable_reachable_below_default) {
+                LOG_WARN(
+                    "AICPU stable reachable CPUs below active capacity: soc=%s scenario=%s occupy=0x%llx "
+                    "stable_reachable=%d capacity=%d requested=%d effective=%d affinity=[%s]",
+                    topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
+                    pto::a5::aicpu_scenario_name(topology.scenario_type),
+                    static_cast<unsigned long long>(topology.device_occupancy.occupy),
+                    launch_plan.stable_reachable_count, PLATFORM_DEFAULT_AICPU_THREAD_NUM, requested, active_aicpu_num,
+                    dump.c_str()
+                );
+            }
+            LOG_INFO(
+                "AICPU ALLOWED_CPUS = [%s] (scenario=%s active=%d launch=%d user_cpus=%zu)", dump.c_str(),
+                pto::a5::aicpu_scenario_name(topology.scenario_type), active_aicpu_num, launch_plan.launch_count,
+                topology.os_schedulable_cpus.size()
+            );
+        }
+    }
+    return 0;
 }
 
 int DeviceRunner::prepare_execution(
@@ -357,82 +452,9 @@ int DeviceRunner::prepare_execution(
 
     resolve_task_binary_addrs(runtime);
 
-    // a5-specific: probe the AICPU topology + compute ALLOWED_CPUS for the
-    // filter-style gate (see src/common/platform/onboard/aicpu/
-    // platform_aicpu_affinity.cpp::platform_aicpu_affinity_gate_filter).
-    // Convention: indices 0..active-2 are scheduler slots and the last slot
-    // is the orchestrator. In auto mode only, unknown shapes may reduce the
-    // active count to the available pool, but execution keeps at least one of
-    // each role.
-    {
-        pto::a5::AicpuTopology topology;
-        runtime.set_aicpu_allowed_cpu_count(0);
-        if (query_aicpu_topology(topology) != 0) {
-            LOG_ERROR("AICPU topology probe failed; affinity gate will not launch");
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        pto::a5::AicpuLaunchPlan launch_plan;
-        std::string plan_error;
-        if (!pto::a5::build_aicpu_launch_plan(topology, requested_aicpu_num, launch_plan, plan_error)) {
-            LOG_ERROR(
-                "cannot build AICPU launch plan: soc=%s scenario=%s occupy=0x%llx reason=%s",
-                topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
-                pto::a5::aicpu_scenario_name(topology.scenario_type),
-                static_cast<unsigned long long>(topology.device_occupancy.occupy), plan_error.c_str()
-            );
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        const auto &allowed = launch_plan.allowed_cpus;
-        active_aicpu_num = launch_plan.effective_active_count;
-        runtime.set_aicpu_thread_num(active_aicpu_num);
-        {
-            const size_t cap = runtime.aicpu_allowed_cpus_capacity();
-            if (allowed.size() > cap) {
-                LOG_ERROR("AICPU selection returned %zu > cap %zu", allowed.size(), cap);
-                return PTO_RUNTIME_ERR_INTERNAL;
-            }
-            int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
-            for (size_t i = 0; i < allowed.size(); ++i)
-                allowed_cpus[i] = allowed[i];
-            runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
-            runtime.set_aicpu_launch_count(launch_plan.launch_count);
-            std::string dump;
-            for (size_t i = 0; i < allowed.size(); ++i) {
-                if (i) dump += ", ";
-                dump += std::to_string(allowed[i]);
-                if (i + 1 == allowed.size()) dump += "(orch)";
-            }
-            if (launch_plan.warn_cpu_topology_unavailable) {
-                LOG_WARN(
-                    "AICPU CPU_TOPO unavailable; using %s: soc=%s occupy=0x%llx "
-                    "stable_reachable=%d requested=%d effective=%d affinity=[%s]%s",
-                    pto::a5::aicpu_topology_source_name(topology.source),
-                    topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
-                    static_cast<unsigned long long>(topology.device_occupancy.occupy),
-                    launch_plan.stable_reachable_count, requested_aicpu_num, active_aicpu_num, dump.c_str(),
-                    topology.source == pto::a5::AicpuTopologySource::kOccupyFallback ?
-                        "; physical/SMT/cluster/die placement is unknown" :
-                        ""
-                );
-            }
-            if (launch_plan.warn_stable_reachable_below_default) {
-                LOG_WARN(
-                    "AICPU stable reachable CPUs below active capacity: soc=%s scenario=%s occupy=0x%llx "
-                    "stable_reachable=%d capacity=%d requested=%d effective=%d affinity=[%s]",
-                    topology.soc_name.empty() ? "(unknown)" : topology.soc_name.c_str(),
-                    pto::a5::aicpu_scenario_name(topology.scenario_type),
-                    static_cast<unsigned long long>(topology.device_occupancy.occupy),
-                    launch_plan.stable_reachable_count, PLATFORM_DEFAULT_AICPU_THREAD_NUM, requested_aicpu_num,
-                    active_aicpu_num, dump.c_str()
-                );
-            }
-            LOG_INFO(
-                "AICPU ALLOWED_CPUS = [%s] (scenario=%s active=%d launch=%d user_cpus=%zu)", dump.c_str(),
-                pto::a5::aicpu_scenario_name(topology.scenario_type), active_aicpu_num, launch_plan.launch_count,
-                topology.os_schedulable_cpus.size()
-            );
-        }
-    }
+    rc = prepare_aicpu_affinity(runtime, requested_aicpu_num, stream_aicpu_);
+    if (rc != 0) return rc;
+    active_aicpu_num = runtime.get_aicpu_thread_num();
 
     // Initialize per-subsystem shared memory.
     //
@@ -934,6 +956,18 @@ int DeviceRunner::force_reset_device() {
 int DeviceRunner::finalize() {
     if (device_id_ == -1) {
         return 0;
+    }
+    if (execution_mode_latch().is_kernel() && kernel_topology_result_ != nullptr) {
+        int rc = rtSetDevice(device_id_);
+        if (rc != 0) return rc;
+        if (kernel_topology_stream_ != nullptr) {
+            rc = aclrtSynchronizeStreamWithTimeout(kernel_topology_stream_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+            if (rc != 0) return rc;
+            kernel_topology_stream_ = nullptr;
+        }
+        rc = mem_alloc_.free(kernel_topology_result_);
+        if (rc != 0) return rc;
+        kernel_topology_result_ = nullptr;
     }
 
     // Fatal cleanup must not walk poisoned streams, mappings, or allocations.

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -120,6 +120,12 @@ public:
      */
     int finalize() override;
 
+    /**
+     * a5 fills the per-core register table only: it has no ffts_base_addr
+     * field. The table is allocated on `mem_alloc_`.
+     */
+    int fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) override;
+
     // `upload_chip_callable_buffer`, `register_callable`,
     // `record_host_orch_callable`, `unregister_callable`, `has_callable`,
     // `bind_callable_to_runtime`, `aicpu_dlopen_count`, and

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -76,6 +76,7 @@ class DeviceRunner : public DeviceRunnerBase {
 public:
     DeviceRunner() = default;
     ~DeviceRunner();
+    int prepare_aicpu_affinity(Runtime &runtime, int requested, rtStream_t control_stream) override;
 
     // `setup_static_arena`, `allocate_tensor`, `free_tensor`,
     // `copy_to_device`, `copy_from_device`,
@@ -291,14 +292,17 @@ private:
     // dep_gen enablement is a5-specific (a2a3 carries its own copy).
     bool enable_dep_gen_{false};
 
-    int query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &out);
-    int query_aicpu_topology(pto::a5::AicpuTopology &out);
+    int query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &out, rtStream_t control_stream);
+    int query_aicpu_topology(pto::a5::AicpuTopology &out, rtStream_t control_stream);
     void clear_aicpu_topology_cache();
     // Device-side occupancy and the merged Host topology are immutable during
     // one DeviceRunner attach/reset lifetime. Cache successful probes only;
     // allowed CPU selection still runs per call because the requested active
     // count may change. Recovery, reset, and finalize clear both values.
     bool aicpu_device_occupancy_cached_{false};
+    // A failed kernel query retains its output until its own stream drains.
+    void *kernel_topology_result_{nullptr};
+    rtStream_t kernel_topology_stream_{nullptr};
     pto::a5::AicpuDeviceOccupancy aicpu_device_occupancy_{};
     bool aicpu_topology_cached_{false};
     pto::a5::AicpuTopology aicpu_topology_{};

--- a/src/a5/platform/onboard/host/host_regs.cpp
+++ b/src/a5/platform/onboard/host/host_regs.cpp
@@ -127,10 +127,11 @@ int init_aicore_register_addresses(uint64_t *runtime_regs_ptr, uint64_t device_i
     }
 
     // Step 3: Copy register addresses to device memory
+    *runtime_regs_ptr = reinterpret_cast<uint64_t>(reg_ptr);
     int ret = rtMemcpy(reg_ptr, regs_size, host_regs.data(), regs_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (ret != 0) {
         LOG_ERROR("Failed to copy register addresses to device (rc=%d)", ret);
-        allocator.free(reg_ptr);
+        if (allocator.free(reg_ptr) == 0) *runtime_regs_ptr = 0;
         return PTO_RUNTIME_ERR_INTERNAL;
     }
 

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -83,6 +83,7 @@
 #include "host_log.h"
 #include "host/platform_compile_info.h"
 #include "host/raii_scope_guard.h"
+#include "host/kernel_pipeline_contract.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -103,6 +104,10 @@ static_assert(
         SCHEDULER_PROFILING_SCHED_PHASES_LEVEL == static_cast<uint64_t>(ChipSwimlaneLevel::SCHED_PHASES),
     "AICore Scheduler profiling levels must match the chip-swimlane contract"
 );
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *, PipelineContract *) {
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
 
 extern "C" const PipelineContract *get_pipeline_contract(void) {
     // Host orchestration materializes this run's own graph into the image it

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -105,6 +105,8 @@ static_assert(
     "AICore Scheduler profiling levels must match the chip-swimlane contract"
 );
 
+int configure_kernel_runtime_impl(Runtime &, bool) { return PTO_RUNTIME_ERR_UNSUPPORTED; }
+
 extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *, PipelineContract *) {
     return PTO_RUNTIME_ERR_UNSUPPORTED;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -62,6 +62,9 @@
 
 // Scheduler context class
 #include "scheduler/scheduler_context.h"
+#include "tensormap_and_ringbuffer/kernel_execution_inputs.h"
+
+using simpler::tmr::ExecutionInputs;
 
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's RuntimeContext into orchestration TLS
@@ -79,12 +82,7 @@ extern "C" void framework_bind_runtime(RuntimeContext *rt);
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
 
-static int32_t read_runtime_status(Runtime *runtime) {
-    if (runtime == nullptr) {
-        return 0;
-    }
-
-    void *sm = runtime->get_gm_sm_ptr();
+static int32_t read_runtime_status(void *sm) {
     if (sm == nullptr) {
         return 0;
     }
@@ -151,6 +149,7 @@ struct AicpuExecutor {
     // Entry-arg ChipTaskArgs built (via create_from_entry_storage) from get_orch_args()
     // before scheduler init; consumed by the (*p_func)(orch_args_cached_) below.
     ChipTaskArgs orch_args_cached_;
+    simpler::tmr::KernelInvocationState kernel_invocation_;
 
     // Per-callable_id table. Single orch thread today, so first-write/read
     // race is not possible; if multiple orch threads are ever introduced,
@@ -161,7 +160,7 @@ struct AicpuExecutor {
     SchedulerContext sched_ctx_;
 
     // ===== Methods =====
-    int32_t init(Runtime *runtime);
+    int32_t init(Runtime *runtime, const ExecutionInputs &inputs);
     // (Re)load a callable's orchestration SO into orch_so_table_[callable_id].
     // Register-only: the register_callable entry calls this to dlopen and
     // populate the slot. The run path never loads — it consumes an already
@@ -170,8 +169,8 @@ struct AicpuExecutor {
         int32_t callable_id, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size, const char *entry_symbol,
         const char *config_symbol, int32_t thread_idx
     );
-    int32_t run(Runtime *runtime);
-    void deinit(Runtime *runtime);
+    int32_t run(Runtime *runtime, const ExecutionInputs &inputs);
+    void deinit(Runtime *runtime, bool invalidate_host_image);
 
     ~AicpuExecutor() {
         // Process-wide teardown (the single static instance dies here). Every
@@ -198,7 +197,7 @@ static_assert(
 
 // ===== AicpuExecutor Method Implementations =====
 
-int32_t AicpuExecutor::init(Runtime *runtime) {
+int32_t AicpuExecutor::init(Runtime *runtime, const ExecutionInputs &inputs) {
     if (runtime == nullptr) {
         LOG_ERROR("runtime is nullptr");
         init_failed_.store(true, std::memory_order_release);
@@ -247,7 +246,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         serial_orch_sched_ = runtime->dev.serial_orch_sched;
 
         hs_arrived_.store(0, std::memory_order_relaxed);
-        if (sched_ctx_.pre_handshake_init(runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs()) != 0) {
+        if (sched_ctx_.pre_handshake_init(
+                runtime, aicpu_thread_num_, sched_thread_num_, get_platform_regs(), inputs.functions, inputs.sm
+            ) != 0) {
             init_failed_.store(true, std::memory_order_release);
             hs_setup_done_.store(true, std::memory_order_release);
             return -1;
@@ -329,7 +330,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     if (is_leader) {
         while (hs_arrived_.load(std::memory_order_acquire) < hs_nthreads) {}
         finished_count_.store(0, std::memory_order_release);
-        if (sched_ctx_.post_handshake_init(runtime) != 0) {
+        if (sched_ctx_.post_handshake_init(runtime, inputs.functions) != 0) {
             init_failed_.store(true, std::memory_order_release);
             init_done_.store(true, std::memory_order_release);
             return -1;
@@ -488,7 +489,7 @@ int32_t AicpuExecutor::load_orch_so(
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::run(Runtime *runtime) {
+int32_t AicpuExecutor::run(Runtime *runtime, const ExecutionInputs &inputs) {
     // Prefer the filter gate's deterministic exec_idx so role assignment
     // (sched 0..N-2 / orch N-1) is driven by host-computed ALLOWED_CPUS,
     // not arrival order. Fall back to the legacy fetch-add counter on
@@ -531,7 +532,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // register_callable entry. The run path only consumes it — it never
             // loads. A missing handle means run was reached without a prior
             // successful registration, which is a caller/scheduling bug.
-            const int32_t callable_id = runtime->get_active_callable_id();
+            const int32_t callable_id = inputs.callable_id;
             if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
                 LOG_ERROR(
                     "Thread %d: invalid callable_id %d (limit=%d)", thread_idx, callable_id, MAX_REGISTERED_CALLABLE_IDS
@@ -564,37 +565,16 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 p_bind = &entry.bind;
                 DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
 
-                // Build the entry-arg once per run; both the config call below and
-                // the orchestration entry (consumed at orch_args_cached_) use it.
-                orch_args_cached_.create_from_entry_storage(runtime->get_orch_args());
-
-                // Validate arg count on every run against the registered SO.
-                if (*p_config_func != nullptr) {
-                    OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
-                    LOG_DEBUG("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
-                    if (cfg.expected_arg_count > 0) {
-                        const simpler::tmr::EntryArgsStorage &args_validate = runtime->get_orch_args();
-                        int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
-                        if (actual_arg_count < cfg.expected_arg_count) {
-                            LOG_ERROR(
-                                "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
-                                cfg.expected_arg_count
-                            );
-                            // The registered SO is fine — these run args are
-                            // incompatible with it. Run only consumes the slot
-                            // (no reload), so leave the table intact and just
-                            // fail this run; unblock scheduler threads first so
-                            // they don't spin forever.
-                            runtime_init_ready_.store(true, std::memory_order_release);
-                            return -1;
-                        }
-                    }
+                if (!simpler::tmr::configure_orchestration_args(inputs, orch_args_cached_, *p_config_func)) {
+                    LOG_ERROR("Thread %d: invocation argument count does not match callable", thread_idx);
+                    runtime_init_ready_.store(true, std::memory_order_release);
+                    return -1;
                 }
 
                 // sm_handle / rt are bound to *this* run's memory and must be
                 // (re)created every run, regardless of whether the SO itself was
                 // reused above.
-                sm_ptr = runtime->get_gm_sm_ptr();
+                sm_ptr = inputs.sm;
             }
 
             // Prebuilt-arena fast path. Host uploads the runtime arena image
@@ -602,8 +582,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // re-wires arena-internal pointers to device addresses below.
             {
                 AicpuPhaseScope arena_wire(AicpuPhase::ArenaWire);
-                void *prebuilt_arena = runtime->get_prebuilt_arena_base();
-                size_t off_runtime = runtime->get_prebuilt_runtime_offset();
+                void *prebuilt_arena = inputs.arena;
+                size_t off_runtime = inputs.runtime_offset;
                 if (prebuilt_arena == nullptr) {
                     LOG_ERROR("Thread %d: prebuilt_arena_base is null", thread_idx);
                     runtime_init_ready_.store(true, std::memory_order_release);
@@ -895,7 +875,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // every subsequent run.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
-            const int32_t callable_id = runtime->get_active_callable_id();
+            const int32_t callable_id = inputs.callable_id;
             framework_bind_runtime(nullptr);
             if (callable_id >= 0 && callable_id < MAX_REGISTERED_CALLABLE_IDS) {
                 DeviceOrchestrationBindRuntimeFunc bind = orch_so_table_[callable_id].bind;
@@ -911,7 +891,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     return run_rc;
 }
 
-void AicpuExecutor::deinit(Runtime * /*runtime*/) {
+void AicpuExecutor::deinit(Runtime * /*runtime*/, bool /*invalidate_host_image*/) {
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();
 
@@ -945,6 +925,39 @@ void AicpuExecutor::deinit(Runtime * /*runtime*/) {
 
     LOG_INFO("DeInit: AicpuExecutor reset complete");
 }
+
+namespace simpler::tmr {
+
+InvocationStatus
+admit_kernel_execution(ByteSpan packet, const KernelCallableView &callable, const KernelBindingView &binding) noexcept {
+    return g_aicpu_executor.kernel_invocation_.admit(packet, callable, binding);
+}
+
+int32_t init_kernel_execution() {
+    const auto &state = g_aicpu_executor.kernel_invocation_;
+    if (!state.active()) return -1;
+    return g_aicpu_executor.init(state.resident(), state.inputs());
+}
+
+int32_t run_kernel_execution() {
+    const auto &state = g_aicpu_executor.kernel_invocation_;
+    if (!state.active()) return -1;
+    return g_aicpu_executor.run(state.resident(), state.inputs());
+}
+
+int32_t kernel_execution_status() {
+    const auto &state = g_aicpu_executor.kernel_invocation_;
+    return state.active() ? read_runtime_status(state.inputs().sm) : -1;
+}
+
+void release_kernel_execution() {
+    auto &state = g_aicpu_executor.kernel_invocation_;
+    if (!state.active()) return;
+    g_aicpu_executor.deinit(state.resident(), false);
+    state.clear();
+}
+
+}  // namespace simpler::tmr
 
 // ===== Public Entry Point =====
 
@@ -1003,7 +1016,7 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
         // init() barriers every thread internally until init is complete on the
         // leader (or a thread failed), then returns the status — so a non-zero
         // return is authoritative on all threads and no extra spin is needed.
-        if (g_aicpu_executor.init(runtime) != 0) {
+        if (g_aicpu_executor.init(runtime, simpler::tmr::program_execution_inputs(*runtime)) != 0) {
             LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
             return -1;
         }
@@ -1012,7 +1025,7 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     int32_t rc = 0;
     {
         AicpuPhaseScope graph_build(AicpuPhase::GraphBuild);
-        rc = g_aicpu_executor.run(runtime);
+        rc = g_aicpu_executor.run(runtime, simpler::tmr::program_execution_inputs(*runtime));
     }
     if (rc != 0) {
         LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
@@ -1026,11 +1039,11 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     // sched overlap into post_orch — inflating it well past the actual teardown.
     // read_runtime_status is two atomic loads every thread needs, so it stays
     // outside the scope.
-    int32_t runtime_rc = read_runtime_status(runtime);
+    int32_t runtime_rc = read_runtime_status(runtime->get_gm_sm_ptr());
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
         AicpuPhaseScope post_orch(AicpuPhase::PostOrch);
         LOG_INFO("aicpu_execute: Last thread finished, cleaning up");
-        g_aicpu_executor.deinit(runtime);
+        g_aicpu_executor.deinit(runtime, true);
     }
 
     if (runtime_rc != 0) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -492,6 +492,11 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
     return true;
 }
 
+int configure_kernel_runtime_impl(Runtime &runtime, bool serial_orch_sched) {
+    runtime.dev.serial_orch_sched = serial_orch_sched;
+    return 0;
+}
+
 extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out) {
     if (config == nullptr || out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -52,6 +52,8 @@
 #include "common/strace.h"
 #include "common/unified_log.h"
 #include "host/platform_compile_info.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "host/raii_scope_guard.h"
 #include "common/host_api.h"
 #include "utils/device_arena.h"
@@ -488,6 +490,52 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
     }
     out->sm_size = SharedMemoryHandle::calculate_size_per_ring(sizing.task_window_sizes);
     return true;
+}
+
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out) {
+    if (config == nullptr || out == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+
+    ArenaSizingConfig sizing;
+    if (!resolve_arena_sizing(
+            config->runtime_env.ring_task_window, config->runtime_env.ring_heap, config->runtime_env.ring_dep_pool,
+            &sizing
+        )) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    uint64_t total_window = 0;
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r)
+        total_window += sizing.task_window_sizes[r];
+    // OrchestratorLayout stores the sum in int32_t and asserts before narrowing.
+    if (total_window > static_cast<uint64_t>(INT32_MAX)) return PTO_RUNTIME_ERR_INTERNAL;
+
+    // Layout has a fixed number of regions; window/dep counts are int32-bounded.
+    // Their reserve-only size arithmetic requires the platform's 64-bit size_t.
+    static_assert(sizeof(size_t) == sizeof(uint64_t));
+    ArenaStaticSizes sizes;
+    if (!derive_arena_static_sizes(sizing, &sizes)) return PTO_RUNTIME_ERR_INTERNAL;
+    constexpr size_t max_usable = std::numeric_limits<size_t>::max() - (DeviceArena::kDefaultBaseAlign - 1);
+    if (sizes.total_heap > max_usable || sizes.sm_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+    DeviceArena arena;
+    const auto layout =
+        runtime_reserve_layout(arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
+    if (layout.offsets.arena_size > max_usable) return PTO_RUNTIME_ERR_INTERNAL;
+
+    const PipelineContract candidate = {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        1,
+        {
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, sizes.total_heap},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, sizes.sm_size},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, layout.offsets.arena_size},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+    if (!is_valid_tmr_kernel_pipeline_contract(&candidate)) return PTO_RUNTIME_ERR_INTERNAL;
+    *out = candidate;
+    return 0;
 }
 
 // per-run: the only signature-aware step. Copy the orch args, replacing each

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1081,6 +1081,17 @@ int32_t SchedulerContext::pre_handshake_init(
     Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base
 ) {
     always_assert(runtime != nullptr);
+    return pre_handshake_init(
+        runtime, aicpu_thread_num, sched_thread_num, regs_base, {runtime->dev.func_id_to_addr_, RUNTIME_MAX_FUNC_ID},
+        runtime->get_gm_sm_ptr()
+    );
+}
+
+int32_t SchedulerContext::pre_handshake_init(
+    Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base,
+    simpler::tmr::CallableTableView functions, void *sm
+) {
+    always_assert(runtime != nullptr);
 
     // Zero all per-core execution state before handshake
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
@@ -1158,14 +1169,14 @@ int32_t SchedulerContext::pre_handshake_init(
     // released to dispatch.
     completed_tasks_.store(0, std::memory_order_release);
     orchestrator_done_.store(false, std::memory_order_release);
-    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    functions_ = functions;
 
     // total_tasks_ must be read before hs_setup_done_ is published: on the
     // decoupled path the orchestrator resets the SM as soon as it observes
     // hs_setup_done_, which zeroes these ring counters, so the read completes here
     // (on the leader, before any thread is released) rather than post-handshake.
-    if (runtime->get_gm_sm_ptr()) {
-        auto *header = static_cast<SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
+    if (sm) {
+        auto *header = static_cast<SharedMemoryHeader *>(sm);
         int64_t task_count = 0;
         for (int r = 0; r < CHIP_MAX_RING_DEPTH; r++) {
             int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
@@ -1181,6 +1192,10 @@ int32_t SchedulerContext::pre_handshake_init(
 }
 
 int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
+    return post_handshake_init(runtime, {runtime->dev.func_id_to_addr_, RUNTIME_MAX_FUNC_ID});
+}
+
+int32_t SchedulerContext::post_handshake_init(Runtime *runtime, simpler::tmr::CallableTableView functions) {
     if (handshake_failed_.load(std::memory_order_acquire)) {
         emergency_shutdown(runtime);
         return -1;
@@ -1281,7 +1296,7 @@ int32_t SchedulerContext::post_handshake_init(Runtime *runtime) {
         }
     }
 
-    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
+    functions_ = functions;
 
     return 0;
 }
@@ -1336,7 +1351,7 @@ void SchedulerContext::deinit() {
     regs_ = 0;
     sched_ = nullptr;
     rt_ = nullptr;
-    func_id_to_addr_ = nullptr;
+    functions_ = {};
 }
 
 void SchedulerContext::bind_runtime(RuntimeContext *rt) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -539,6 +539,7 @@ SchedulerContext::SyncStartStageResult SchedulerContext::stage_sync_start_cores(
 #endif
             uint64_t my_mask[EARLY_DISPATCH_CORE_MASK_WORDS] = {0};
             for (int i = 0; i < handle_count; i++) {
+                if (!handles[i].valid) continue;
                 publish_subtask_to_core(handles[i], dispatch_ts, thread_idx);
                 if (gated) {
                     int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -32,6 +32,8 @@
 #endif
 
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
+#include "tensormap_and_ringbuffer/callable_table_view.h"
+
 class Runtime;
 struct Handshake;
 struct RuntimeContext;
@@ -67,6 +69,10 @@ public:
     // success, negative on failure.
     int32_t
     pre_handshake_init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base);
+    int32_t pre_handshake_init(
+        Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, uint64_t regs_base,
+        simpler::tmr::CallableTableView functions, void *sm
+    );
     // All threads: handshake this thread's contiguous slice [lo, hi) of cores
     // (partitioned by tidx/nthreads). Each core is touched by exactly one thread.
     void handshake_partition(Runtime *runtime, int32_t tidx, int32_t nthreads);
@@ -90,6 +96,7 @@ public:
     // Leader-only, after the handshake barrier: build worker-id lists, assign
     // cores, init profiling subsystems, read task counts, init payloads.
     int32_t post_handshake_init(Runtime *runtime);
+    int32_t post_handshake_init(Runtime *runtime, simpler::tmr::CallableTableView functions);
 
     // Reset all SchedulerContext-owned state to its post-construction defaults.
     // Called by AicpuExecutor::deinit() during per-run teardown.
@@ -179,7 +186,7 @@ private:
     // be submitted; schedulers poll it.
     std::atomic<bool> orchestrator_done_{false};
     std::atomic<bool> completed_{false};
-    uint64_t *func_id_to_addr_{nullptr};
+    simpler::tmr::CallableTableView functions_{};
 
     // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};
@@ -251,7 +258,7 @@ private:
         ChipReadyQueue *queues, ResourceShape shape, int32_t thread_idx, ChipTaskSlotState **out, int max_count
     );
 
-    void build_payload(
+    bool build_payload(
         DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, SubtaskSlot subslot, int32_t block_idx,
         bool force_gate = false
     );
@@ -271,6 +278,7 @@ private:
         int32_t core_offset;
         uint64_t *dispatch_timestamp_slot;
         int32_t task_timing_slot;  // TASK_TIMING_SLOT_NONE unless the task is tagged
+        bool valid{false};
     };
 
     PublishHandle prepare_subtask_to_core(
@@ -281,6 +289,7 @@ private:
     // `thread_idx` is the publishing Scheduler thread's index, used to select the
     // per-thread task-timing record; every call site already has it in scope.
     inline void publish_subtask_to_core(const PublishHandle &h, uint64_t dispatch_ts, int32_t thread_idx) {
+        if (!h.valid) return;
         if (h.dispatch_timestamp_slot != nullptr) {
             *h.dispatch_timestamp_slot = dispatch_ts;
         }
@@ -479,13 +488,7 @@ private:
     // Small inline helpers
     // =========================================================================
 
-    uint64_t get_function_bin_addr(int func_id) const {
-        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-            LOG_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
-            return 0;
-        }
-        return func_id_to_addr_[func_id];
-    }
+    uint64_t get_function_bin_addr(int func_id) const { return functions_.lookup(func_id); }
 };
 
 #endif  // SCHEDULER_CONTEXT_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -111,13 +111,15 @@ int SchedulerContext::pop_ready_tasks_batch(
     return count;
 }
 
-void SchedulerContext::build_payload(
+bool SchedulerContext::build_payload(
     DispatchPayload &dispatch_payload, ChipTaskSlotState &slot_state, SubtaskSlot subslot, int32_t block_idx,
     bool force_gate
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
     uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
+    if (callable_addr == 0 || callable_addr % alignof(CoreCallable) != 0) return false;
     const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
+    if (callable->resolved_addr() == 0) return false;
     dispatch_payload.function_bin_addr = callable->resolved_addr();
     auto &payload = *slot_state.payload;
     if (SchedulerState::should_gate_early_dispatch(
@@ -137,6 +139,7 @@ void SchedulerContext::build_payload(
     dispatch_payload.local_context.s_block_idx = block_idx;
     dispatch_payload.local_context.s_block_num = slot_state.logical_block_num;
     dispatch_payload.local_context.async_ctx.task_token = slot_state.task->task_id;
+    return true;
 }
 
 SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
@@ -159,7 +162,13 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    build_payload(payload, slot_state, subslot, block_idx, force_gate);
+    if (!build_payload(payload, slot_state, subslot, block_idx, force_gate)) {
+        int32_t expected = SIMPLER_ERROR_NONE;
+        sched_->sm_header->sched_error_code.compare_exchange_strong(
+            expected, SIMPLER_ERROR_INVALID_ARGS, std::memory_order_acq_rel
+        );
+        return {};
+    }
 
     if (to_pending) {
         core_exec_state.pending_subslot = subslot;
@@ -200,9 +209,12 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
     }
 #endif
 
-    return PublishHandle{
-        core_exec_state.reg_addr, reg_task_id, core_offset, dispatch_timestamp_slot, slot_state.task_attrs.timing_slot()
-    };
+    return PublishHandle{core_exec_state.reg_addr,
+                         reg_task_id,
+                         core_offset,
+                         dispatch_timestamp_slot,
+                         slot_state.task_attrs.timing_slot(),
+                         true};
 }
 
 int SchedulerContext::prepare_block_for_dispatch(
@@ -619,6 +631,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
     if (n > 0) {
         wmb();
         for (int i = 0; i < n; i++) {
+            if (!handles[i].valid) continue;
             publish_subtask_to_core(handles[i], early_dispatch_ts, thread_idx);
             int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
             sched_->early_dispatch_doorbell_table[cid].addr = handles[i].reg_addr;
@@ -648,6 +661,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
             }
         }
         for (int i = 0; i < n; i++) {
+            if (!handles[i].valid) continue;
             int32_t cid = tracker.get_core_id_by_offset(handles[i].core_offset);
             SchedulerState::ring_claimed_local_doorbell(
                 owned[cid >> 6], cid, handles[i].reg_addr, handles[i].reg_task_id

--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -450,7 +450,8 @@ public:
      *
      * Drains recycled/done/ready first (just discards — release goes via
      * dev_to_host_ to avoid double-free) and then iterates the full mapping
-     * table. Each unique allocation base is released exactly once.
+     * table. Each unique allocation base is released exactly once, in no
+     * specified order.
      */
     template <typename ReleaseFn>
     void release_all_owned(const ReleaseFn &release_fn) {
@@ -479,7 +480,6 @@ public:
                 }
             }
         }
-        std::sort(release_order.begin(), release_order.end(), std::less<void *>{});
         for (void *p : release_order) {
             release_fn(p);
         }
@@ -693,7 +693,7 @@ public:
     void notify_ready_waiters() {
         for (int shard_index = 0; shard_index < shard_count_; shard_index++) {
             auto &shard = ready_shards_[shard_index];
-            std::lock_guard<std::mutex> lock(shard.wait_mutex);
+            std::scoped_lock<std::mutex> lock(shard.wait_mutex);
             shard.cv.notify_all();
         }
     }

--- a/src/common/platform/include/host/execution_mode_latch.h
+++ b/src/common/platform/include/host/execution_mode_latch.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include "execution_mode.h"
+#include "runtime_c_api.h"
+
+/**
+ * Write-once execution identity of one device context.
+ *
+ * A context's mode is a property of its construction, not a state that
+ * evolves: the C ABI creates contexts mode-less (`create_device_context`
+ * takes no parameters), so the first init entry to run completes the
+ * construction by latching the mode, and the latch never changes afterwards
+ * — not on finalize, not on error. `simpler_init` latches PROGRAM before
+ * touching any runner state, so a live program context is never unlatched
+ * and the program/kernel mutual exclusion is enforced on every init, not by
+ * anyone remembering a separate claim step. Re-initializing a finalized
+ * context under the same mode stays possible (latching the held mode is
+ * idempotent); changing a context's identity is not. That permission is real
+ * for PROGRAM, whose finalize resets device_id_ to -1; for KERNEL the latch
+ * would allow the re-latch but KernelExecutionState's phase machine refuses
+ * the re-init, since close() leaves the phase Closed and initialize() accepts
+ * only New.
+ *
+ * There is no unlatch and no rollback: an init that fails after latching
+ * leaves the context on that identity permanently, so a handle from a failed
+ * kernel init can never be recycled into a program context. Latching is
+ * therefore the step an init takes once it has decided which identity it is
+ * constructing, and an init that adopts device state must roll that state
+ * back itself.
+ *
+ * Every kernel-mode guard keys on is_kernel(), which is false until an init
+ * latches KERNEL — so the guards arm exactly when a kernel context comes
+ * into existence.
+ */
+class ExecutionModeLatch {
+public:
+    /** Latch the identity. Idempotent for the held mode; a different mode
+        returns PTO_RUNTIME_ERR_INVALID_STATE. */
+    int latch(SimplerExecutionMode mode) {
+        std::scoped_lock lock(mutex_);
+        if (latched_ && mode_ != mode) return PTO_RUNTIME_ERR_INVALID_STATE;
+        mode_ = mode;
+        latched_ = true;
+        return 0;
+    }
+
+    bool is_kernel() const {
+        std::scoped_lock lock(mutex_);
+        return latched_ && mode_ == SIMPLER_MODE_KERNEL;
+    }
+
+    bool is_latched() const {
+        std::scoped_lock lock(mutex_);
+        return latched_;
+    }
+
+    /** The held mode; meaningful only once is_latched(). */
+    SimplerExecutionMode latched_mode() const {
+        std::scoped_lock lock(mutex_);
+        return mode_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    bool latched_{false};
+    SimplerExecutionMode mode_{SIMPLER_MODE_PROGRAM};
+};

--- a/src/common/platform/include/host/kernel_entry_validation.h
+++ b/src/common/platform/include/host/kernel_entry_validation.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "callable.h"
+#include "callable_protocol.h"
+#include "runtime_c_api.h"
+
+/**
+ * Structural argument validation shared by every host-runtime component's
+ * kernel-mode entries. Both platform c_api implementations (onboard and sim)
+ * route through these checks, so a stub and a real implementation accept and
+ * reject exactly the same arguments — the same parity rule the shared phase
+ * machine follows. Each function returns 0 or PTO_RUNTIME_ERR_INTERNAL and
+ * mutates nothing; logging stays with the callers.
+ */
+
+/* A binary buffer and its size describe one object, so they are valid only
+   present-together or absent-together. */
+inline bool kernel_binary_span_is_consistent(const void *binary, size_t size) {
+    return (binary == nullptr) == (size == 0);
+}
+
+inline int validate_kernel_init_args(
+    const void *ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
+    size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size, const void *config,
+    uint64_t context_generation
+) {
+    if (ctx == nullptr || config == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (device_id < 0 || context_generation == 0) return PTO_RUNTIME_ERR_INTERNAL;
+    if (!kernel_binary_span_is_consistent(aicpu_binary, aicpu_size) ||
+        !kernel_binary_span_is_consistent(aicore_binary, aicore_size) ||
+        !kernel_binary_span_is_consistent(dispatcher_binary, dispatcher_size)) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    return 0;
+}
+
+inline int validate_kernel_prepare_callable_args(
+    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size, const void *caller_stream
+) {
+    if (ctx == nullptr || callable == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_size < sizeof(ChipCallable)) return PTO_RUNTIME_ERR_INTERNAL;
+    /* ChipCallable's storage_ is CALLABLE_CHILD_ALIGN-aligned relative to the
+       header, so a misaligned image puts every child at a misaligned address. */
+    if (reinterpret_cast<uintptr_t>(callable) % alignof(ChipCallable) != 0) return PTO_RUNTIME_ERR_INTERNAL;
+    return 0;
+}
+
+inline int
+validate_kernel_launch_args(const void *ctx, int32_t callable_id, const void *args, const void *caller_stream) {
+    if (ctx == nullptr || args == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
+    return 0;
+}

--- a/src/common/platform/include/host/kernel_entry_validation.h
+++ b/src/common/platform/include/host/kernel_entry_validation.h
@@ -13,9 +13,11 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <cstring>
 
 #include "callable.h"
 #include "callable_protocol.h"
+#include "kernel_invocation_validation.h"
 #include "runtime_c_api.h"
 
 /**
@@ -49,14 +51,53 @@ inline int validate_kernel_init_args(
 }
 
 inline int validate_kernel_prepare_callable_args(
-    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size, const void *caller_stream
+    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
-    if (ctx == nullptr || callable == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (ctx == nullptr || callable == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
     if (callable_size < sizeof(ChipCallable)) return PTO_RUNTIME_ERR_INTERNAL;
     /* ChipCallable's storage_ is CALLABLE_CHILD_ALIGN-aligned relative to the
        header, so a misaligned image puts every child at a misaligned address. */
     if (reinterpret_cast<uintptr_t>(callable) % alignof(ChipCallable) != 0) return PTO_RUNTIME_ERR_INTERNAL;
+    const auto *bytes = static_cast<const uint8_t *>(callable);
+    int32_t sig_count = 0;
+    int32_t cached_scalars = 0;
+    std::memcpy(&sig_count, bytes + offsetof(ChipCallable, sig_count_), sizeof(sig_count));
+    std::memcpy(&cached_scalars, bytes + offsetof(ChipCallable, scalar_count_), sizeof(cached_scalars));
+    int32_t tensors = 0;
+    int32_t scalars = 0;
+    const auto *signature = reinterpret_cast<const ArgDirection *>(bytes + offsetof(ChipCallable, signature_));
+    if (simpler::kernel::derive_invocation_counts(signature, sig_count, cached_scalars, &tensors, &scalars) !=
+        simpler::kernel::InvocationStatus::Ok)
+        return PTO_RUNTIME_ERR_INTERNAL;
+
+    const auto *image = static_cast<const ChipCallable *>(callable);
+    const auto valid_name = [](const char *name, uint32_t length) {
+        return length < CALLABLE_FUNC_NAME_MAX && name[length] == '\0' && std::memchr(name, '\0', length) == nullptr;
+    };
+    if (!valid_name(image->func_name_, image->func_name_len_) ||
+        !valid_name(image->config_name_, image->config_name_len_))
+        return PTO_RUNTIME_ERR_INTERNAL;
+    const size_t storage_size = callable_size - offsetof(ChipCallable, storage_);
+    size_t used = image->binary_size_;
+    constexpr size_t max_children = sizeof(image->child_offsets_) / sizeof(image->child_offsets_[0]);
+    if (used > storage_size || image->child_count_ < 0 || static_cast<size_t>(image->child_count_) > max_children)
+        return PTO_RUNTIME_ERR_INTERNAL;
+    for (int32_t i = 0; i < image->child_count_; ++i) {
+        const size_t offset = image->child_offsets_[i];
+        // Canonical child packing starts at the next aligned byte after
+        // the preceding binary; subtraction precedes every span read.
+        const size_t padding = (CALLABLE_ALIGN - used % CALLABLE_ALIGN) % CALLABLE_ALIGN;
+        if (padding > storage_size - used || offset != used + padding ||
+            CoreCallable::binary_data_offset() > storage_size - offset)
+            return PTO_RUNTIME_ERR_INTERNAL;
+        const auto *child = reinterpret_cast<const CoreCallable *>(image->storage_ + offset);
+        if (child->sig_count_ < 0 || child->sig_count_ > CORE_MAX_TENSOR_ARGS) return PTO_RUNTIME_ERR_INTERNAL;
+        const size_t binary_offset = offset + CoreCallable::binary_data_offset();
+        if (child->binary_size_ > storage_size - binary_offset) return PTO_RUNTIME_ERR_INTERNAL;
+        used = binary_offset + child->binary_size_;
+    }
+    if (used != storage_size) return PTO_RUNTIME_ERR_INTERNAL;
     return 0;
 }
 

--- a/src/common/platform/include/host/kernel_execution_state.h
+++ b/src/common/platform/include/host/kernel_execution_state.h
@@ -33,7 +33,14 @@ struct KernelContextOps {
     int (*get_current_device)(void *context, int *device_id){nullptr};
     int (*create_hidden_stream)(void *context, void **stream){nullptr};
     int (*destroy_hidden_stream)(void *context, void *stream){nullptr};
-    int (*create_event)(void *context, void **event){nullptr};
+    /**
+     * Creation flag every context event is born with, forwarded verbatim to
+     * create_event. The platform constant it carries is knowledge of whoever
+     * builds this table; KernelExecutionState only relays it, so a host-only
+     * test observes the flag the platform actually asked for.
+     */
+    uint32_t event_flag{0};
+    int (*create_event)(void *context, uint32_t flag, void **event){nullptr};
     int (*destroy_event)(void *context, void *event){nullptr};
 
     bool valid() const {
@@ -79,24 +86,39 @@ enum class KernelContextPhase : uint8_t {
     Closed,
 };
 
+/**
+ * The two streams a context creates and owns. Only Aicore is hidden in the
+ * capture sense; Aicpu is a dedicated private stream. Neither is the caller's.
+ */
 enum class KernelStreamKind : size_t {
     Aicpu = 0,
     Aicore,
     Count,
 };
 
+/**
+ * One event per edge of the chained caller ↔ aicpu ↔ aicore synchronization,
+ * plus the call tail. Caller and aicore are never adjacent, so no event joins
+ * them directly.
+ *
+ * AicoreStart is recorded on the aicpu stream *before* the AICPU launch: the
+ * AICPU orchestrator spins on AICore's handshake report, so an AicoreStart
+ * recorded after the launch could only fire once the AICPU task completed,
+ * which is a deadlock.
+ */
 enum class KernelEventKind : size_t {
-    PrepareTail = 0,
-    Start,
-    AicoreDone,
-    SerialTail,
+    Start = 0,   /* caller → aicpu fork */
+    AicoreStart, /* aicpu → aicore fork */
+    AicoreDone,  /* aicore → aicpu join */
+    AicpuDone,   /* aicpu → caller join */
+    SerialTail,  /* caller-visible call tail; the stream-switch gate reads it */
     Count,
 };
 
 /**
  * Context-lifetime state for the borrowed kernel execution mode.
  *
- * This object owns the persistent hidden stream pair and event set; every
+ * This object owns the dedicated AICPU stream, hidden AICore stream and event set; every
  * graph-visible persistent execution resource belongs here rather than in a
  * per-invocation object. The caller stream is never stored or destroyed —
  * each launch receives it as a borrowed argument.
@@ -126,9 +148,9 @@ enum class KernelEventKind : size_t {
  * The destructor performs no runtime calls. If a caller skips explicit close
  * while an ACLGraph can still reference these handles, freeing them would be
  * a use-after-free, so the handles leak instead. Refusing to destroy an
- * unclosed kernel runner is the public C API's half of that contract;
- * destroy_device_context refuses only on an outstanding native run, so that
- * refusal does not yet cover an unclosed kernel runner.
+ * unclosed kernel runner is the public C API's half of that contract:
+ * destroy_device_context refuses while this object owns stream/event handles
+ * or the runner has an outstanding native run.
  */
 class KernelExecutionState {
 public:

--- a/src/common/platform/include/host/kernel_execution_state.h
+++ b/src/common/platform/include/host/kernel_execution_state.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+#include "runtime_c_api.h"
+
+/**
+ * Runtime operations owned by the kernel-context lifecycle — the complete
+ * vocabulary available to context init and close.
+ *
+ * Deliberately absent from this table: device/stream synchronization, device
+ * reset, ACL finalization, capture queries, model handles, and
+ * stream-to-model attachment. Keeping those operations unrepresentable makes
+ * the host-only lifecycle tests an architectural guard instead of a mock
+ * that can silently exercise forbidden behavior.
+ */
+struct KernelContextOps {
+    void *context{nullptr};
+    int (*get_current_device)(void *context, int *device_id){nullptr};
+    int (*create_hidden_stream)(void *context, void **stream){nullptr};
+    int (*destroy_hidden_stream)(void *context, void *stream){nullptr};
+    int (*create_event)(void *context, void **event){nullptr};
+    int (*destroy_event)(void *context, void *event){nullptr};
+
+    bool valid() const {
+        return get_current_device != nullptr && create_hidden_stream != nullptr && destroy_hidden_stream != nullptr &&
+               create_event != nullptr && destroy_event != nullptr;
+    }
+};
+
+/**
+ * Allocation-free operation table for one borrowed-stream kernel-mode
+ * enqueue — the complete vocabulary available to a launch. Synchronization,
+ * allocation, stream/event creation, capture inspection, and model
+ * attachment cannot be expressed. The opaque context normally points to a
+ * stack snapshot owned by the caller.
+ *
+ * The unrepresentability guarantee binds only launch code that routes every
+ * runtime call through this table; routing through it is the launch
+ * implementation's obligation, and its call-sequence tests are what hold the
+ * obligation.
+ */
+struct KernelLaunchOps {
+    void *context{nullptr};
+    int (*wait_event)(void *context, void *stream, void *event) noexcept {nullptr};
+    int (*memset_handshake)(void *context, void *stream) noexcept {nullptr};
+    int (*record_event)(void *context, void *event, void *stream) noexcept {nullptr};
+    int (*launch_aicpu)(void *context, void *stream) noexcept {nullptr};
+    int (*launch_aicore)(void *context, void *stream) noexcept {nullptr};
+    int (*cancel_waiting_aicore)(void *context, void *stream) noexcept {nullptr};
+
+    bool valid() const {
+        return wait_event != nullptr && memset_handshake != nullptr && record_event != nullptr &&
+               launch_aicpu != nullptr && launch_aicore != nullptr && cancel_waiting_aicore != nullptr;
+    }
+};
+
+enum class KernelContextPhase : uint8_t {
+    New = 0,
+    Initializing,
+    Collecting,
+    ReadyEnqueued,
+    Poisoned,
+    Closing,
+    Closed,
+};
+
+enum class KernelStreamKind : size_t {
+    Aicpu = 0,
+    Aicore,
+    Count,
+};
+
+enum class KernelEventKind : size_t {
+    PrepareTail = 0,
+    Start,
+    AicoreDone,
+    SerialTail,
+    Count,
+};
+
+/**
+ * Context-lifetime state for the borrowed kernel execution mode.
+ *
+ * This object owns the persistent hidden stream pair and event set; every
+ * graph-visible persistent execution resource belongs here rather than in a
+ * per-invocation object. The caller stream is never stored or destroyed —
+ * each launch receives it as a borrowed argument.
+ *
+ * Phase machine:
+ *   New → (initialize) → Collecting ⇄ ReadyEnqueued
+ *   Collecting/ReadyEnqueued → (poison, on partial-enqueue failure) → Poisoned
+ *   Collecting/ReadyEnqueued/Poisoned → (close) → Closing → Closed
+ * Initializing is held only inside initialize()'s critical section and the
+ * lock is released with the phase already past it, so no caller observes it;
+ * close()'s rejection of it is defensive. The stream and event sets are the
+ * launch protocol's shared vocabulary, common to both runtimes, so
+ * initialize() creates all of them unconditionally.
+ *
+ * A pre-enqueue validation failure leaves the phase unchanged. Poisoned
+ * rejects dispatch but still accepts close. Closing is sticky: entered
+ * before the first destructive teardown step, it rejects all dispatch, and a
+ * cleanup failure stays in Closing for explicit close() retry — successfully
+ * destroyed handles are nulled, so a retry redoes only the remainder.
+ *
+ * Error reporting keeps two slots so a controlled runtime error can never
+ * mask a real teardown failure: last_runtime_error() latches the first
+ * poison cause, unexpected_teardown_error() latches the first real cleanup
+ * failure. A caller deciding an overall verdict consults them in that order
+ * before reporting controlled success.
+ *
+ * The destructor performs no runtime calls. If a caller skips explicit close
+ * while an ACLGraph can still reference these handles, freeing them would be
+ * a use-after-free, so the handles leak instead. Refusing to destroy an
+ * unclosed kernel runner is the public C API's half of that contract;
+ * destroy_device_context refuses only on an outstanding native run, so that
+ * refusal does not yet cover an unclosed kernel runner.
+ */
+class KernelExecutionState {
+public:
+    KernelExecutionState() = default;
+    ~KernelExecutionState() = default;
+    KernelExecutionState(const KernelExecutionState &) = delete;
+    KernelExecutionState &operator=(const KernelExecutionState &) = delete;
+
+    int initialize(int requested_device_id, const KernelContextOps &ops);
+    int mark_ready_enqueued();
+    void poison(int runtime_error);
+    int close();
+
+    KernelContextPhase phase() const;
+    bool accepts_dispatch() const;
+    int device_id() const;
+    int last_runtime_error() const;
+    int unexpected_teardown_error() const;
+    bool has_live_resources() const;
+    void *hidden_stream(KernelStreamKind kind) const;
+    void *event(KernelEventKind kind) const;
+
+private:
+    int cleanup_owned_resources_locked();
+    bool has_live_resources_locked() const;
+
+    mutable std::mutex mutex_;
+    KernelContextPhase phase_{KernelContextPhase::New};
+    int device_id_{-1};
+    int last_runtime_error_{0};
+    int unexpected_teardown_error_{0};
+    KernelContextOps ops_{};
+    std::array<void *, static_cast<size_t>(KernelStreamKind::Count)> hidden_streams_{};
+    std::array<void *, static_cast<size_t>(KernelEventKind::Count)> events_{};
+};

--- a/src/common/platform/include/host/kernel_pipeline_contract.h
+++ b/src/common/platform/include/host/kernel_pipeline_contract.h
@@ -11,9 +11,9 @@
 
 #pragma once
 
-typedef enum SimplerExecutionMode {
-    /* Exclusive-device execution. */
-    SIMPLER_MODE_PROGRAM = 0,
-    /* Caller-stream execution on a borrowed device. */
-    SIMPLER_MODE_KERNEL = 1,
-} SimplerExecutionMode;
+#include "worker/runtime_c_api.h"
+
+// Internal host-runtime hook, not a dlsym lifecycle API. Input is borrowed and
+// immutable during the call; output is caller-exclusive and unchanged on error.
+// No device resources are acquired or retained. Separate calls may run concurrently.
+extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out);

--- a/src/common/platform/include/host/kernel_static_config.h
+++ b/src/common/platform/include/host/kernel_static_config.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstring>
+
+#include "common/platform_config.h"
+#include "task_interface/call_config.h"
+#include "worker/runtime_c_api.h"
+
+// Host-only request snapshot. Topology resolution precedes freeze; neither
+// callable registration order nor launch can replace a frozen configuration.
+class KernelStaticConfig {
+public:
+    static int validate(const CallConfig *config) {
+        if (config == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+        CallConfig value;
+        std::memcpy(&value, config, sizeof(value));
+        if (value.aicpu_thread_num < 0 || value.aicpu_thread_num == 1 ||
+            value.aicpu_thread_num > PLATFORM_MAX_AICPU_THREADS)
+            return PTO_RUNTIME_ERR_INTERNAL;
+        if (value.diagnostics_any() || value.capture_clock_anchors != 0) return PTO_RUNTIME_ERR_UNSUPPORTED;
+        return 0;
+    }
+
+    int initialize(const CallConfig *config, uint64_t generation, bool serial_orch_sched) {
+        if (initialized_) return PTO_RUNTIME_ERR_INVALID_STATE;
+        const int rc = validate(config);
+        if (rc != 0) return rc;
+        if (generation == 0) return PTO_RUNTIME_ERR_INTERNAL;
+        std::memcpy(&request_, config, sizeof(request_));
+        generation_ = generation;
+        serial_orch_sched_ = serial_orch_sched;
+        initialized_ = true;
+        return 0;
+    }
+
+    bool initialized() const { return initialized_; }
+    bool frozen() const { return frozen_; }
+    int freeze() {
+        if (!initialized_) return PTO_RUNTIME_ERR_INVALID_STATE;
+        frozen_ = true;
+        return 0;
+    }
+    const CallConfig &request() const { return request_; }
+    uint64_t generation() const { return generation_; }
+    bool serial_orch_sched() const { return serial_orch_sched_; }
+
+private:
+    CallConfig request_{};
+    uint64_t generation_{0};
+    bool serial_orch_sched_{false};
+    bool initialized_{false};
+    bool frozen_{false};
+};

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -25,9 +25,11 @@
  */
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -437,6 +439,17 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
 
     // CANN dlog must be levelled BEFORE the device context is opened
     // (rtSetDevice inside attach_current_thread): CANN snapshots the
@@ -1199,6 +1212,49 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * This backend reports kernel mode unsupported: supported() is 0 and init
+ * refuses after the shared structural validation, so no context here ever
+ * latches kernel mode and prepare/launch reject with INVALID_STATE.
+ * Argument validation is shared with every other component through
+ * kernel_entry_validation.h, so an argument this stub accepts is one a real
+ * implementation accepts.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -30,6 +30,8 @@
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "host/kernel_entry_validation.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -1237,6 +1239,17 @@ int simpler_kernel_mode_init(
         config, context_generation
     );
     if (rc != 0) return rc;
+    try {
+        PipelineContract contract{};
+        const int rc = build_kernel_pipeline_contract_impl(config, &contract);
+        if (rc != 0) return rc;
+        if (!is_valid_pipeline_contract(&contract, SIMPLER_MODE_KERNEL) || !has_serviceable_arena_topology(contract) ||
+            !has_serviceable_stream_topology(contract)) {
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
     LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
     return PTO_RUNTIME_ERR_UNSUPPORTED;
 }

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -378,6 +378,14 @@ void destroy_device_context(DeviceContextHandle ctx) {
         LOG_ERROR("destroy_device_context: refusing to destroy a context with an unfinalized native run");
         return;
     }
+    // An unclosed kernel context still owns stream and event handles a
+    // captured ACLGraph may reference. Destroying it would free them under the
+    // graph, so the context is deliberately leaked instead: the caller closes
+    // it explicitly, or the process ends.
+    if (runner != nullptr && runner->kernel_execution_state().has_live_resources()) {
+        LOG_ERROR("destroy_device_context: refusing to destroy an unclosed kernel context; leaving it alive");
+        return;
+    }
     delete runner;
 }
 
@@ -427,7 +435,8 @@ int finalize_device(DeviceContextHandle ctx) {
             LOG_ERROR("finalize_device: native run must be finalized first");
             return PTO_RUNTIME_ERR_INTERNAL;
         }
-        return runner->finalize();
+        const int rc = runner->finalize();
+        return rc;
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -535,6 +544,68 @@ int simpler_init(
  * Per-callable_id preparation
  * =========================================================================== */
 
+/**
+ * Upload and record one callable on `runner`, leaving the AICPU-side
+ * registration launch to the caller: program mode brings the device up lazily
+ * and launches on the runner's own AICPU stream, kernel mode is already up and
+ * launches on the kernel context's. `needs_aicpu_register` reports whether
+ * that launch is owed — hbg resolves its orchestration host-side and owes
+ * none.
+ */
+static int record_callable_on_runner(
+    DeviceRunnerBase *runner, int32_t callable_id, const void *callable, bool *needs_aicpu_register
+) {
+    *needs_aicpu_register = false;
+    CallableArtifacts artifacts;
+    auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
+        if (artifacts.chip_buffer_hash != 0) {
+            runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
+        }
+    });
+    const HostApi host_api(runner, 0, 0, &g_host_api_ops);
+    int rc = register_callable_impl(reinterpret_cast<const ChipCallable *>(callable), &host_api, &artifacts);
+    if (rc != 0) return rc;
+
+    auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
+        if (artifacts.host_dlopen_handle != nullptr) {
+            dlclose(artifacts.host_dlopen_handle);
+        }
+    });
+
+    // Re-pack ChildKernelAddr -> std::pair to match the existing
+    // record_device_orch_callable* signature. The named struct only crosses
+    // the runtime-maker / device-runner interface; CallableState stores the
+    // historical pair shape.
+    std::vector<std::pair<int, uint64_t>> kernel_addrs;
+    kernel_addrs.reserve(artifacts.kernel_addrs.size());
+    for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
+        kernel_addrs.emplace_back(c.func_id, c.device_addr);
+    }
+
+    // hbg's register_callable_impl populates host_dlopen_handle; trb's leaves
+    // it null and fills orch_so_data + func_name/config_name.
+    if (artifacts.host_dlopen_handle != nullptr) {
+        rc = runner->record_host_orch_callable(
+            callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.host_dlopen_handle,
+            artifacts.host_orch_func_ptr, std::move(kernel_addrs), std::move(artifacts.signature)
+        );
+        if (rc != 0) return rc;
+        host_dlopen_guard.dismiss();
+        chip_buffer_guard.dismiss();
+        return 0;
+    }
+
+    rc = runner->record_device_orch_callable(
+        callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.chip_buffer_dev,
+        artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(), artifacts.config_name.c_str(),
+        std::move(kernel_addrs), std::move(artifacts.signature)
+    );
+    if (rc != 0) return rc;
+    chip_buffer_guard.dismiss();
+    *needs_aicpu_register = true;
+    return 0;
+}
+
 int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
     if (ctx == NULL || callable == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
@@ -547,54 +618,9 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
         int rc = runner->attach_current_thread(runner->device_id());
         if (rc != 0) return rc;
 
-        CallableArtifacts artifacts;
-        auto chip_buffer_guard = RAIIScopeGuard([runner, &artifacts]() {
-            if (artifacts.chip_buffer_hash != 0) {
-                runner->release_chip_callable_buffer(artifacts.chip_buffer_hash);
-            }
-        });
-        const HostApi host_api(runner, 0, 0, &g_host_api_ops);
-        rc = register_callable_impl(reinterpret_cast<const ChipCallable *>(callable), &host_api, &artifacts);
-        if (rc != 0) {
-            return rc;
-        }
-        auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
-            if (artifacts.host_dlopen_handle != nullptr) {
-                dlclose(artifacts.host_dlopen_handle);
-            }
-        });
-
-        // Re-pack ChildKernelAddr -> std::pair to match the existing
-        // record_device_orch_callable* signature. The named struct only crosses
-        // the runtime-maker / device-runner interface; CallableState
-        // stores the historical pair shape.
-        std::vector<std::pair<int, uint64_t>> kernel_addrs;
-        kernel_addrs.reserve(artifacts.kernel_addrs.size());
-        for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
-            kernel_addrs.emplace_back(c.func_id, c.device_addr);
-        }
-
-        // hbg's register_callable_impl populates host_dlopen_handle; trb's
-        // leaves it null and fills orch_so_data + func_name/config_name.
         bool needs_aicpu_register = false;
-        if (artifacts.host_dlopen_handle != nullptr) {
-            rc = runner->record_host_orch_callable(
-                callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.host_dlopen_handle,
-                artifacts.host_orch_func_ptr, std::move(kernel_addrs), std::move(artifacts.signature)
-            );
-            if (rc != 0) return rc;
-            host_dlopen_guard.dismiss();
-            chip_buffer_guard.dismiss();
-        } else {
-            rc = runner->record_device_orch_callable(
-                callable_id, artifacts.chip_buffer_hash, artifacts.aicore_image_hash, artifacts.chip_buffer_dev,
-                artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-                artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
-            );
-            if (rc != 0) return rc;
-            chip_buffer_guard.dismiss();
-            needs_aicpu_register = true;
-        }
+        rc = record_callable_on_runner(runner, callable_id, callable, &needs_aicpu_register);
+        if (rc != 0) return rc;
         if (needs_aicpu_register) {
             rc = runner->launch_device_register(callable_id);
             if (rc != 0) {
@@ -1219,12 +1245,10 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
 /* ===========================================================================
  * Kernel-mode lifecycle
  *
- * This backend reports kernel mode unsupported: supported() is 0 and init
- * refuses after the shared structural validation, so no context here ever
- * latches kernel mode and prepare/launch reject with INVALID_STATE.
- * Argument validation is shared with every other component through
- * kernel_entry_validation.h, so an argument this stub accepts is one a real
- * implementation accepts.
+ * Init and prepare create context-owned resources on a borrowed device.
+ * Launch remains a rejecting stub, so supported() reports 0. Structural
+ * argument validation is shared with the simulated components through
+ * kernel_entry_validation.h.
  * =========================================================================== */
 
 int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
@@ -1234,7 +1258,7 @@ int simpler_kernel_mode_init(
     const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
     const CallConfig *config, uint64_t context_generation
 ) {
-    const int rc = validate_kernel_init_args(
+    int rc = validate_kernel_init_args(
         ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
         config, context_generation
     );
@@ -1250,17 +1274,82 @@ int simpler_kernel_mode_init(
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
-    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
-    return PTO_RUNTIME_ERR_UNSUPPORTED;
+
+    DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+    // A same-mode latch is idempotent, but initialization is not. Reject
+    // reuse before replacing executors. The adopted device identity also
+    // catches init failures whose resource rollback
+    // returned the kernel execution state to New.
+    if (runner->device_id() >= 0 || runner->kernel_execution_state().phase() != KernelContextPhase::New) {
+        LOG_ERROR("simpler_kernel_mode_init: this context has already been initialized or requires close");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    rc = runner->execution_mode_latch().latch(SIMPLER_MODE_KERNEL);
+    if (rc != 0) {
+        LOG_ERROR("simpler_kernel_mode_init: incompatible execution-mode latch");
+        return rc;
+    }
+
+    // The caller's CANN log level is the caller's: unlike simpler_init, this
+    // path opens no device context of its own, so it has nothing to level and
+    // no standing to change a process-wide setting it does not own.
+    try {
+        std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
+        std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
+        runner->set_executors(std::move(aicpu_vec), std::move(aicore_vec));
+        if (dispatcher_binary != NULL && dispatcher_size > 0) {
+            std::vector<uint8_t> dispatcher_vec(dispatcher_binary, dispatcher_binary + dispatcher_size);
+            runner->set_dispatcher_binary(std::move(dispatcher_vec));
+        }
+        rc = runner->init_kernel_context(device_id);
+    } catch (...) {
+        rc = PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (rc != 0) {
+        runner->kernel_execution_state().poison(rc);
+        return rc;
+    }
+    return 0;
 }
 
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
-    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size);
     if (rc != 0) return rc;
-    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
-    return PTO_RUNTIME_ERR_INVALID_STATE;
+
+    DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+    if (!runner->execution_mode_latch().is_kernel()) {
+        LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    if (!runner->kernel_execution_state().accepts_dispatch()) {
+        LOG_ERROR("simpler_kernel_mode_prepare_callable: the kernel context no longer accepts preparation");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+
+    try {
+        // The caller owns the thread's current device; this records identity
+        // without binding the thread or changing device configuration.
+        rc = runner->adopt_borrowed_device(runner->device_id());
+        if (rc != 0) return rc;
+
+        // prepare_kernel_callable's AICPU registration self-skips a callable
+        // whose orchestration was resolved host-side, so the flag it reports
+        // adds nothing here.
+        bool needs_aicpu_register = false;
+        rc = record_callable_on_runner(runner, callable_id, callable, &needs_aicpu_register);
+        if (rc != 0) return rc;
+
+        rc = runner->prepare_kernel_callable(callable_id);
+        if (rc != 0) {
+            runner->unregister_callable(callable_id);
+            return rc;
+        }
+        return 0;
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
 }
 
 int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -30,6 +30,7 @@
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "host/kernel_entry_validation.h"
+#include "host/kernel_static_config.h"
 #include "host/kernel_pipeline_contract.h"
 #include "worker/pipeline_contract.h"
 #include "prepare_callable_common.h"
@@ -382,7 +383,8 @@ void destroy_device_context(DeviceContextHandle ctx) {
     // captured ACLGraph may reference. Destroying it would free them under the
     // graph, so the context is deliberately leaked instead: the caller closes
     // it explicitly, or the process ends.
-    if (runner != nullptr && runner->kernel_execution_state().has_live_resources()) {
+    if (runner != nullptr &&
+        (runner->kernel_execution_state().has_live_resources() || runner->has_persistent_kernel_args())) {
         LOG_ERROR("destroy_device_context: refusing to destroy an unclosed kernel context; leaving it alive");
         return;
     }
@@ -1265,6 +1267,8 @@ int simpler_kernel_mode_init(
     if (rc != 0) return rc;
     try {
         PipelineContract contract{};
+        const int config_rc = KernelStaticConfig::validate(config);
+        if (config_rc != 0) return config_rc;
         const int rc = build_kernel_pipeline_contract_impl(config, &contract);
         if (rc != 0) return rc;
         if (!is_valid_pipeline_contract(&contract, SIMPLER_MODE_KERNEL) || !has_serviceable_arena_topology(contract) ||
@@ -1301,7 +1305,7 @@ int simpler_kernel_mode_init(
             std::vector<uint8_t> dispatcher_vec(dispatcher_binary, dispatcher_binary + dispatcher_size);
             runner->set_dispatcher_binary(std::move(dispatcher_vec));
         }
-        rc = runner->init_kernel_context(device_id);
+        rc = runner->init_kernel_context(device_id, *config, context_generation);
     } catch (...) {
         rc = PTO_RUNTIME_ERR_INTERNAL;
     }

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -45,6 +45,7 @@
 #include "common/sdma_warmup_layout.h"
 #include "common/unified_log.h"
 #include "host/acl_error_log.h"
+#include "kernel_platform_ops.h"
 #include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
@@ -515,6 +516,10 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
     // writes here would still be a C++ data race.
     if (device_id_ == -1) {
         timeout_config_ = resolve_onboard_timeout_config();
+        // aclrtSetOpExecuteTimeOutV2 is device-global: it changes the
+        // op-execute timeout of every operator any process runs on this
+        // device, including the host framework's own. Only a context that
+        // owns the device may set it.
         configure_aicore_op_timeout();
         device_id_ = device_id;
     }
@@ -613,7 +618,7 @@ int DeviceRunnerBase::ensure_device_initialized() {
         );
     }
 
-    rc = ensure_binaries_loaded();
+    rc = ensure_binaries_loaded(stream_aicpu_);
     if (rc != 0) return rc;
 
     // Before the AICPU init launch: that launch is what publishes the workspace
@@ -621,13 +626,84 @@ int DeviceRunnerBase::ensure_device_initialized() {
     rc = ensure_dma_workspace_provisioned();
     if (rc != 0) return rc;
 
-    rc = ensure_aicpu_init_launched();
+    rc = ensure_aicpu_init_launched(stream_aicpu_);
     if (rc != 0) return rc;
 
     return ensure_dma_workspace_warmed();
 }
 
-int DeviceRunnerBase::ensure_aicpu_init_launched() {
+int DeviceRunnerBase::init_kernel_context(int device_id) {
+    int rc = adopt_borrowed_device(device_id);
+    if (rc != 0) return rc;
+
+    rc = kernel_exec_state_.initialize(device_id_, make_onboard_kernel_context_ops());
+    if (rc != 0) {
+        LOG_ERROR("init_kernel_context: context stream/event creation failed: %d", rc);
+        return rc;
+    }
+
+    rtStream_t control_stream = static_cast<rtStream_t>(kernel_exec_state_.hidden_stream(KernelStreamKind::Aicpu));
+    rtStream_t aicore_stream = static_cast<rtStream_t>(kernel_exec_state_.hidden_stream(KernelStreamKind::Aicore));
+
+    // Same latch as the program path: resolve_block_dim() is pure arithmetic
+    // once this holds.
+    if (max_block_dim_ == 0) {
+        max_block_dim_ = query_max_block_dim(aicore_stream, &max_cube_cores_, &max_vector_cores_);
+        LOG_INFO(
+            "DeviceRunner: kernel context device=%d max_block_dim=%d (cube=%u, vector=%u)", device_id_, max_block_dim_,
+            max_cube_cores_, max_vector_cores_
+        );
+    }
+
+    rc = ensure_binaries_loaded(control_stream);
+    if (rc != 0) return rc;
+
+    // The async-DMA workspace is program mode's SDMA channel; kernel mode
+    // provisions none, so this launch publishes the all-zero addresses that
+    // mean "that engine is unavailable".
+    return ensure_aicpu_init_launched(control_stream);
+}
+
+PersistentArgsOps DeviceRunnerBase::persistent_args_ops() {
+    PersistentArgsOps ops{};
+    ops.context = this;
+    ops.alloc = [](void *context, size_t bytes) -> void * {
+        return static_cast<DeviceRunnerBase *>(context)->mem_alloc_.alloc(bytes);
+    };
+    ops.free_ = [](void *context, void *ptr) -> int {
+        return static_cast<DeviceRunnerBase *>(context)->mem_alloc_.free(ptr);
+    };
+    ops.copy_h2d = [](void *, void *dst, size_t dst_bytes, const void *src, size_t src_bytes) -> int {
+        return static_cast<int>(rtMemcpy(dst, dst_bytes, src, src_bytes, RT_MEMCPY_HOST_TO_DEVICE));
+    };
+    ops.fill_arch_fields = [](void *context, KernelArgs *args, uint64_t device_id) -> int {
+        return static_cast<DeviceRunnerBase *>(context)->fill_persistent_arch_fields(args, device_id);
+    };
+    return ops;
+}
+
+int DeviceRunnerBase::prepare_kernel_callable(int32_t callable_id) {
+    rtStream_t control_stream = static_cast<rtStream_t>(kernel_exec_state_.hidden_stream(KernelStreamKind::Aicpu));
+    if (control_stream == nullptr) {
+        LOG_ERROR("prepare_kernel_callable: no live kernel context");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+
+    int rc = register_callable_on_device(callable_id, control_stream);
+    if (rc != 0) return rc;
+
+    // Idempotent: only the first prepared callable allocates. The uploaded
+    // Runtime keeps its per-callable and per-invocation fields at the
+    // sentinels Runtime() sets — binding a callable into the device image is a
+    // later step's work, and overwriting them here would make every launch
+    // silently run whichever callable was prepared first.
+    rc = persistent_args_.prepare_once(kernel_runtime_, persistent_args_ops(), static_cast<uint64_t>(device_id_));
+    if (rc != 0) return rc;
+
+    return kernel_exec_state_.mark_ready_enqueued();
+}
+
+int DeviceRunnerBase::ensure_aicpu_init_launched(rtStream_t control_stream) {
     if (aicpu_init_launched_) {
         return 0;
     }
@@ -652,14 +728,14 @@ int DeviceRunnerBase::ensure_aicpu_init_launched() {
 
     LOG_INFO("=== launch_aicpu_payload %s ===", host::KernelNames::InitName);
     int rc = launch_aicpu_payload(
-        stream_aicpu_, &init_args, sizeof(init_args), host::KernelNames::InitName, /*aicpu_num=*/1
+        control_stream, &init_args, sizeof(init_args), host::KernelNames::InitName, /*aicpu_num=*/1
     );
     if (rc != 0) {
         LOG_ERROR("ensure_aicpu_init_launched: launch_aicpu_payload failed: %d", rc);
         return rc;
     }
 
-    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    rc = aclrtSynchronizeStreamWithTimeout(control_stream, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
     if (rc != 0) {
         LOG_ERROR("ensure_aicpu_init_launched: stream sync failed: %d (device_id=%d)", rc, device_id_);
         return rc;
@@ -668,15 +744,16 @@ int DeviceRunnerBase::ensure_aicpu_init_launched() {
     return 0;
 }
 
-int DeviceRunnerBase::ensure_binaries_loaded() {
+int DeviceRunnerBase::ensure_binaries_loaded(rtStream_t control_stream) {
     // Check if already loaded (binaries are owned by the runner via
     // set_executors and live for the runner's lifetime).
     if (binaries_loaded_) {
         return 0;
     }
 
-    // Device must be set first
-    if (stream_aicpu_ == nullptr) {
+    // The control stream is what the bootstrap launch rides; a context that
+    // has not created one yet has no device to bootstrap on.
+    if (control_stream == nullptr) {
         LOG_ERROR("Device not set before loading binaries");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
@@ -698,7 +775,7 @@ int DeviceRunnerBase::ensure_binaries_loaded() {
     // rtsLaunchCpuKernel directly against the preinstall file.
     int rc = load_aicpu_op_.BootstrapDispatcher(
         dispatcher_so_binary_.data(), dispatcher_so_binary_.size(), aicpu_so_binary_.data(), aicpu_so_binary_.size(),
-        stream_aicpu_, device_id_
+        control_stream, device_id_
     );
     if (rc != 0) {
         LOG_ERROR("LoadAicpuOp::BootstrapDispatcher failed: %d", rc);
@@ -786,8 +863,12 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
     if (callable == nullptr) {
         return 0;
     }
-    if (stream_aicpu_ == nullptr) {
-        LOG_ERROR("Run context not prepared before upload_chip_callable_buffer()");
+    // The upload allocates and copies; it needs a bound device and nothing
+    // else. A kernel-mode context has no stream_aicpu_ — its AICPU stream
+    // belongs to KernelExecutionState — so the stream is not the precondition
+    // to test here.
+    if (device_id_ < 0) {
+        LOG_ERROR("No device bound before upload_chip_callable_buffer()");
         return 0;
     }
 
@@ -912,11 +993,24 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
         return 0;
     }
 
-    int rc = ensure_device_initialized();
+    const int rc = ensure_device_initialized();
     if (rc != 0) {
         LOG_ERROR("launch_device_register: ensure_device_initialized failed: %d", rc);
         return rc;
     }
+    return register_callable_on_device(callable_id, stream_aicpu_);
+}
+
+int DeviceRunnerBase::register_callable_on_device(int32_t callable_id, rtStream_t control_stream) {
+    auto it = callables_.find(callable_id);
+    if (it == callables_.end()) {
+        LOG_ERROR("register_callable_on_device: callable_id=%d not registered", callable_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (it->second.host_dlopen_handle != nullptr) {
+        return 0;
+    }
+    int rc = 0;
 
     // Build the orch-SO descriptor straight from CallableState — no full
     // Runtime H2D as the old prewarm path did. Registration always (re)dlopens
@@ -933,23 +1027,23 @@ int DeviceRunnerBase::launch_device_register(int32_t callable_id) {
 
     LOG_INFO("=== launch_aicpu_payload %s ===", host::KernelNames::RegisterCallableName);
     rc = launch_aicpu_payload(
-        stream_aicpu_, &reg_args, sizeof(reg_args), host::KernelNames::RegisterCallableName, /*aicpu_num=*/1
+        control_stream, &reg_args, sizeof(reg_args), host::KernelNames::RegisterCallableName, /*aicpu_num=*/1
     );
     if (rc != 0) {
-        LOG_ERROR("launch_device_register: launch_aicpu_payload failed: %d", rc);
+        LOG_ERROR("register_callable_on_device: launch_aicpu_payload failed: %d", rc);
         return rc;
     }
 
-    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    rc = aclrtSynchronizeStreamWithTimeout(control_stream, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
     if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
         LOG_ERROR(
-            "launch_device_register: stream sync timeout timeout_ms=%d device_id=%d", PLATFORM_STREAM_SYNC_TIMEOUT_MS,
-            device_id_
+            "register_callable_on_device: stream sync timeout timeout_ms=%d device_id=%d",
+            PLATFORM_STREAM_SYNC_TIMEOUT_MS, device_id_
         );
         return rc;
     }
     if (rc != 0) {
-        LOG_ERROR("launch_device_register: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
+        LOG_ERROR("register_callable_on_device: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
         ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
@@ -1614,6 +1708,20 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
             free_tensor(device_wall_dev_ptr_);
         }
         device_wall_dev_ptr_ = nullptr;
+    }
+
+    // Kernel-mode context resources. The argument blocks route through
+    // mem_alloc_, so they are released before its finalize below; the streams
+    // and events do not, and go after them so a caller that inspects the
+    // teardown sees arguments released while their owning context still
+    // exists. Both are no-ops on a program-mode context.
+    if (abandon_device_resources) {
+        persistent_args_.abandon();
+    } else {
+        const int args_rc = persistent_args_.finalize_once();
+        if (args_rc != 0 && rc == 0) rc = args_rc;
+        const int close_rc = kernel_exec_state_.close();
+        if (close_rc != 0 && rc == 0) rc = close_rc;
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -373,7 +373,26 @@ int DeviceRunnerBase::setup_static_arena(
     ArenaBank &bank = this->arena_bank(arena_bank);
 
     bool arena_changed = false;
-    auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+    // A kernel-mode context's config is context-static, so each region is
+    // committed at most once and never grown or released afterwards; captured
+    // graphs may hold the committed base address. A request that would
+    // re-base or release a committed region under kernel mode is therefore an
+    // internal invariant break, not caller-configurable behavior. The refusal
+    // is not self-contained: the caller collapses a nonzero return to
+    // `ok = false` and then releases all three regions unconditionally, and
+    // DeviceArena::release() frees the backing buffer — so a fired guard drops
+    // the very base addresses it names.
+    const bool kernel_mode = execution_mode_latch().is_kernel();
+    auto commit_region = [&arena_changed,
+                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (requested_size == 0) {
             // hbg's runtime_arena path: caller passed 0 and never reserved
             // a region. Leave the arena uncommitted; acquire_pooled_* will
@@ -441,6 +460,10 @@ int DeviceRunnerBase::setup_static_arena(
 }
 
 std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
+    // A freshly spawned thread carries no CANN device context of its own, so
+    // this bind creates one rather than taking anything from the caller — it
+    // is the one rtSetDevice a borrowed-device context still owns, and it is
+    // scoped to a thread this runner created.
     int dev_id = device_id_;
     return std::thread([dev_id, fn = std::move(fn)]() {
         rtSetDevice(dev_id);
@@ -448,7 +471,7 @@ std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
     });
 }
 
-int DeviceRunnerBase::attach_current_thread(int device_id) {
+int DeviceRunnerBase::bind_current_thread(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("Invalid device_id: %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -468,13 +491,57 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
         ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
+    return 0;
+}
 
-    // simpler_init performs the only lifetime write. Prepared-run admission
-    // and execution subsequently attach different host threads, so repeated
-    // same-value writes here would still be a C++ data race.
+int DeviceRunnerBase::attach_current_thread(int device_id) {
+    // rtSetDevice and the op-execute watchdog below are acts of device
+    // ownership, so this entry belongs to a program context. A kernel context
+    // reaches its device through adopt_borrowed_device instead; the one caller
+    // here that runs under both identities is DeviceRunner::finalize(), which
+    // skips this call on a kernel latch.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("attach_current_thread: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
+
+    int rc = bind_current_thread(device_id);
+    if (rc != 0) return rc;
+
+    // Both writers of device_id_ — this one and adopt_borrowed_device — guard
+    // on the still-unset value, and both run before any prepare, execution or
+    // collector thread attaches. Prepared-run admission and execution
+    // subsequently attach different host threads, so repeated same-value
+    // writes here would still be a C++ data race.
     if (device_id_ == -1) {
         timeout_config_ = resolve_onboard_timeout_config();
         configure_aicore_op_timeout();
+        device_id_ = device_id;
+    }
+    return 0;
+}
+
+int DeviceRunnerBase::adopt_borrowed_device(int device_id) {
+    // The caller already holds this device current on its own threads, so the
+    // only thing a kernel context takes from it is the identity: no
+    // rtSetDevice, and no configure_aicore_op_timeout, which would rewrite the
+    // op-execute watchdog for every other user of that card. Resolving the
+    // timeout config is pure environment parsing and stays, because the stream
+    // and scheduler timeouts derived from it are read on both identities.
+    if (!execution_mode_latch().is_kernel()) {
+        LOG_ERROR("adopt_borrowed_device: refused — the context has not latched kernel mode");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    if (device_id < 0) {
+        LOG_ERROR("Invalid device_id: %d", device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ != -1 && device_id_ != device_id) {
+        LOG_ERROR("DeviceRunner already on device %d; close before adopting device %d", device_id_, device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ == -1) {
+        timeout_config_ = resolve_onboard_timeout_config();
         device_id_ = device_id;
     }
     return 0;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -46,6 +46,7 @@
 #include "common/unified_log.h"
 #include "host/acl_error_log.h"
 #include "kernel_platform_ops.h"
+#include "host/kernel_pipeline_contract.h"
 #include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
@@ -632,8 +633,12 @@ int DeviceRunnerBase::ensure_device_initialized() {
     return ensure_dma_workspace_warmed();
 }
 
-int DeviceRunnerBase::init_kernel_context(int device_id) {
-    int rc = adopt_borrowed_device(device_id);
+int DeviceRunnerBase::init_kernel_context(int device_id, const CallConfig &config, uint64_t context_generation) {
+    const char *serial_env = std::getenv("SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE");
+    const bool serial = serial_env && (serial_env[0] == '1' || serial_env[0] == 't' || serial_env[0] == 'T');
+    int rc = kernel_static_config_.initialize(&config, context_generation, serial);
+    if (rc != 0) return rc;
+    rc = adopt_borrowed_device(device_id);
     if (rc != 0) return rc;
 
     rc = kernel_exec_state_.initialize(device_id_, make_onboard_kernel_context_ops());
@@ -689,15 +694,21 @@ int DeviceRunnerBase::prepare_kernel_callable(int32_t callable_id) {
         return PTO_RUNTIME_ERR_INVALID_STATE;
     }
 
+    if (!kernel_static_config_.initialized()) return PTO_RUNTIME_ERR_INVALID_STATE;
+    if (!persistent_args_.is_prepared()) {
+        if (persistent_args_.has_live_resources()) return PTO_RUNTIME_ERR_INVALID_STATE;
+        int rc = prepare_launch_shape(kernel_runtime_, kernel_static_config_.request());
+        if (rc != 0) return rc;
+        rc = prepare_aicpu_affinity(kernel_runtime_, kernel_static_config_.request().aicpu_thread_num, control_stream);
+        if (rc != 0) return rc;
+        rc = configure_kernel_runtime_impl(kernel_runtime_, kernel_static_config_.serial_orch_sched());
+        if (rc != 0) return rc;
+        rc = persistent_args_.prepare_once(kernel_runtime_, persistent_args_ops(), static_cast<uint64_t>(device_id_));
+        if (rc != 0) return rc;
+        rc = kernel_static_config_.freeze();
+        if (rc != 0) return rc;
+    }
     int rc = register_callable_on_device(callable_id, control_stream);
-    if (rc != 0) return rc;
-
-    // Idempotent: only the first prepared callable allocates. The uploaded
-    // Runtime keeps its per-callable and per-invocation fields at the
-    // sentinels Runtime() sets — binding a callable into the device image is a
-    // later step's work, and overwriting them here would make every launch
-    // silently run whichever callable was prepared first.
-    rc = persistent_args_.prepare_once(kernel_runtime_, persistent_args_ops(), static_cast<uint64_t>(device_id_));
     if (rc != 0) return rc;
 
     return kernel_exec_state_.mark_ready_enqueued();
@@ -1556,6 +1567,13 @@ int DeviceRunnerBase::finalize_common() { return finalize_common_impl(false); }
 int DeviceRunnerBase::abandon_common_after_device_failure() { return finalize_common_impl(true); }
 
 int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
+    if (!abandon_device_resources && execution_mode_latch_.is_kernel()) {
+        const int args_rc = persistent_args_.finalize_once();
+        if (args_rc != 0) {
+            kernel_exec_state_.poison(args_rc);
+            return args_rc;
+        }
+    }
     int rc = 0;
     auto capture = [&rc](int err) {
         if (err != 0 && rc == 0) rc = err;

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -69,6 +69,7 @@
 #include "host/execution_mode_latch.h"
 #include "host/kernel_execution_state.h"
 #include "kernel_persistent_args.h"
+#include "host/kernel_static_config.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -149,6 +150,7 @@ public:
 
     /** Context-lifetime streams and events, live only in kernel mode. */
     KernelExecutionState &kernel_execution_state() { return kernel_exec_state_; }
+    bool has_persistent_kernel_args() const { return persistent_args_.has_live_resources(); }
 
     /**
      * Bring up a kernel-mode context on a device the caller already owns:
@@ -157,7 +159,7 @@ public:
      * and launch simpler_aicpu_init on the context's AICPU stream. Creates no
      * async-DMA workspace — that channel belongs to program mode.
      */
-    int init_kernel_context(int device_id);
+    int init_kernel_context(int device_id, const CallConfig &config, uint64_t context_generation);
 
     /**
      * Register one callable on a kernel-mode context and make sure the
@@ -874,6 +876,7 @@ protected:
 
     /** The four operations PersistentKernelArgs is allowed to perform. */
     PersistentArgsOps persistent_args_ops();
+    virtual int prepare_aicpu_affinity(Runtime &runtime, int requested, rtStream_t control_stream) = 0;
 
     /**
      * Launch the AICPU callable registration on `control_stream` and wait for
@@ -1266,6 +1269,7 @@ protected:
     // on destruction.
     KernelExecutionState kernel_exec_state_;
     PersistentKernelArgs persistent_args_;
+    KernelStaticConfig kernel_static_config_;
     // The Runtime image a kernel-mode context uploads once. Its per-callable
     // and per-invocation fields stay at the sentinels Runtime() sets; binding
     // a callable into it is a later step's work.

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -19,8 +19,9 @@
  *   - The trivial tensor-memory wrappers (`allocate_tensor`,
  *     `free_tensor`, `copy_*_device`).
  *   - The arena-pool accessors (`acquire_pooled_gm_heap`, etc.).
- *   - Device lifecycle: `attach_current_thread`,
- *     `configure_aicore_op_timeout`, `ensure_device_initialized`,
+ *   - Device lifecycle: `bind_current_thread`, `attach_current_thread`,
+ *     `adopt_borrowed_device`, `configure_aicore_op_timeout`,
+ *     `ensure_device_initialized`,
  *     `ensure_binaries_loaded`, persistent AICPU/AICore streams,
  *     dispatcher/executor bytes, `LoadAicpuOp`, `KernelArgsHelper`.
  *   - block_dim resolution: `query_max_block_dim`, `resolve_block_dim`.
@@ -65,6 +66,7 @@
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -133,6 +135,15 @@ public:
      * distinct buffers; tests read this to prove the split is real.
      */
     uint64_t retained_temp_addr(uint32_t slot_id) const;
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. Every kernel-mode guard on the ACL-lifecycle and arena
+     * paths keys on is_kernel(); `attach_current_thread` refuses outright on a
+     * kernel latch, which is what keeps the program-mode entries and the
+     * per-thread device bind off a borrowed device.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
@@ -215,17 +226,37 @@ public:
     std::thread create_thread(std::function<void()> fn);
 
     /**
-     * Attach the current host thread to the target device.
+     * Bind the calling thread to a device, taking nothing else from it.
      *
-     * Required before host-side runtime initialization may allocate or
-     * free device memory on the current thread. Idempotent for the same
-     * id; errors if called with a different id after a prior attach.
-     * No streams are created here.
+     * Idempotent for the same id; errors if called with a different id after
+     * a prior adopt. Creates no streams and records no identity.
+     *
+     * @param device_id  Device ID (0-15)
+     * @return 0 on success, error code on failure.
+     */
+    int bind_current_thread(int device_id);
+
+    /**
+     * Bind the current host thread and adopt the device for a program
+     * context: on the first call it also resolves the timeout config, writes
+     * the card's op-execute watchdog, and records device_id_.
+     *
+     * Required before host-side runtime initialization may allocate or free
+     * device memory on the current thread. Refuses with
+     * PTO_RUNTIME_ERR_UNSUPPORTED on a context latched to kernel mode, which
+     * owns neither the bind nor the watchdog.
      *
      * @param device_id  Device ID (0-15)
      * @return 0 on success, error code on failure.
      */
     int attach_current_thread(int device_id);
+    /**
+     * Record which device a kernel-mode context runs on. Takes no device side
+     * effect: the caller already holds the device current, so this neither
+     * binds the thread nor touches the card's op-execute watchdog. Requires
+     * the execution-mode latch to already read kernel.
+     */
+    int adopt_borrowed_device(int device_id);
 
     /**
      * One-shot device initialization. Performs, in order:
@@ -303,7 +334,7 @@ public:
         sdma_warmup_binary_ = std::move(sdma_warmup_binary);
     }
 
-    /** The device id captured by simpler_init's `attach_current_thread` call. */
+    /** Which device this context is on; -1 until an init entry adopts one. */
     int device_id() const { return device_id_; }
 
     /**
@@ -1176,9 +1207,16 @@ protected:
 
     // ---- State shared by both a2a3 and a5 ---------------------------------
     //
-    // `device_id_` is written once by simpler_init and is immutable while
-    // native prepare, execution, and collector threads attach to the runner.
+    // Which device this context is on — not a claim of ownership, which the
+    // execution-mode latch carries instead. Written once before any prepare,
+    // execution or collector thread attaches: `attach_current_thread` writes
+    // it for a program context and `adopt_borrowed_device` for a kernel one, both
+    // guarded on the still-unset value, so repeated same-value writes from
+    // later-attaching threads cannot race.
     int device_id_{-1};
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -67,6 +67,8 @@
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
 #include "host/execution_mode_latch.h"
+#include "host/kernel_execution_state.h"
+#include "kernel_persistent_args.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -144,6 +146,25 @@ public:
      * per-thread device bind off a borrowed device.
      */
     ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
+
+    /** Context-lifetime streams and events, live only in kernel mode. */
+    KernelExecutionState &kernel_execution_state() { return kernel_exec_state_; }
+
+    /**
+     * Bring up a kernel-mode context on a device the caller already owns:
+     * adopt its identity without changing the caller's device binding, create
+     * the context's own streams and events, then bootstrap the inner AICPU SO
+     * and launch simpler_aicpu_init on the context's AICPU stream. Creates no
+     * async-DMA workspace — that channel belongs to program mode.
+     */
+    int init_kernel_context(int device_id);
+
+    /**
+     * Register one callable on a kernel-mode context and make sure the
+     * context's persistent argument blocks exist. Idempotent in the part that
+     * matters: only the first callable pays for the argument blocks.
+     */
+    int prepare_kernel_callable(int32_t callable_id);
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
@@ -670,6 +691,14 @@ public:
     virtual int finalize() = 0;
 
     /**
+     * Populate the device-side KernelArgs fields only this architecture knows
+     * how to produce: the per-core register table on both, plus a2a3's FFTS
+     * base address. Anything allocated here must come from `mem_alloc_`, which
+     * is what PersistentKernelArgs releases through. DFX fields stay zero.
+     */
+    virtual int fill_persistent_arch_fields(KernelArgs *args, uint64_t device_id) = 0;
+
+    /**
      * dep_gen enablement setter. The shared c_api `simpler_run` calls this
      * unconditionally; a2a3 and a5 override it to capture submit_task inputs.
      * The base default is a no-op for any arch that does not implement dep_gen.
@@ -843,15 +872,26 @@ protected:
      */
     void configure_aicore_op_timeout();
 
+    /** The four operations PersistentKernelArgs is allowed to perform. */
+    PersistentArgsOps persistent_args_ops();
+
     /**
-     * Load AICPU SO and initialize device args. Called from
-     * `ensure_device_initialized()` after the persistent streams are
-     * created. Reads `aicpu_so_binary_` / `dispatcher_so_binary_` off
-     * the runner; releases both host buffers on success.
+     * Launch the AICPU callable registration on `control_stream` and wait for
+     * it. The device must already be up; launch_device_register() is the
+     * program-mode entry that brings it up first.
+     */
+    int register_callable_on_device(int32_t callable_id, rtStream_t control_stream);
+
+    /**
+     * Load AICPU SO and initialize device args. Called after the context's
+     * AICPU control stream exists, with that stream: it is `stream_aicpu_`
+     * for a program-mode context and the kernel context's own AICPU stream
+     * otherwise. Reads `aicpu_so_binary_` / `dispatcher_so_binary_` off the
+     * runner; releases both host buffers on success.
      *
      * @return 0 on success, error code on failure.
      */
-    int ensure_binaries_loaded();
+    int ensure_binaries_loaded(rtStream_t control_stream);
 
     /**
      * Initial launch of `simpler_aicpu_init`, latching the invariants (orch
@@ -862,7 +902,11 @@ protected:
      *
      * @return 0 on success, error code on failure.
      */
-    int ensure_aicpu_init_launched();
+    /**
+     * Launch simpler_aicpu_init on the context's AICPU control stream and
+     * wait for it. Same stream ownership rule as ensure_binaries_loaded().
+     */
+    int ensure_aicpu_init_launched(rtStream_t control_stream);
 
     /**
      * Provision the async-DMA workspaces this Worker asked for (see
@@ -1217,6 +1261,15 @@ protected:
     // This context's execution identity. Write-once: the first init entry to
     // run latches it, and it never changes afterwards.
     ExecutionModeLatch execution_mode_latch_;
+    // Kernel-mode context state. Both stay at their default-constructed
+    // values for a program-mode context, and neither performs a runtime call
+    // on destruction.
+    KernelExecutionState kernel_exec_state_;
+    PersistentKernelArgs persistent_args_;
+    // The Runtime image a kernel-mode context uploads once. Its per-callable
+    // and per-invocation fields stay at the sentinels Runtime() sets; binding
+    // a callable into it is a later step's work.
+    Runtime kernel_runtime_;
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results

--- a/src/common/platform/onboard/host/kernel_persistent_args.cpp
+++ b/src/common/platform/onboard/host/kernel_persistent_args.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * PersistentKernelArgs implementation.
+ *
+ * Linked into both a2a3 and a5 `libhost_runtime.so`, once per runtime variant:
+ * the `KernelArgs` layout and the `Runtime` device-image length both come from
+ * the include path the arch/runtime CMake sets up.
+ */
+
+#include "kernel_persistent_args.h"
+
+#include "common/unified_log.h"
+#include "runtime_c_api.h"
+
+int PersistentKernelArgs::prepare_once(const Runtime &host_runtime, const PersistentArgsOps &ops, uint64_t device_id) {
+    if (prepared_) return 0;
+    if (!ops.valid()) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: incomplete operation table");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    ops_ = ops;
+
+    // Only the device-read prefix of Runtime crosses to the device: trb copies
+    // its `dev` descriptor (offset 0), hbg copies the whole object.
+    const size_t runtime_bytes = runtime_device_copy_size(host_runtime);
+    void *runtime_dev = ops_.alloc(ops_.context, runtime_bytes);
+    if (runtime_dev == nullptr) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: alloc for runtime_args failed");
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    int rc = ops_.copy_h2d(ops_.context, runtime_dev, runtime_bytes, &host_runtime, runtime_bytes);
+    if (rc != 0) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: copy of runtime_args failed: %d", rc);
+        (void)ops_.free_(ops_.context, runtime_dev);
+        return rc;
+    }
+    args_.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
+
+    rc = ops_.fill_arch_fields(ops_.context, &args_, device_id);
+    if (rc != 0) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: arch field init failed: %d", rc);
+        (void)ops_.free_(ops_.context, runtime_dev);
+        args_ = KernelArgs{};
+        return rc;
+    }
+
+    // Taken last: this is a whole-struct copy of `args_`, so every field the
+    // device reads — including the two blocks above — must already be set.
+    void *device_args = ops_.alloc(ops_.context, sizeof(KernelArgs));
+    if (device_args == nullptr) {
+        LOG_ERROR("PersistentKernelArgs::prepare_once: alloc for device KernelArgs failed");
+        rc = PTO_RUNTIME_ERR_INTERNAL;
+    } else {
+        rc = ops_.copy_h2d(ops_.context, device_args, sizeof(KernelArgs), &args_, sizeof(KernelArgs));
+        if (rc != 0) {
+            LOG_ERROR("PersistentKernelArgs::prepare_once: copy of device KernelArgs failed: %d", rc);
+            (void)ops_.free_(ops_.context, device_args);
+        }
+    }
+    if (rc != 0) {
+        if (args_.regs != 0) (void)ops_.free_(ops_.context, reinterpret_cast<void *>(args_.regs));
+        (void)ops_.free_(ops_.context, runtime_dev);
+        args_ = KernelArgs{};
+        return rc;
+    }
+
+    device_k_args_ = reinterpret_cast<KernelArgs *>(device_args);
+    prepared_ = true;
+    return 0;
+}
+
+int PersistentKernelArgs::release_block(void *block, int &first_error) {
+    const int rc = ops_.free_(ops_.context, block);
+    if (rc != 0 && first_error == 0) first_error = rc;
+    return rc;
+}
+
+int PersistentKernelArgs::finalize_once() {
+    if (ops_.free_ == nullptr) {
+        device_k_args_ = nullptr;
+        args_ = KernelArgs{};
+        prepared_ = false;
+        return 0;
+    }
+
+    int first_error = 0;
+    if (device_k_args_ != nullptr && release_block(device_k_args_, first_error) == 0) {
+        device_k_args_ = nullptr;
+    }
+    if (args_.regs != 0 && release_block(reinterpret_cast<void *>(args_.regs), first_error) == 0) {
+        args_.regs = 0;
+    }
+    if (args_.runtime_args != nullptr && release_block(args_.runtime_args, first_error) == 0) {
+        args_.runtime_args = nullptr;
+    }
+    if (first_error != 0) return first_error;
+
+    args_ = KernelArgs{};
+    prepared_ = false;
+    return 0;
+}
+
+void PersistentKernelArgs::abandon() {
+    args_ = KernelArgs{};
+    device_k_args_ = nullptr;
+    ops_ = {};
+    prepared_ = false;
+}

--- a/src/common/platform/onboard/host/kernel_persistent_args.cpp
+++ b/src/common/platform/onboard/host/kernel_persistent_args.cpp
@@ -23,6 +23,7 @@
 
 int PersistentKernelArgs::prepare_once(const Runtime &host_runtime, const PersistentArgsOps &ops, uint64_t device_id) {
     if (prepared_) return 0;
+    if (has_live_resources()) return PTO_RUNTIME_ERR_INVALID_STATE;
     if (!ops.valid()) {
         LOG_ERROR("PersistentKernelArgs::prepare_once: incomplete operation table");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -37,19 +38,18 @@ int PersistentKernelArgs::prepare_once(const Runtime &host_runtime, const Persis
         LOG_ERROR("PersistentKernelArgs::prepare_once: alloc for runtime_args failed");
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    args_.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
     int rc = ops_.copy_h2d(ops_.context, runtime_dev, runtime_bytes, &host_runtime, runtime_bytes);
     if (rc != 0) {
         LOG_ERROR("PersistentKernelArgs::prepare_once: copy of runtime_args failed: %d", rc);
-        (void)ops_.free_(ops_.context, runtime_dev);
+        (void)finalize_once();
         return rc;
     }
-    args_.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
 
     rc = ops_.fill_arch_fields(ops_.context, &args_, device_id);
     if (rc != 0) {
         LOG_ERROR("PersistentKernelArgs::prepare_once: arch field init failed: %d", rc);
-        (void)ops_.free_(ops_.context, runtime_dev);
-        args_ = KernelArgs{};
+        (void)finalize_once();
         return rc;
     }
 
@@ -60,16 +60,14 @@ int PersistentKernelArgs::prepare_once(const Runtime &host_runtime, const Persis
         LOG_ERROR("PersistentKernelArgs::prepare_once: alloc for device KernelArgs failed");
         rc = PTO_RUNTIME_ERR_INTERNAL;
     } else {
+        device_k_args_ = reinterpret_cast<KernelArgs *>(device_args);
         rc = ops_.copy_h2d(ops_.context, device_args, sizeof(KernelArgs), &args_, sizeof(KernelArgs));
         if (rc != 0) {
             LOG_ERROR("PersistentKernelArgs::prepare_once: copy of device KernelArgs failed: %d", rc);
-            (void)ops_.free_(ops_.context, device_args);
         }
     }
     if (rc != 0) {
-        if (args_.regs != 0) (void)ops_.free_(ops_.context, reinterpret_cast<void *>(args_.regs));
-        (void)ops_.free_(ops_.context, runtime_dev);
-        args_ = KernelArgs{};
+        (void)finalize_once();
         return rc;
     }
 
@@ -85,6 +83,7 @@ int PersistentKernelArgs::release_block(void *block, int &first_error) {
 }
 
 int PersistentKernelArgs::finalize_once() {
+    prepared_ = false;
     if (ops_.free_ == nullptr) {
         device_k_args_ = nullptr;
         args_ = KernelArgs{};

--- a/src/common/platform/onboard/host/kernel_persistent_args.h
+++ b/src/common/platform/onboard/host/kernel_persistent_args.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Context-lifetime owner of the AICore argument block.
+ *
+ * `KernelArgsHelper` reallocates its device blocks per prepared run; this owner
+ * allocates them exactly once and hands the same three device addresses to
+ * every subsequent launch, so a steady-state launch performs no allocation and
+ * no host-to-device copy.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "common/kernel_args.h"
+#include "runtime.h"
+
+/**
+ * The complete vocabulary available to argument preparation — the third
+ * restricted table alongside KernelContextOps and KernelLaunchOps, and the
+ * only one of the three that may allocate. Synchronization, stream and event
+ * operations are absent, so a launch-path operation cannot be written against
+ * this table at all.
+ *
+ * Allocation, release and host-to-device copy arrive as operations rather
+ * than a `MemoryAllocator &` because `MemoryAllocator::alloc` / `free` are
+ * non-virtual and `rtMemcpy` is a free function: a host-only test can observe
+ * the balance of this object's device traffic only if they are parameters.
+ *
+ * `fill_arch_fields` exists for the second reason, which allocation
+ * indirection alone does not solve: the device-side fields that are neither
+ * pure memory nor uniform across architectures. The register table comes from
+ * an arch entry that takes its own allocator and a different signature on
+ * a2a3 than on a5, and reaches the driver; `ffts_base_addr` exists only on
+ * a2a3. Absorbing both at the table's construction point keeps the platform
+ * knowledge with the platform, exactly as `KernelContextOps::event_flag` does
+ * for ACL_EVENT_SYNC.
+ */
+struct PersistentArgsOps {
+    void *context{nullptr};
+    void *(*alloc)(void *context, size_t bytes){nullptr};
+    int (*free_)(void *context, void *ptr){nullptr};
+    int (*copy_h2d)(void *context, void *dst, size_t dst_bytes, const void *src, size_t src_bytes){nullptr};
+    /**
+     * Populate the arch-specific device fields of `args`: `regs` on both
+     * arches (a2a3 additionally selecting AicoreRegKind::Ctrl) and
+     * `ffts_base_addr` on a2a3. DFX fields stay zero. Anything this
+     * allocates must come from `alloc` above, so release through `free_`
+     * matches and a host-only test's counts balance.
+     */
+    int (*fill_arch_fields)(void *context, KernelArgs *args, uint64_t device_id){nullptr};
+
+    bool valid() const {
+        return alloc != nullptr && free_ != nullptr && copy_h2d != nullptr && fill_arch_fields != nullptr;
+    }
+};
+
+/**
+ * Prepare-once / reuse-N-times / release-at-close owner of the three device
+ * blocks an AICore launch reads: the device `Runtime` image, the per-core
+ * register table, and the device copy of `KernelArgs` itself.
+ *
+ * Every operation this object performs happens in `prepare_once` and
+ * `finalize_once`. The destructor performs none, so an owner that is dropped
+ * without `finalize_once` leaks its device blocks rather than freeing memory
+ * an in-flight device program may still read.
+ *
+ * The ops table is stored at `prepare_once` because `finalize_once` and
+ * `abandon` run from a teardown path that no longer has it, the same reason
+ * `KernelExecutionState` stores its own.
+ */
+class PersistentKernelArgs {
+public:
+    PersistentKernelArgs() = default;
+    ~PersistentKernelArgs() = default;
+    PersistentKernelArgs(const PersistentKernelArgs &) = delete;
+    PersistentKernelArgs &operator=(const PersistentKernelArgs &) = delete;
+
+    /**
+     * Allocate and populate the three device blocks. Idempotent: a second
+     * call on a prepared owner returns 0 without allocating, which is what
+     * makes it correct to call from every prepare_callable.
+     *
+     * A failure at any step releases whatever this call allocated, in reverse
+     * order, and leaves the owner unprepared with all three fields back at
+     * their unset values; the original failure code is returned.
+     */
+    int prepare_once(const Runtime &host_runtime, const PersistentArgsOps &ops, uint64_t device_id);
+
+    bool is_prepared() const { return prepared_; }
+
+    /** Device address of the `KernelArgs` copy AICore's kernel entry receives. */
+    KernelArgs *device_k_args() const { return device_k_args_; }
+
+    const KernelArgs &args() const { return args_; }
+
+    /**
+     * Release the three device blocks in reverse allocation order. Idempotent.
+     *
+     * A failed release keeps its address so a retry redoes only the remainder,
+     * and leaves the owner prepared; the first failure code is returned.
+     */
+    int finalize_once();
+
+    /**
+     * Drop the device-address bookkeeping without calling the ops table. The
+     * device blocks are gone with the reset or quarantined device that made
+     * releasing them meaningless.
+     */
+    void abandon();
+
+private:
+    int release_block(void *block, int &first_error);
+
+    KernelArgs args_{};
+    KernelArgs *device_k_args_{nullptr};
+    PersistentArgsOps ops_{};
+    bool prepared_{false};
+};

--- a/src/common/platform/onboard/host/kernel_persistent_args.h
+++ b/src/common/platform/onboard/host/kernel_persistent_args.h
@@ -56,7 +56,8 @@ struct PersistentArgsOps {
      * arches (a2a3 additionally selecting AicoreRegKind::Ctrl) and
      * `ffts_base_addr` on a2a3. DFX fields stay zero. Anything this
      * allocates must come from `alloc` above, so release through `free_`
-     * matches and a host-only test's counts balance.
+     * matches and a host-only test's counts balance. Every successful
+     * allocation is recorded in args even on failure; the owner rolls it back.
      */
     int (*fill_arch_fields)(void *context, KernelArgs *args, uint64_t device_id){nullptr};
 
@@ -91,16 +92,19 @@ public:
      * call on a prepared owner returns 0 without allocating, which is what
      * makes it correct to call from every prepare_callable.
      *
-     * A failure at any step releases whatever this call allocated, in reverse
-     * order, and leaves the owner unprepared with all three fields back at
-     * their unset values; the original failure code is returned.
+     * Failure revokes readiness and rolls back in reverse order. Failed
+     * releases retain ownership until finalize_once succeeds or abandon is
+     * called. Preparation is rejected while such resources remain.
      */
     int prepare_once(const Runtime &host_runtime, const PersistentArgsOps &ops, uint64_t device_id);
 
     bool is_prepared() const { return prepared_; }
+    bool has_live_resources() const {
+        return device_k_args_ != nullptr || args_.regs != 0 || args_.runtime_args != nullptr;
+    }
 
     /** Device address of the `KernelArgs` copy AICore's kernel entry receives. */
-    KernelArgs *device_k_args() const { return device_k_args_; }
+    KernelArgs *device_k_args() const { return prepared_ ? device_k_args_ : nullptr; }
 
     const KernelArgs &args() const { return args_; }
 
@@ -108,7 +112,7 @@ public:
      * Release the three device blocks in reverse allocation order. Idempotent.
      *
      * A failed release keeps its address so a retry redoes only the remainder,
-     * and leaves the owner prepared; the first failure code is returned.
+     * and leaves the owner unprepared; the first failure code is returned.
      */
     int finalize_once();
 

--- a/src/common/platform/onboard/host/kernel_platform_ops.cpp
+++ b/src/common/platform/onboard/host/kernel_platform_ops.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * CANN implementation of the kernel-mode context vocabulary.
+ *
+ * Linked into both a2a3 and a5 `libhost_runtime.so`.
+ */
+
+#include "kernel_platform_ops.h"
+
+#include <acl/acl.h>
+#include <runtime/rt.h>
+
+#include "common/unified_log.h"
+#include "host/acl_error_log.h"
+
+namespace {
+
+int get_current_device(void *, int *device_id) {
+    int32_t current = -1;
+    const aclError rc = aclrtGetDevice(&current);
+    if (rc != ACL_SUCCESS) {
+        LOG_ERROR("kernel context: aclrtGetDevice failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    *device_id = static_cast<int>(current);
+    return 0;
+}
+
+int create_hidden_stream(void *, void **stream) {
+    rtStream_t created = nullptr;
+    const rtError_t rc = rtStreamCreate(&created, 0);
+    if (rc != RT_ERROR_NONE) {
+        LOG_ERROR("kernel context: rtStreamCreate failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    *stream = created;
+    return 0;
+}
+
+int destroy_hidden_stream(void *, void *stream) {
+    const rtError_t rc = rtStreamDestroy(static_cast<rtStream_t>(stream));
+    if (rc != RT_ERROR_NONE) {
+        LOG_ERROR("kernel context: rtStreamDestroy failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    return 0;
+}
+
+int create_event(void *, uint32_t flag, void **event) {
+    aclrtEvent created = nullptr;
+    const aclError rc = aclrtCreateEventExWithFlag(&created, flag);
+    if (rc != ACL_SUCCESS) {
+        LOG_ERROR("kernel context: aclrtCreateEventExWithFlag(flag=0x%x) failed: %d", flag, static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    *event = created;
+    return 0;
+}
+
+int destroy_event(void *, void *event) {
+    const aclError rc = aclrtDestroyEvent(static_cast<aclrtEvent>(event));
+    if (rc != ACL_SUCCESS) {
+        LOG_ERROR("kernel context: aclrtDestroyEvent failed: %d", static_cast<int>(rc));
+        ACL_LOG_ERROR_DETAIL(rc);
+        return static_cast<int>(rc);
+    }
+    return 0;
+}
+
+}  // namespace
+
+KernelContextOps make_onboard_kernel_context_ops() {
+    KernelContextOps ops{};
+    ops.get_current_device = &get_current_device;
+    ops.create_hidden_stream = &create_hidden_stream;
+    ops.destroy_hidden_stream = &destroy_hidden_stream;
+    ops.event_flag = ACL_EVENT_SYNC;
+    ops.create_event = &create_event;
+    ops.destroy_event = &destroy_event;
+    return ops;
+}

--- a/src/common/platform/onboard/host/kernel_platform_ops.h
+++ b/src/common/platform/onboard/host/kernel_platform_ops.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The CANN backing of the kernel-mode context vocabulary.
+ *
+ * Every platform constant the context lifecycle needs — chiefly the event
+ * creation flag — is resolved here, so KernelExecutionState stays free of
+ * CANN and its host-only tests keep observing the values this platform
+ * actually asks for.
+ */
+
+#pragma once
+
+#include "host/kernel_execution_state.h"
+
+/**
+ * The context-lifetime operation table backed by CANN.
+ *
+ * Every entry is a free CANN call, so the table carries no receiver and its
+ * `context` stays null. Events are created with ACL_EVENT_SYNC: the launch
+ * sequence waits on them from a stream and never queries their status from
+ * the host.
+ */
+KernelContextOps make_onboard_kernel_context_ops();

--- a/src/common/platform/onboard/host/tmr_kernel_invocation.cpp
+++ b/src/common/platform/onboard/host/tmr_kernel_invocation.cpp
@@ -9,35 +9,14 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#pragma once
+#include "tmr_kernel_invocation.h"
 
-#include "aicpu_loader/host/load_aicpu_op.h"
-#include "worker/runtime_c_api.h"
-#include "worker/tmr_kernel_invocation.h"
-
-class DeviceRunnerBase;
+#include "device_runner_base.h"
 
 namespace simpler::tmr {
 
-inline constexpr char TmrKernelInvocationName[] = "simpler_aicpu_kernel_exec";
-
-// The runner owns the initialized loader. The same borrowing and complete
-// enqueue/commit contract below applies to this production transport adapter.
 int enqueue_tmr_invocation_aicpu(
     DeviceRunnerBase &runner, void *stream, int32_t aicpu_num, const TmrEncodingCandidate &candidate,
-    const PreparedInvocationView &callable, const TmrExecutionBindingView &binding
-) noexcept;
-
-// Called by the owner's KernelLaunchOps::launch_aicpu callback. The owner
-// holds candidate, callable and binding live through this call and commits
-// its encoding cache only after the complete enqueue sequence succeeds.
-// stream is the owner's dedicated AICPU stream, not the borrowed caller
-// stream. The owner establishes event ordering outside this transport call.
-// The loader must have registered the kernel-mode entry, not the program
-// KernelArgs entry. CPU transport copy/lifetime support is a platform
-// integration precondition, verified with the native snapshot probe.
-inline int enqueue_tmr_invocation_aicpu(
-    host::LoadAicpuOp &loader, void *stream, int32_t aicpu_num, const TmrEncodingCandidate &candidate,
     const PreparedInvocationView &callable, const TmrExecutionBindingView &binding
 ) noexcept {
     if (stream == nullptr || aicpu_num <= 0) return PTO_RUNTIME_ERR_INTERNAL;
@@ -47,8 +26,8 @@ inline int enqueue_tmr_invocation_aicpu(
     if (status != InvocationStatus::Ok) return PTO_RUNTIME_ERR_INTERNAL;
     try {
         const auto packet = candidate.packet();
-        return loader.LaunchBuiltInOp(
-            stream, const_cast<uint8_t *>(packet.data), packet.size, aicpu_num, TmrKernelInvocationName
+        return runner.launch_aicpu_payload(
+            stream, const_cast<uint8_t *>(packet.data), packet.size, TmrKernelInvocationName, aicpu_num
         );
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;

--- a/src/common/platform/onboard/host/tmr_kernel_invocation.h
+++ b/src/common/platform/onboard/host/tmr_kernel_invocation.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "aicpu_loader/host/load_aicpu_op.h"
+#include "worker/runtime_c_api.h"
+#include "worker/tmr_kernel_invocation.h"
+
+namespace simpler::tmr {
+
+inline constexpr char TmrKernelInvocationName[] = "simpler_aicpu_kernel_exec";
+
+// Called by the owner's KernelLaunchOps::launch_aicpu callback. The owner
+// holds candidate, callable and binding live through this call and commits
+// its encoding cache only after the complete enqueue sequence succeeds.
+// stream is the owner's dedicated AICPU stream, not the borrowed caller
+// stream. The owner establishes event ordering outside this transport call.
+// The loader must have registered the kernel-mode entry, not the program
+// KernelArgs entry. CPU transport copy/lifetime support is a platform
+// integration precondition, verified with the native snapshot probe.
+inline int enqueue_tmr_invocation_aicpu(
+    host::LoadAicpuOp &loader, void *stream, int32_t aicpu_num, const TmrEncodingCandidate &candidate,
+    const PreparedInvocationView &callable, const TmrExecutionBindingView &binding
+) noexcept {
+    if (stream == nullptr || aicpu_num <= 0) return PTO_RUNTIME_ERR_INTERNAL;
+    const auto status = validate_tmr_submission(candidate, callable, binding);
+    if (status == InvocationStatus::StaleCallable || status == InvocationStatus::InvalidBinding)
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    if (status != InvocationStatus::Ok) return PTO_RUNTIME_ERR_INTERNAL;
+    try {
+        const auto packet = candidate.packet();
+        return loader.LaunchBuiltInOp(
+            stream, const_cast<uint8_t *>(packet.data), packet.size, aicpu_num, TmrKernelInvocationName
+        );
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+}
+
+}  // namespace simpler::tmr

--- a/src/common/platform/shared/host/kernel_execution_state.cpp
+++ b/src/common/platform/shared/host/kernel_execution_state.cpp
@@ -31,7 +31,7 @@ int KernelExecutionState::initialize(int requested_device_id, const KernelContex
     }
     if (rc == 0) {
         for (auto &event : events_) {
-            rc = ops_.create_event(ops_.context, &event);
+            rc = ops_.create_event(ops_.context, ops_.event_flag, &event);
             if (rc != 0) break;
         }
     }

--- a/src/common/platform/shared/host/kernel_execution_state.cpp
+++ b/src/common/platform/shared/host/kernel_execution_state.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/kernel_execution_state.h"
+
+int KernelExecutionState::initialize(int requested_device_id, const KernelContextOps &ops) {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::New) return PTO_RUNTIME_ERR_INVALID_STATE;
+    if (requested_device_id < 0 || !ops.valid()) return PTO_RUNTIME_ERR_INTERNAL;
+
+    int current_device = -1;
+    int rc = ops.get_current_device(ops.context, &current_device);
+    if (rc != 0) return rc;
+    if (current_device != requested_device_id) return PTO_RUNTIME_ERR_INVALID_STATE;
+
+    phase_ = KernelContextPhase::Initializing;
+    ops_ = ops;
+    device_id_ = requested_device_id;
+
+    for (auto &stream : hidden_streams_) {
+        rc = ops_.create_hidden_stream(ops_.context, &stream);
+        if (rc != 0) break;
+    }
+    if (rc == 0) {
+        for (auto &event : events_) {
+            rc = ops_.create_event(ops_.context, &event);
+            if (rc != 0) break;
+        }
+    }
+    if (rc != 0) {
+        const int cleanup_rc = cleanup_owned_resources_locked();
+        if (cleanup_rc != 0) {
+            if (unexpected_teardown_error_ == 0) unexpected_teardown_error_ = cleanup_rc;
+            phase_ = KernelContextPhase::Closing;
+        } else {
+            phase_ = KernelContextPhase::New;
+            device_id_ = -1;
+            ops_ = {};
+        }
+        return rc;
+    }
+
+    phase_ = KernelContextPhase::Collecting;
+    return 0;
+}
+
+int KernelExecutionState::mark_ready_enqueued() {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::Collecting && phase_ != KernelContextPhase::ReadyEnqueued) {
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    phase_ = KernelContextPhase::ReadyEnqueued;
+    return 0;
+}
+
+void KernelExecutionState::poison(int runtime_error) {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::Collecting && phase_ != KernelContextPhase::ReadyEnqueued) return;
+    phase_ = KernelContextPhase::Poisoned;
+    if (last_runtime_error_ == 0) last_runtime_error_ = runtime_error;
+}
+
+int KernelExecutionState::close() {
+    std::scoped_lock lock(mutex_);
+    switch (phase_) {
+    case KernelContextPhase::New:
+        phase_ = KernelContextPhase::Closed;
+        return 0;
+    case KernelContextPhase::Closed:
+        return 0;
+    case KernelContextPhase::Initializing:
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    case KernelContextPhase::Collecting:
+    case KernelContextPhase::ReadyEnqueued:
+    case KernelContextPhase::Poisoned:
+    case KernelContextPhase::Closing:
+        break;
+    }
+    phase_ = KernelContextPhase::Closing;
+    const int rc = cleanup_owned_resources_locked();
+    if (rc != 0) {
+        if (unexpected_teardown_error_ == 0) unexpected_teardown_error_ = rc;
+        return rc;
+    }
+    phase_ = KernelContextPhase::Closed;
+    return 0;
+}
+
+int KernelExecutionState::cleanup_owned_resources_locked() {
+    int first_error = 0;
+    for (size_t i = events_.size(); i > 0; --i) {
+        void *&event = events_[i - 1];
+        if (event == nullptr) continue;
+        const int rc = ops_.destroy_event(ops_.context, event);
+        if (rc != 0) {
+            if (first_error == 0) first_error = rc;
+            continue;
+        }
+        event = nullptr;
+    }
+    for (size_t i = hidden_streams_.size(); i > 0; --i) {
+        void *&stream = hidden_streams_[i - 1];
+        if (stream == nullptr) continue;
+        const int rc = ops_.destroy_hidden_stream(ops_.context, stream);
+        if (rc != 0) {
+            if (first_error == 0) first_error = rc;
+            continue;
+        }
+        stream = nullptr;
+    }
+    return first_error;
+}
+
+KernelContextPhase KernelExecutionState::phase() const {
+    std::scoped_lock lock(mutex_);
+    return phase_;
+}
+
+bool KernelExecutionState::accepts_dispatch() const {
+    std::scoped_lock lock(mutex_);
+    return phase_ == KernelContextPhase::Collecting || phase_ == KernelContextPhase::ReadyEnqueued;
+}
+
+int KernelExecutionState::device_id() const {
+    std::scoped_lock lock(mutex_);
+    return device_id_;
+}
+
+int KernelExecutionState::last_runtime_error() const {
+    std::scoped_lock lock(mutex_);
+    return last_runtime_error_;
+}
+
+int KernelExecutionState::unexpected_teardown_error() const {
+    std::scoped_lock lock(mutex_);
+    return unexpected_teardown_error_;
+}
+
+bool KernelExecutionState::has_live_resources() const {
+    std::scoped_lock lock(mutex_);
+    return has_live_resources_locked();
+}
+
+bool KernelExecutionState::has_live_resources_locked() const {
+    for (void *stream : hidden_streams_) {
+        if (stream != nullptr) return true;
+    }
+    for (void *event : events_) {
+        if (event != nullptr) return true;
+    }
+    return false;
+}
+
+void *KernelExecutionState::hidden_stream(KernelStreamKind kind) const {
+    std::scoped_lock lock(mutex_);
+    return hidden_streams_[static_cast<size_t>(kind)];
+}
+
+void *KernelExecutionState::event(KernelEventKind kind) const {
+    std::scoped_lock lock(mutex_);
+    return events_[static_cast<size_t>(kind)];
+}

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -24,9 +24,11 @@
 #include "runtime_c_api.h"
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -433,6 +435,18 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
+
     runner->set_dma_workspace_request(enable_sdma != 0);
 
     int rc;
@@ -1010,6 +1024,49 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
 int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * Simulation never supports kernel mode: it has no real streams for a caller
+ * to lend. supported() is 0 and init refuses after the shared structural
+ * validation, so no context here ever latches kernel mode and
+ * prepare/launch reject with INVALID_STATE. Argument validation is shared
+ * with every other component through kernel_entry_validation.h, so an
+ * argument this stub accepts is one the onboard path accepts too.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by the simulator");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -29,6 +29,8 @@
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "host/kernel_entry_validation.h"
+#include "host/kernel_pipeline_contract.h"
+#include "worker/pipeline_contract.h"
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -1049,6 +1051,17 @@ int simpler_kernel_mode_init(
         config, context_generation
     );
     if (rc != 0) return rc;
+    try {
+        PipelineContract contract{};
+        const int rc = build_kernel_pipeline_contract_impl(config, &contract);
+        if (rc != 0) return rc;
+        if (!is_valid_pipeline_contract(&contract, SIMPLER_MODE_KERNEL) || !has_serviceable_arena_topology(contract) ||
+            !has_serviceable_stream_topology(contract)) {
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
+    } catch (...) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
     LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by the simulator");
     return PTO_RUNTIME_ERR_UNSUPPORTED;
 }

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -29,6 +29,7 @@
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
 #include "host/kernel_entry_validation.h"
+#include "host/kernel_static_config.h"
 #include "host/kernel_pipeline_contract.h"
 #include "worker/pipeline_contract.h"
 #include "prepare_callable_common.h"
@@ -1053,6 +1054,8 @@ int simpler_kernel_mode_init(
     if (rc != 0) return rc;
     try {
         PipelineContract contract{};
+        const int config_rc = KernelStaticConfig::validate(config);
+        if (config_rc != 0) return config_rc;
         const int rc = build_kernel_pipeline_contract_impl(config, &contract);
         if (rc != 0) return rc;
         if (!is_valid_pipeline_contract(&contract, SIMPLER_MODE_KERNEL) || !has_serviceable_arena_topology(contract) ||

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -1067,9 +1067,9 @@ int simpler_kernel_mode_init(
 }
 
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
-    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size);
     if (rc != 0) return rc;
     LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
     return PTO_RUNTIME_ERR_INVALID_STATE;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -141,7 +141,26 @@ int SimDeviceRunnerBase::setup_static_arena(
     // worker's lifetime). If a caller asks for a larger layout on any
     // region, redo just that region.
     bool arena_changed = false;
-    auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+    // A kernel-mode context's config is context-static, so each region is
+    // committed at most once and never grown or released afterwards; captured
+    // graphs may hold the committed base address. A request that would
+    // re-base or release a committed region under kernel mode is therefore an
+    // internal invariant break, not caller-configurable behavior. The refusal
+    // is not self-contained: the caller collapses a nonzero return to
+    // `ok = false` and then releases all three regions unconditionally, and
+    // DeviceArena::release() frees the backing buffer — so a fired guard drops
+    // the very base addresses it names.
+    const bool kernel_mode = execution_mode_latch().is_kernel();
+    auto commit_region = [&arena_changed,
+                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (requested_size == 0) {
             if (arena.is_committed() && cached_size != 0) {
                 arena.release();

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -55,6 +55,7 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "platform_comm/comm.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
@@ -260,6 +261,15 @@ public:
     void set_dma_workspace_request(bool enable_sdma) { sdma_requested_ = enable_sdma; }
     int ensure_dma_workspace_provisioned();
     int device_id() const { return device_id_; }
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. The arena guard keys on is_kernel(). Simulation never
+     * supports kernel mode — it has no real streams for a caller to lend — so
+     * on this backend the latch only ever holds PROGRAM.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
+
     uint64_t last_device_wall_ns() const { return device_wall_ns_; }
     // Per-phase AICPU wall (ns) from the most recent run; RunWall aliases
     // last_device_wall_ns(). 0 for a phase that was never stamped. Used to emit
@@ -368,13 +378,19 @@ protected:
     // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
 
-    // Configuration. device_id_ is set once in attach_current_thread() during
-    // simpler_init and read afterwards; the user's call sequence is single-
-    // threaded with respect to it so plain int is sufficient.
+    // Configuration. device_id_ is which device this context is on — not a
+    // claim of ownership, which the execution-mode latch carries instead. Set
+    // once in attach_current_thread() during simpler_init and read afterwards;
+    // the user's call sequence is single-threaded with respect to it so plain
+    // int is sufficient.
     int device_id_{-1};
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};
+
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
 
     // Executor binaries — populated once via set_executors() during simpler_init,
     // owned for the rest of the runner's lifetime.

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -40,6 +40,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "arg_direction.h"
@@ -108,6 +109,20 @@ struct Callable {
     int32_t child_count_;
     char config_name_[CALLABLE_FUNC_NAME_MAX];
     uint32_t config_name_len_;
+    // Cached derivation of the signature: the number of ArgDirection::SCALAR
+    // entries in signature_[0..sig_count_). The factory rejects a nonzero
+    // value that disagrees with the signature; 0 additionally means "not
+    // recorded", which a legacy blob and a scalar-free orchestration share.
+    // sig_count_ includes the scalar entries, so a consumer derives the
+    // effective count first — this field when nonzero, otherwise the
+    // signature's SCALAR entries, the split count_callable_tensor_args
+    // already computes — and takes sig_count_ minus that as the tensor
+    // comparandum. Subtracting this field directly counts an unrecorded
+    // callable's scalars as tensors. Occupies
+    // four bytes of the historical padding between config_name_len_ and the
+    // 16-byte-aligned storage_, so every other field keeps its wire offset
+    // and a legacy zero-initialized blob reads as scalar_count == 0.
+    int32_t scalar_count_;
     // Children live in storage_ at CALLABLE_ALIGN-aligned offsets, but the
     // all-uint32 header above can leave offsetof(storage_) at 4-mod-8, which
     // would place an 8-byte-aligned Child (CoreCallable has a uint64) on a
@@ -129,6 +144,9 @@ struct Callable {
     uint32_t func_name_len() const { return func_name_len_; }
     const char *config_name() const { return config_name_; }
     uint32_t config_name_len() const { return config_name_len_; }
+    // 0 means either an artifact built before this field existed or an
+    // orchestration that takes no scalars; the two are indistinguishable.
+    int32_t scalar_count() const { return scalar_count_; }
 
     const Child &child(int32_t i) const {
         if (i < 0 || i >= child_count_) throw std::out_of_range("Callable: child index out of range");
@@ -149,9 +167,9 @@ private:
 
     template <typename C, int MS, int MC>
     friend std::vector<uint8_t> make_callable(
-        const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
-        const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
-        const char *config_name
+        const ArgDirection *sig, int32_t sig_count, int32_t scalar_count, const char *func_name, const void *binary,
+        uint32_t binary_size, const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers,
+        int32_t child_count, const char *config_name
     );
 };
 
@@ -176,6 +194,43 @@ static_assert(
     offsetof(ChipCallable, storage_) % CALLABLE_CHILD_ALIGN == 0,
     "ChipCallable.storage_ must be CALLABLE_CHILD_ALIGN-aligned for SIMT kernel binaries"
 );
+
+// Callable bytes are shipped through L3/L4 IPC and the on-disk kernel cache,
+// so the header layout is wire ABI. scalar_count_ must consume tail padding
+// rather than move any historical field. The constants below encode
+// CHIP_MAX_TENSOR_ARGS = 256, CORE_MAX_TENSOR_ARGS = 32,
+// CALLABLE_FUNC_NAME_MAX = 64, and MaxChildren = 1024; a deliberate capacity
+// change updates them in the same commit.
+static_assert(
+    std::is_trivially_copyable_v<ChipCallable> && std::is_standard_layout_v<ChipCallable>,
+    "ChipCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(
+    std::is_trivially_copyable_v<CoreCallable> && std::is_standard_layout_v<CoreCallable>,
+    "CoreCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(offsetof(ChipCallable, signature_) == 0, "ChipCallable wire ABI: signature offset changed");
+static_assert(offsetof(ChipCallable, sig_count_) == 1024, "ChipCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(ChipCallable, binary_size_) == 1028, "ChipCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(ChipCallable, func_name_) == 1032, "ChipCallable wire ABI: func_name offset changed");
+static_assert(offsetof(ChipCallable, func_name_len_) == 1096, "ChipCallable wire ABI: func_name_len offset changed");
+static_assert(offsetof(ChipCallable, child_func_ids_) == 1100, "ChipCallable wire ABI: child_func_ids offset changed");
+static_assert(offsetof(ChipCallable, child_offsets_) == 5196, "ChipCallable wire ABI: child_offsets offset changed");
+static_assert(offsetof(ChipCallable, child_count_) == 9292, "ChipCallable wire ABI: child_count offset changed");
+static_assert(offsetof(ChipCallable, config_name_) == 9296, "ChipCallable wire ABI: config_name offset changed");
+static_assert(
+    offsetof(ChipCallable, config_name_len_) == 9360, "ChipCallable wire ABI: config_name_len offset changed"
+);
+static_assert(offsetof(ChipCallable, scalar_count_) == 9364, "ChipCallable wire ABI: scalar_count offset changed");
+static_assert(offsetof(ChipCallable, storage_) == 9376, "ChipCallable wire ABI: storage offset changed");
+static_assert(sizeof(ChipCallable) == 9376, "ChipCallable wire ABI: header size changed");
+static_assert(offsetof(CoreCallable, signature_) == 0, "CoreCallable wire ABI: signature offset changed");
+static_assert(offsetof(CoreCallable, sig_count_) == 128, "CoreCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(CoreCallable, binary_size_) == 132, "CoreCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(CoreCallable, resolved_addr_) == 136, "CoreCallable wire ABI: resolved_addr offset changed");
+static_assert(offsetof(CoreCallable, storage_) == 144, "CoreCallable wire ABI: storage offset changed");
+static_assert(sizeof(CoreCallable) == 144, "CoreCallable wire ABI: header size changed");
+static_assert(CoreCallable::binary_data_offset() == 192, "CoreCallable wire ABI: binary data offset changed");
 
 // ============================================================================
 // Factory: make_callable for static leaf
@@ -216,8 +271,8 @@ make_callable(const ArgDirection *sig, int32_t sig_count, const void *binary, ui
 
 template <typename Child, int MaxSig, int MaxChildren>
 std::vector<uint8_t> make_callable(
-    const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
-    const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
+    const ArgDirection *sig, int32_t sig_count, int32_t scalar_count, const char *func_name, const void *binary,
+    uint32_t binary_size, const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
     // No default arg here: the friend declaration above has none, so a default
     // on this definition is a "redeclaration may not have default arguments"
     // error once ChipCallable is instantiated (the static_assert below does
@@ -230,6 +285,27 @@ std::vector<uint8_t> make_callable(
             "make_callable: requested tensor count " + std::to_string(sig_count) + " exceeds supported tensor count " +
             std::to_string(MaxSig)
         );
+    }
+    if (scalar_count < 0 || scalar_count > CHIP_MAX_SCALAR_ARGS) {
+        throw std::invalid_argument(
+            "make_callable: requested scalar count " + std::to_string(scalar_count) +
+            " is outside the supported range [0, " + std::to_string(CHIP_MAX_SCALAR_ARGS) + "]"
+        );
+    }
+    // scalar_count is a cached derivation of the signature, so a nonzero
+    // value must match the signature's SCALAR entries; 0 stays valid with any
+    // signature because it also means "not recorded" (legacy semantics).
+    if (scalar_count != 0) {
+        int32_t signature_scalars = 0;
+        for (int32_t i = 0; i < sig_count; ++i) {
+            if (sig[i] == ArgDirection::SCALAR) ++signature_scalars;
+        }
+        if (scalar_count != signature_scalars) {
+            throw std::invalid_argument(
+                "make_callable: requested scalar count " + std::to_string(scalar_count) +
+                " disagrees with the signature's " + std::to_string(signature_scalars) + " SCALAR entries"
+            );
+        }
     }
     if (child_count > MaxChildren) throw std::invalid_argument("make_callable: child_count exceeds MaxChildren");
 
@@ -250,6 +326,7 @@ std::vector<uint8_t> make_callable(
     for (int32_t i = 0; i < sig_count; ++i)
         obj->signature_[i] = sig[i];
     obj->sig_count_ = sig_count;
+    obj->scalar_count_ = scalar_count;
     obj->binary_size_ = binary_size;
 
     // Store func_name (null-terminated, truncated to CALLABLE_FUNC_NAME_MAX-1)

--- a/src/common/task_interface/execution_mode.h
+++ b/src/common/task_interface/execution_mode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The one definition of a context's execution mode, shared by every layer
+ * that names it: the host-side identity latch on the platform runners, the
+ * invocation wire header, and the C ABI documentation. A context's mode is
+ * decided by which init entry runs first and never changes afterwards.
+ */
+
+#pragma once
+
+typedef enum SimplerExecutionMode {
+    /* Historical exclusive-device semantics, claimed by simpler_init. */
+    SIMPLER_MODE_PROGRAM = 0,
+    /* Borrowed-device semantics, claimed by simpler_kernel_mode_init. */
+    SIMPLER_MODE_KERNEL = 1,
+} SimplerExecutionMode;

--- a/src/common/task_interface/execution_mode.h
+++ b/src/common/task_interface/execution_mode.h
@@ -8,12 +8,18 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
+/**
+ * The one definition of a context's execution mode, shared by every layer
+ * that names it: the host-side identity latch on the platform runners, the
+ * invocation wire header, and the C ABI documentation. A context's mode is
+ * decided by which init entry runs first and never changes afterwards.
+ */
 
 #pragma once
 
 typedef enum SimplerExecutionMode {
-    /* Exclusive-device execution. */
+    /* Historical exclusive-device semantics, claimed by simpler_init. */
     SIMPLER_MODE_PROGRAM = 0,
-    /* Caller-stream execution on a borrowed device. */
+    /* Borrowed-device semantics, claimed by simpler_kernel_mode_init. */
     SIMPLER_MODE_KERNEL = 1,
 } SimplerExecutionMode;

--- a/src/common/task_interface/kernel_invocation_header.h
+++ b/src/common/task_interface/kernel_invocation_header.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unified invocation-args wire header (host → AICPU).
+ *
+ * Every kernel-mode launch ships one immutable args snapshot to the AICPU:
+ * this fixed header followed by `payload_bytes` of runtime-specific payload.
+ * The header is the shared envelope both runtimes use; the payload format
+ * under it belongs to each runtime (tensormap_and_ringbuffer carries
+ * graph-build input, host_build_graph carries a serialized graph blob) and is
+ * not constrained here. Validating identity, generation, and capacity against
+ * this header before dispatching to the runtime payload consumer is the AICPU
+ * dispatch entry's obligation: that validation lives with the consumers, not
+ * in this header, and no consumer implements it.
+ *
+ * Both sides of this wire are produced by the same build (`build_runtimes.py`
+ * emits the host runtime and the AICPU executor into one
+ * `build/lib/{arch}/{variant}/{runtime}/`), so the struct carries no version
+ * or size negotiation: evolving it means changing both sides in one tree.
+ * The layout is still shipped by memcpy through CANN's HostArgs deep copy, so
+ * the struct is POD, position-independent, and carries no pointers.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "execution_mode.h"
+
+typedef struct SimplerKernelInvocationHeader {
+    uint32_t mode;       /* SimplerExecutionMode of the issuing context */
+    int32_t callable_id; /* target callable; matches the prepared registration */
+    /* Occupancy generation of the residency slot `callable_id` resolves to —
+       a property of the slot, not of the callable in it. The counter advances
+       when the slot takes a different tenant, so a generation carried by the
+       callable could not detect slot reuse. Zero means "not recorded"; a live
+       generation starts at 1, matching PipelineSlotLease and CanonicalIdentity.
+       The comparison belongs on the AICPU dispatch path because replay does
+       not return to the host, so a stale captured snapshot has to be caught
+       on-device. Nothing mints this value and no device-side comparand
+       exists. */
+    uint64_t generation;
+    /* Byte length of the runtime-specific payload that follows this header. */
+    uint64_t payload_bytes;
+    /* Arg counts of this invocation. ChipCallable's sig_count includes the
+       scalar entries, and its scalar_count() reads 0 both for a scalar-free
+       orchestration and for an artifact built before that field existed, so
+       a consumer derives the effective scalar count first — scalar_count()
+       when nonzero, otherwise the signature's ArgDirection::SCALAR entries —
+       then checks tensor_count against sig_count minus it and scalar_count
+       against it. Subtracting scalar_count() directly would count an
+       unrecorded callable's scalars as tensors. */
+    int32_t tensor_count;
+    int32_t scalar_count;
+    /* Count of host-only duplicate tensor args (a tensor the host must read
+       is passed twice: a device arg plus a host-only copy). Zero until the
+       host-only copy contract lands; consumers reject nonzero meanwhile. */
+    int32_t host_copy_tensor_count;
+} SimplerKernelInvocationHeader;
+
+#ifdef __cplusplus
+#include <type_traits>
+
+static_assert(
+    std::is_trivially_copyable_v<SimplerKernelInvocationHeader> &&
+    std::is_standard_layout_v<SimplerKernelInvocationHeader>
+);
+#endif

--- a/src/common/task_interface/kernel_invocation_validation.h
+++ b/src/common/task_interface/kernel_invocation_validation.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "arg_direction.h"
+#include "callable_protocol.h"
+#include "kernel_invocation_header.h"
+
+namespace simpler::kernel {
+
+struct ByteSpan {
+    const uint8_t *data{nullptr};
+    size_t size{0};
+};
+
+enum class InvocationStatus {
+    Ok,
+    InvalidArgument,
+    InvalidHeader,
+    InvalidCounts,
+    InvalidSignature,
+    InvalidSize,
+    StaleCallable,
+    InvalidBinding,
+    InvalidTensor,
+    AllocationFailure,
+};
+
+// Values come from an independently validated, live prepared registration.
+// The resource owner protects publication and borrowing through consumption.
+// slot_generation versions callable residency, not its execution context.
+struct PreparedInvocationView {
+    int32_t callable_id;
+    int32_t tensor_count;
+    int32_t scalar_count;
+    uint64_t slot_generation;
+};
+
+inline bool valid_invocation_counts(int32_t tensors, int32_t scalars) noexcept {
+    return tensors >= 0 && tensors <= CHIP_MAX_TENSOR_ARGS && scalars >= 0 && scalars <= CHIP_MAX_SCALAR_ARGS &&
+           tensors + scalars <= CHIP_MAX_TENSOR_ARGS;
+}
+
+// signature names a readable, aligned array of sig_count entries; its owning
+// callable's flexible-array bounds are validated before this function is called.
+inline InvocationStatus derive_invocation_counts(
+    const ArgDirection *signature, int32_t sig_count, int32_t cached_scalars, int32_t *tensors, int32_t *scalars
+) noexcept {
+    if (tensors == nullptr || scalars == nullptr || (signature == nullptr && sig_count != 0))
+        return InvocationStatus::InvalidArgument;
+    if (sig_count < 0 || sig_count > CHIP_MAX_TENSOR_ARGS || cached_scalars < 0 ||
+        cached_scalars > CHIP_MAX_SCALAR_ARGS)
+        return InvocationStatus::InvalidCounts;
+    int32_t scalar_count = 0;
+    for (int32_t i = 0; i < sig_count; ++i) {
+        switch (signature[i]) {
+        case ArgDirection::SCALAR:
+            ++scalar_count;
+            break;
+        case ArgDirection::IN:
+        case ArgDirection::OUT:
+        case ArgDirection::INOUT:
+            if (scalar_count != 0) return InvocationStatus::InvalidSignature;
+            break;
+        default:
+            return InvocationStatus::InvalidSignature;
+        }
+    }
+    if (!valid_invocation_counts(sig_count - scalar_count, scalar_count) ||
+        (cached_scalars != 0 && cached_scalars != scalar_count))
+        return InvocationStatus::InvalidSignature;
+    *tensors = sig_count - scalar_count;
+    *scalars = scalar_count;
+    return InvocationStatus::Ok;
+}
+
+inline bool valid_prepared_invocation(const PreparedInvocationView &view) noexcept {
+    return view.callable_id >= 0 && view.callable_id < MAX_REGISTERED_CALLABLE_IDS && view.slot_generation != 0 &&
+           valid_invocation_counts(view.tensor_count, view.scalar_count);
+}
+
+inline InvocationStatus validate_invocation_header(
+    ByteSpan packet, const PreparedInvocationView &trusted, SimplerKernelInvocationHeader *out
+) noexcept {
+    if (out == nullptr || packet.data == nullptr) return InvocationStatus::InvalidArgument;
+    if (packet.size < sizeof(SimplerKernelInvocationHeader)) return InvocationStatus::InvalidSize;
+    SimplerKernelInvocationHeader header{};
+    std::memcpy(&header, packet.data, sizeof(header));
+    if (header.mode != SIMPLER_MODE_KERNEL || header.callable_id < 0 ||
+        header.callable_id >= MAX_REGISTERED_CALLABLE_IDS || header.generation == 0)
+        return InvocationStatus::InvalidHeader;
+    if (!valid_invocation_counts(header.tensor_count, header.scalar_count) || header.host_copy_tensor_count != 0)
+        return InvocationStatus::InvalidCounts;
+    if (header.payload_bytes != packet.size - sizeof(header)) return InvocationStatus::InvalidSize;
+    if (!valid_prepared_invocation(trusted)) return InvocationStatus::InvalidArgument;
+    if (header.callable_id != trusted.callable_id || header.generation != trusted.slot_generation)
+        return InvocationStatus::StaleCallable;
+    if (header.tensor_count != trusted.tensor_count || header.scalar_count != trusted.scalar_count)
+        return InvocationStatus::InvalidCounts;
+    *out = header;
+    return InvocationStatus::Ok;
+}
+
+}  // namespace simpler::kernel

--- a/src/common/tensormap_and_ringbuffer/callable_table_view.h
+++ b/src/common/tensormap_and_ringbuffer/callable_table_view.h
@@ -11,13 +11,20 @@
 
 #pragma once
 
-#include "worker/runtime_c_api.h"
+#include <cstddef>
+#include <cstdint>
 
-// Internal host-runtime hook, not a dlsym lifecycle API. Input is borrowed and
-// immutable during the call; output is caller-exclusive and unchanged on error.
-// No device resources are acquired or retained. Separate calls may run concurrently.
-extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out);
+namespace simpler::tmr {
 
-class Runtime;
-// Host-only preparation of runtime-specific static fields; no device work.
-int configure_kernel_runtime_impl(Runtime &runtime, bool serial_orch_sched);
+// Entries are device CoreCallable addresses, not instruction addresses.
+// The provider pins both the table and the callable images through all readers.
+struct CallableTableView {
+    const uint64_t *entries{nullptr};
+    size_t count{0};
+
+    uint64_t lookup(int32_t id) const noexcept {
+        if (entries == nullptr || id < 0 || static_cast<size_t>(id) >= count) return 0;
+        return entries[id];
+    }
+};
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/kernel_execution_inputs.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_execution_inputs.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <limits>
+
+#include "callable_table_view.h"
+#include "kernel_invocation_args.h"
+#include "runtime.h"
+#include "runtime_core.h"
+
+namespace simpler::tmr {
+
+struct ExecutionInputs {
+    int32_t callable_id{-1};
+    const EntryArgsStorage *args{nullptr};
+    CallableTableView functions{};
+    void *sm{nullptr};
+    void *arena{nullptr};
+    size_t runtime_offset{0};
+};
+
+inline ExecutionInputs program_execution_inputs(const Runtime &runtime) {
+    return {
+        runtime.get_active_callable_id(),
+        &runtime.get_orch_args(),
+        {runtime.dev.func_id_to_addr_, RUNTIME_MAX_FUNC_ID},
+        runtime.get_gm_sm_ptr(),
+        runtime.get_prebuilt_arena_base(),
+        runtime.get_prebuilt_runtime_offset()
+    };
+}
+
+// Trusted, process-local views; none of these C++ objects is a transport wire.
+// required_bytes and the initialized arena layout come from the resource provider.
+struct ExecutionRegionView {
+    void *base{nullptr};
+    size_t capacity{0};
+    size_t required_bytes{0};
+};
+
+struct KernelBindingView {
+    TmrExecutionBindingView identity{};
+    Runtime *resident{nullptr};
+    ExecutionRegionView sm{};
+    ExecutionRegionView arena{};
+    size_t runtime_offset{0};
+};
+
+struct KernelCallableView {
+    PreparedInvocationView identity{};
+    CallableTableView functions{};
+};
+
+inline bool valid_execution_region(const ExecutionRegionView &region, size_t alignment) noexcept {
+    const uintptr_t base = reinterpret_cast<uintptr_t>(region.base);
+    return base != 0 && base % alignment == 0 && region.required_bytes != 0 &&
+           region.required_bytes <= region.capacity && region.capacity <= std::numeric_limits<uintptr_t>::max() - base;
+}
+
+inline InvocationStatus validate_execution_binding(const KernelBindingView &binding) noexcept {
+    if (binding.identity.device_binding_addr == 0 || binding.identity.context_generation == 0 ||
+        binding.resident == nullptr || reinterpret_cast<uintptr_t>(binding.resident) % alignof(Runtime) != 0 ||
+        !valid_execution_region(binding.sm, alignof(SharedMemoryHeader)) ||
+        binding.sm.required_bytes < sizeof(SharedMemoryHeader) ||
+        !valid_execution_region(binding.arena, DeviceArena::kDefaultBaseAlign) ||
+        binding.runtime_offset > binding.arena.required_bytes ||
+        sizeof(RuntimeContext) > binding.arena.required_bytes - binding.runtime_offset ||
+        (reinterpret_cast<uintptr_t>(binding.arena.base) + binding.runtime_offset) % alignof(RuntimeContext) != 0)
+        return InvocationStatus::InvalidBinding;
+    return InvocationStatus::Ok;
+}
+
+// One execution's storage, owned by the existing executor. Admission and clear
+// require exclusive ownership; readers join before clear or a following admission.
+// The provider has already published the arena image and pins all borrowed views.
+class KernelInvocationState {
+public:
+    InvocationStatus
+    admit(ByteSpan packet, const KernelCallableView &callable, const KernelBindingView &binding) noexcept {
+        if (active_) return InvocationStatus::InvalidArgument;
+        const auto status = validate_execution_binding(binding);
+        if (status != InvocationStatus::Ok) return status;
+        if (callable.functions.count > RUNTIME_MAX_FUNC_ID ||
+            reinterpret_cast<uintptr_t>(callable.functions.entries) % alignof(uint64_t) != 0 ||
+            (callable.functions.count != 0 && callable.functions.entries == nullptr))
+            return InvocationStatus::InvalidBinding;
+        const auto decoded = consume_tmr_invocation(packet, callable.identity, binding.identity, &storage_);
+        if (decoded != InvocationStatus::Ok) return decoded;
+        inputs_ = {callable.identity.callable_id, &storage_, callable.functions, binding.sm.base, binding.arena.base,
+                   binding.runtime_offset};
+        resident_ = binding.resident;
+        active_ = true;
+        return InvocationStatus::Ok;
+    }
+
+    bool active() const { return active_; }
+    Runtime *resident() const { return resident_; }
+    const ExecutionInputs &inputs() const { return inputs_; }
+    // All ChipTaskArgs/TensorRef borrowers must be reset before this call.
+    void clear() {
+        inputs_ = {};
+        resident_ = nullptr;
+        storage_.clear();
+        active_ = false;
+    }
+
+private:
+    EntryArgsStorage storage_{};
+    ExecutionInputs inputs_{};
+    Runtime *resident_{nullptr};
+    bool active_{false};
+};
+
+inline bool configure_orchestration_args(
+    const ExecutionInputs &inputs, ChipTaskArgs &args, OrchestrationConfig (*config)(const ChipTaskArgs &)
+) {
+    args.create_from_entry_storage(*inputs.args);
+    if (config == nullptr) return true;
+    const auto cfg = config(args);
+    return cfg.expected_arg_count <= 0 ||
+           inputs.args->tensor_count() + inputs.args->scalar_count() >= cfg.expected_arg_count;
+}
+
+// Internal device consumption phases. Admission/release have one owner;
+// init/run execute on the admitted affinity group. No launch symbol is registered.
+// Caller supplies publication, cancellation, and an all-consumers-complete barrier.
+InvocationStatus
+admit_kernel_execution(ByteSpan packet, const KernelCallableView &, const KernelBindingView &) noexcept;
+int32_t init_kernel_execution();
+int32_t run_kernel_execution();
+int32_t kernel_execution_status();
+void release_kernel_execution();
+
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/kernel_invocation.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_invocation.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstring>
+#include <limits>
+#include <type_traits>
+
+#include "task_interface/kernel_invocation_validation.h"
+#include "task_interface/tensor.h"
+
+namespace simpler::tmr {
+
+using kernel::ByteSpan;
+using kernel::InvocationStatus;
+using kernel::PreparedInvocationView;
+
+// Borrowed from the owner of an immutable execution binding. This view does
+// not allocate, publish, retain or release the referenced device resources.
+// The provider owns the binding format and capacity validation. The address
+// is opaque here; context_generation is independent of callable residency.
+struct TmrExecutionBindingView {
+    uint64_t device_binding_addr;
+    uint64_t context_generation;
+};
+
+struct TmrBindingRef {
+    uint64_t device_binding_addr;
+    uint64_t context_generation;
+};
+static_assert(std::is_trivially_copyable_v<TmrBindingRef> && std::is_standard_layout_v<TmrBindingRef>);
+static_assert(sizeof(TmrBindingRef) == 16);
+static_assert(offsetof(TmrBindingRef, device_binding_addr) == 0);
+static_assert(offsetof(TmrBindingRef, context_generation) == 8);
+
+inline InvocationStatus tmr_invocation_size(const PreparedInvocationView &callable, size_t *out) noexcept {
+    if (out == nullptr || !kernel::valid_prepared_invocation(callable)) return InvocationStatus::InvalidArgument;
+    // Validated counts bound each term and the sum on all supported hosts.
+    *out = sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef) +
+           static_cast<size_t>(callable.tensor_count) * sizeof(ChipTensor) +
+           static_cast<size_t>(callable.scalar_count) * sizeof(uint64_t);
+    return InvocationStatus::Ok;
+}
+
+inline InvocationStatus normalize_invocation_tensor(const ChipTensor &input, ChipTensor *out) noexcept {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    const uint64_t element_bytes = get_element_size(input.dtype);
+    if (input.address_space != AddressSpace::DEVICE || element_bytes == 0 || input.ndims == 0 ||
+        input.ndims > MAX_TENSOR_DIMS)
+        return InvocationStatus::InvalidTensor;
+    bool empty = false;
+    for (uint32_t i = 0; i < input.ndims; ++i)
+        empty |= input.shapes[i] == 0;
+    if (!empty) {
+        const uint64_t limit = std::numeric_limits<uint64_t>::max();
+        uint64_t elements = 1;
+        uint64_t extent = 1;
+        for (uint32_t i = 0; i < input.ndims; ++i) {
+            if (input.strides[i] == 0 || elements > limit / input.shapes[i]) return InvocationStatus::InvalidTensor;
+            elements *= input.shapes[i];
+            const uint64_t term = static_cast<uint64_t>(input.shapes[i] - 1) * input.strides[i];
+            if (term > limit - extent) return InvocationStatus::InvalidTensor;
+            extent += term;
+        }
+        if (elements > limit / element_bytes || input.buffer.addr == 0 ||
+            input.buffer.size > limit - input.buffer.addr || input.start_offset > limit - extent ||
+            input.start_offset + extent > input.buffer.size / element_bytes)
+            return InvocationStatus::InvalidTensor;
+    }
+    // Empty views capture no bytes. Canonical row-major empty shapes can have
+    // zero strides; neither an address nor backing bytes are required.
+    ChipTensor normalized;
+    std::memset(&normalized, 0, sizeof(normalized));
+    normalized.buffer = input.buffer;
+    normalized.start_offset = input.start_offset;
+    normalized.ndims = input.ndims;
+    normalized.dtype = input.dtype;
+    normalized.address_space = input.address_space;
+    for (uint32_t i = 0; i < input.ndims; ++i) {
+        normalized.shapes[i] = input.shapes[i];
+        normalized.strides[i] = input.strides[i];
+    }
+    std::memcpy(out, &normalized, sizeof(normalized));
+    return InvocationStatus::Ok;
+}
+
+class TmrInvocationView;
+inline InvocationStatus decode_tmr_invocation(
+    ByteSpan packet, const PreparedInvocationView &trusted_callable, const TmrExecutionBindingView &trusted_binding,
+    TmrInvocationView *out
+) noexcept;
+
+// The immutable packet storage outlives this view and every read through it.
+class TmrInvocationView {
+public:
+    int32_t tensor_count() const noexcept { return header_.tensor_count; }
+    int32_t scalar_count() const noexcept { return header_.scalar_count; }
+    bool valid() const noexcept { return packet_.data != nullptr; }
+
+    bool tensor(int32_t index, ChipTensor *out) const noexcept {
+        if (out == nullptr || !valid() || index < 0 || index >= tensor_count()) return false;
+        const size_t offset = sizeof(header_) + sizeof(TmrBindingRef) + static_cast<size_t>(index) * sizeof(*out);
+        std::memcpy(out, packet_.data + offset, sizeof(*out));
+        return true;
+    }
+
+    bool scalar(int32_t index, uint64_t *out) const noexcept {
+        if (out == nullptr || !valid() || index < 0 || index >= scalar_count()) return false;
+        const size_t offset = sizeof(header_) + sizeof(TmrBindingRef) +
+                              static_cast<size_t>(tensor_count()) * sizeof(ChipTensor) +
+                              static_cast<size_t>(index) * sizeof(*out);
+        std::memcpy(out, packet_.data + offset, sizeof(*out));
+        return true;
+    }
+
+private:
+    ByteSpan packet_{};
+    SimplerKernelInvocationHeader header_{};
+    friend InvocationStatus decode_tmr_invocation(
+        ByteSpan, const PreparedInvocationView &, const TmrExecutionBindingView &, TmrInvocationView *
+    ) noexcept;
+};
+
+inline InvocationStatus decode_tmr_invocation(
+    ByteSpan packet, const PreparedInvocationView &trusted_callable, const TmrExecutionBindingView &trusted_binding,
+    TmrInvocationView *out
+) noexcept {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    TmrInvocationView candidate;
+    auto status = kernel::validate_invocation_header(packet, trusted_callable, &candidate.header_);
+    if (status != InvocationStatus::Ok) return status;
+    size_t expected_bytes = 0;
+    status = tmr_invocation_size(trusted_callable, &expected_bytes);
+    if (status != InvocationStatus::Ok) return status;
+    if (packet.size != expected_bytes) return InvocationStatus::InvalidSize;
+    TmrBindingRef binding{};
+    std::memcpy(&binding, packet.data + sizeof(SimplerKernelInvocationHeader), sizeof(binding));
+    if (trusted_binding.device_binding_addr == 0 || trusted_binding.context_generation == 0 ||
+        binding.device_binding_addr != trusted_binding.device_binding_addr ||
+        binding.context_generation != trusted_binding.context_generation)
+        return InvocationStatus::InvalidBinding;
+    candidate.packet_ = packet;
+    for (int32_t i = 0; i < candidate.tensor_count(); ++i) {
+        ChipTensor tensor{};
+        ChipTensor normalized{};
+        candidate.tensor(i, &tensor);
+        status = normalize_invocation_tensor(tensor, &normalized);
+        if (status != InvocationStatus::Ok) return status;
+    }
+    *out = candidate;
+    return InvocationStatus::Ok;
+}
+
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include "entry_args.h"
+#include "kernel_invocation.h"
+
+namespace simpler::tmr {
+
+// out is caller-owned invocation storage and outlives config/orchestration
+// and every TensorRef derived from it. It is not a persistent Runtime prefix.
+inline InvocationStatus materialize_tmr_entry_args(const TmrInvocationView &view, EntryArgsStorage *out) noexcept {
+    if (out == nullptr || !view.valid()) return InvocationStatus::InvalidArgument;
+    out->clear();
+    for (int32_t i = 0; i < view.tensor_count(); ++i) {
+        ChipTensor tensor{};
+        view.tensor(i, &tensor);
+        out->tensors_[i] = Tensor::from_boundary(tensor);
+    }
+    for (int32_t i = 0; i < view.scalar_count(); ++i)
+        view.scalar(i, &out->scalars_[i]);
+    out->tensor_count_ = view.tensor_count();
+    out->scalar_count_ = view.scalar_count();
+    return InvocationStatus::Ok;
+}
+
+}  // namespace simpler::tmr

--- a/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
+++ b/src/common/tensormap_and_ringbuffer/kernel_invocation_args.h
@@ -33,4 +33,18 @@ inline InvocationStatus materialize_tmr_entry_args(const TmrInvocationView &view
     return InvocationStatus::Ok;
 }
 
+// trusted views are resolved independently of packet before this call. No
+// execution state is published until admission succeeds. out stays unchanged
+// on rejection and owns the converted arguments through their final use.
+inline InvocationStatus consume_tmr_invocation(
+    ByteSpan packet, const PreparedInvocationView &callable, const TmrExecutionBindingView &binding,
+    EntryArgsStorage *out
+) noexcept {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    TmrInvocationView view;
+    const auto status = decode_tmr_invocation(packet, callable, binding, &view);
+    if (status != InvocationStatus::Ok) return status;
+    return materialize_tmr_entry_args(view, out);
+}
+
 }  // namespace simpler::tmr

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -253,6 +253,14 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = load_symbol<CommGlobalDomainReleaseFn>(handle, "comm_global_domain_release");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
         comm_destroy_fn_ = load_symbol<CommDestroyFn>(handle, "comm_destroy");
+        // Kernel-mode lifecycle entries are part of the uniform host_runtime.so
+        // ABI like the ACL/comm group above: every runtime exports them, and
+        // variants without kernel-mode support ship validating stubs.
+        kernel_supported_fn_ = load_symbol<SimplerKernelSupportedFn>(handle, "simpler_kernel_mode_supported");
+        kernel_init_fn_ = load_symbol<SimplerKernelInitFn>(handle, "simpler_kernel_mode_init");
+        kernel_prepare_callable_fn_ =
+            load_symbol<SimplerKernelPrepareCallableFn>(handle, "simpler_kernel_mode_prepare_callable");
+        kernel_launch_fn_ = load_symbol<SimplerKernelLaunchFn>(handle, "simpler_kernel_mode_launch");
     } catch (...) {
         throw;
     }
@@ -380,6 +388,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw;
     }
@@ -439,6 +451,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw std::runtime_error("simpler_init failed with code " + std::to_string(init_rc));
     }
@@ -529,6 +545,10 @@ void ChipWorker::finalize() {
     comm_global_domain_release_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
+    kernel_supported_fn_ = nullptr;
+    kernel_init_fn_ = nullptr;
+    kernel_prepare_callable_fn_ = nullptr;
+    kernel_launch_fn_ = nullptr;
     runtime_bufs_.clear();
     pipeline_generations_.reset();
     pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -20,6 +20,7 @@
 
 #include <atomic>
 #include <cstdlib>
+#include <cstdio>
 #include <cstring>
 #include <fstream>
 #include <limits>
@@ -495,8 +496,20 @@ void ChipWorker::finalize() {
     // communicator handles and streams before tearing down the device context.
     clear_comm_sessions();
 
+    int device_finalize_rc = 0;
     if (device_ctx_ != nullptr && finalize_device_fn_ != nullptr && initialized_) {
-        finalize_device_fn_(device_ctx_);
+        device_finalize_rc = finalize_device_fn_(device_ctx_);
+    }
+    // A context whose teardown did not complete still owns device resources,
+    // and unloading the library that owns their release routines — or
+    // destroying the context that holds them — is unrecoverable. Both the
+    // context and the handle stay, so an explicit retry can finish the job.
+    if (device_finalize_rc != 0) {
+        std::fprintf(
+            stderr, "ChipWorker::finalize: device teardown failed (%d); keeping the context and host runtime loaded\n",
+            device_finalize_rc
+        );
+        return;
     }
     if (device_ctx_ != nullptr && destroy_device_context_fn_ != nullptr) {
         destroy_device_context_fn_(device_ctx_);

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -266,7 +266,8 @@ void ChipWorker::init(
     }
 
     const PipelineContract *contract = get_pipeline_contract_fn();
-    if (!is_valid_pipeline_contract(contract) || !has_serviceable_arena_topology(*contract)) {
+    if (!is_valid_pipeline_contract(contract) || !has_serviceable_arena_topology(*contract) ||
+        !has_serviceable_stream_topology(*contract)) {
         throw std::runtime_error("host runtime returned a PipelineContract this build cannot accept");
     }
     const PipelineContract resolved_contract = *contract;

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -296,6 +296,10 @@ private:
     using CommGlobalDomainReleaseFn = int (*)(uint64_t);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
+    using SimplerKernelSupportedFn = decltype(&simpler_kernel_mode_supported);
+    using SimplerKernelInitFn = decltype(&simpler_kernel_mode_init);
+    using SimplerKernelPrepareCallableFn = decltype(&simpler_kernel_mode_prepare_callable);
+    using SimplerKernelLaunchFn = decltype(&simpler_kernel_mode_launch);
 
     struct CommSession {
         void *handle = nullptr;
@@ -356,6 +360,10 @@ private:
     CommGlobalDomainReleaseFn comm_global_domain_release_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;
+    SimplerKernelSupportedFn kernel_supported_fn_ = nullptr;
+    SimplerKernelInitFn kernel_init_fn_ = nullptr;
+    SimplerKernelPrepareCallableFn kernel_prepare_callable_fn_ = nullptr;
+    SimplerKernelLaunchFn kernel_launch_fn_ = nullptr;
     void *device_ctx_ = nullptr;
     std::vector<CommSession> comm_sessions_;
     std::unordered_map<uint64_t, size_t> comm_session_index_;

--- a/src/common/worker/pipeline_contract.h
+++ b/src/common/worker/pipeline_contract.h
@@ -16,28 +16,31 @@
  * will honor are stated in one place and can be exercised on their own.
  */
 
-#ifndef SRC_COMMON_WORKER_PIPELINE_CONTRACT_H_
-#define SRC_COMMON_WORKER_PIPELINE_CONTRACT_H_
+#pragma once
 
 #include <cstdint>
 
 #include "runtime_c_api.h"
+#include "execution_mode.h"
 
 /**
- * Whether this build can honor `contract`.
+ * Whether `contract` has a valid structure and mode-specific byte counts.
+ * Serviceability and runtime-specific resource sets are checked separately.
  *
  * Rejects a contract whose ABI version is not the one compiled in, that
  * declares more resources than fit, that asks for a pipeline depth outside
  * the supported range, or whose resources carry an unspecified or out-of-range kind, an
- * out-of-range class, or a non-zero reserved `bytes_per_copy`.
+ * out-of-range class, or a byte count incompatible with the mode and kind.
  *
  * The unspecified-kind rule is what catches a `resource_count` larger than the
  * entries a runtime actually filled in: the trailing entries are still zeroed,
  * and zero is not a resource. Repeated kinds stay legal, so a runtime may
  * declare several resources of one kind.
  */
-inline bool is_valid_pipeline_contract(const PipelineContract *contract) {
-    if (contract == nullptr || contract->abi_version != PTO_PIPELINE_CONTRACT_ABI_VERSION ||
+// Accept the raw mode value so unknown values can be rejected before an enum cast.
+inline bool is_valid_pipeline_contract(const PipelineContract *contract, uint32_t mode) {
+    if ((mode != SIMPLER_MODE_PROGRAM && mode != SIMPLER_MODE_KERNEL) || contract == nullptr ||
+        contract->abi_version != PTO_PIPELINE_CONTRACT_ABI_VERSION ||
         contract->resource_count > PTO_PIPELINE_MAX_RESOURCES || contract->pipeline_depth == 0 ||
         contract->pipeline_depth > PTO_PIPELINE_MAX_DEPTH) {
         return false;
@@ -45,11 +48,17 @@ inline bool is_valid_pipeline_contract(const PipelineContract *contract) {
     for (uint32_t i = 0; i < contract->resource_count; ++i) {
         const PipelineResource &resource = contract->resources[i];
         if (resource.kind == PTO_PIPELINE_KIND_UNSPECIFIED || resource.kind > PTO_PIPELINE_AICORE_STREAM ||
-            resource.resource_class > PTO_PIPELINE_EXEC_HANDLE || resource.bytes_per_copy != 0) {
+            resource.resource_class > PTO_PIPELINE_EXEC_HANDLE) {
             return false;
         }
+        const bool sized_arena = mode == SIMPLER_MODE_KERNEL && resource.kind <= PTO_PIPELINE_RUNTIME_IMAGE;
+        if (sized_arena ? resource.bytes_per_copy == 0 : resource.bytes_per_copy != 0) return false;
     }
     return true;
+}
+
+inline bool is_valid_pipeline_contract(const PipelineContract *contract) {
+    return is_valid_pipeline_contract(contract, SIMPLER_MODE_PROGRAM);
 }
 
 /** Return the number of concrete copies required for one resource. */
@@ -65,6 +74,7 @@ inline uint32_t pipeline_resource_slot(
 }
 
 /** Find a declared resource kind, or return nullptr when the runtime does not use it. */
+// The caller must validate the contract before looking up a resource.
 inline const PipelineResource *find_pipeline_resource(const PipelineContract &contract, uint32_t kind) {
     for (uint32_t i = 0; i < contract.resource_count; ++i) {
         if (contract.resources[i].kind == kind) return &contract.resources[i];
@@ -81,6 +91,7 @@ inline const PipelineResource *find_pipeline_resource(const PipelineContract &co
  * declares one of them twice, where only the first entry would ever be read —
  * describes a layout the executor cannot produce, and is rejected at load
  * rather than at the first launch that would need the second bank.
+ * The caller must validate the contract before checking this topology.
  */
 inline bool has_serviceable_arena_topology(const PipelineContract &contract) {
     constexpr uint32_t ARENA_KINDS[] = {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_GM_SM, PTO_PIPELINE_RUNTIME_IMAGE};
@@ -104,4 +115,36 @@ inline bool has_serviceable_arena_topology(const PipelineContract &contract) {
     return true;
 }
 
-#endif  // SRC_COMMON_WORKER_PIPELINE_CONTRACT_H_
+// Each execution role is supplied exactly once. Copy counts do not prescribe
+// the number of physical streams created by the platform.
+inline bool has_serviceable_stream_topology(const PipelineContract &contract) {
+    if (contract.resource_count > PTO_PIPELINE_MAX_RESOURCES) return false;
+    constexpr uint32_t STREAM_KINDS[] = {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_AICORE_STREAM};
+    for (uint32_t kind : STREAM_KINDS) {
+        uint32_t count = 0;
+        for (uint32_t i = 0; i < contract.resource_count; ++i) {
+            const auto &resource = contract.resources[i];
+            if (resource.kind != kind) continue;
+            if (resource.resource_class != PTO_PIPELINE_EXEC_HANDLE) return false;
+            ++count;
+        }
+        if (count != 1) return false;
+    }
+    return true;
+}
+
+// Complete TMR kernel admission, including structural checks before any lookup.
+inline bool is_valid_tmr_kernel_pipeline_contract(const PipelineContract *contract) {
+    if (!is_valid_pipeline_contract(contract, SIMPLER_MODE_KERNEL) || contract->pipeline_depth != 1 ||
+        contract->resource_count != 6 || !has_serviceable_arena_topology(*contract) ||
+        !has_serviceable_stream_topology(*contract)) {
+        return false;
+    }
+    for (uint32_t kind = PTO_PIPELINE_GM_HEAP; kind <= PTO_PIPELINE_TASK_ARGS; ++kind) {
+        const auto *resource = find_pipeline_resource(*contract, kind);
+        const auto expected_class =
+            kind == PTO_PIPELINE_TASK_ARGS ? PTO_PIPELINE_HOST_PER_RUN : PTO_PIPELINE_DEVICE_SCRATCH;
+        if (resource == nullptr || resource->resource_class != expected_class) return false;
+    }
+    return true;
+}

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -30,6 +30,9 @@
  *                   simpler_unregister_callable,
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
  *                   get_run_stream_set_create_count
+ *   - kernel mode:  simpler_kernel_mode_supported, simpler_kernel_mode_init,
+ *                   simpler_kernel_mode_prepare_callable,
+ *                   simpler_kernel_mode_launch
  *   - pipeline:     get_pipeline_contract,
  *                   supports_concurrent_native_prepare_ctx,
  *                   get_arena_bank_gm_heap_base_ctx,
@@ -102,6 +105,10 @@ enum {
     /* The request names a capability this platform/runtime does not implement. */
     PTO_RUNTIME_ERR_UNSUPPORTED = PTO_RUNTIME_ERR_BASE - 1,
     PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = PTO_RUNTIME_ERR_BASE - 2,
+    /* The call is structurally valid but arrives out of order for this
+       context's lifecycle (e.g. launch on a context with no live kernel
+       claim). */
+    PTO_RUNTIME_ERR_INVALID_STATE = PTO_RUNTIME_ERR_BASE - 3,
 };
 
 /** Return values from simpler_poll_run(). */
@@ -324,7 +331,8 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  *      separate call. Only `prewarm_config->runtime_env` is read.
  *
  * Returns 0 on success, negative on attach, provisioning, or prewarm-build
- * failure.
+ * failure, and PTO_RUNTIME_ERR_INVALID_STATE when the context is already
+ * latched to kernel mode.
  */
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
@@ -522,6 +530,108 @@ size_t get_host_dlopen_count(DeviceContextHandle ctx);
  * bootstrap pair.
  */
 size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
+
+/* ===========================================================================
+ * Kernel-mode lifecycle (four entries + finalize_device)
+ *
+ * A context has one of two execution modes for its whole lifetime, decided by
+ * which init entry runs first. simpler_init latches program mode — the
+ * historical exclusive-device path driven through the prepared-run family
+ * above. simpler_kernel_mode_init latches kernel mode, which borrows the
+ * caller's already-current device and caller-owned stream to enqueue one
+ * bounded asynchronous operator per launch: no device reset, no internal
+ * stream/device synchronize on the prepare/launch/close paths, zero
+ * allocation at launch, and no capture/model-state queries, so a launch is
+ * capturable by ACLGraph as an ordinary node.
+ *
+ * Identity is a write-once property of the context, not a state that evolves:
+ * ExecutionModeLatch on the platform runner holds it, the first init entry to
+ * run latches it, and it never changes — not on finalize, not on error. There
+ * is no separate declaration call to forget, and no unlatch, so a handle from
+ * a failed kernel init can never be recycled into a program context.
+ * simpler_init latches PROGRAM before touching any process or runner state, so
+ * the mutual exclusion is enforced on every program init. Every kernel-mode
+ * guard on the device/ACL lifecycle and arena paths keys on the latch reading
+ * kernel; none of the entries below latches yet, so today only program
+ * contexts exist and those guards never fire.
+ *
+ * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
+ * context-static, so each pooled arena region is committed at most once and
+ * never grown or released afterwards. The platform arena reports a growth or
+ * release request under kernel mode as an internal invariant break
+ * (PTO_RUNTIME_ERR_INTERNAL), and capacity intent travels in
+ * CallConfig.runtime_env like everywhere else.
+ *
+ * All four entries below are part of the required dlsym surface: every
+ * host_runtime.so exports them, and variants without kernel-mode support
+ * export stubs that run the same structural validation and then refuse —
+ * supported returns 0, init reports PTO_RUNTIME_ERR_UNSUPPORTED, and
+ * prepare_callable and launch report PTO_RUNTIME_ERR_INVALID_STATE because
+ * no kernel context is live. The fifth lifecycle entry is the existing
+ * finalize_device(): in kernel mode it releases only context-owned resources
+ * and never resets the device or finalizes ACL. device_id_ records which
+ * device a context is on rather than a claim on it, so a kernel context
+ * reaches that teardown path; the platform finalize() skips the per-thread
+ * device bind on a kernel latch, because the caller already holds its own
+ * device current.
+ *
+ * These entries accept only POD structs, serialized blobs, and device/stream
+ * pointers — never framework objects. The caller stream is always an explicit
+ * parameter and is never stored beyond the call or destroyed by simpler.
+ * =========================================================================== */
+
+/** Return nonzero when this runtime/context can execute kernel-mode launches. */
+int simpler_kernel_mode_supported(DeviceContextHandle ctx);
+
+/**
+ * Initialize a kernel-mode context on the caller's already-current device.
+ *
+ * A successful call latches kernel mode on the context — mutually exclusive
+ * with the program-mode simpler_init — and the claim is what arms the
+ * kernel-mode guards on the platform's device/ACL lifecycle and arena paths.
+ *
+ * Takes no device ownership: no device reset, no ACL init/finalize, and no
+ * stream or device synchronize on this path. Creates only context-owned
+ * persistent handles used by asynchronous preparation and launch. `config`
+ * is context-static; launches never mutate it. `context_generation` is a
+ * nonzero host-process-unique identity minted by the caller for sequential
+ * contexts; generation zero is invalid.
+ */
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+);
+
+/**
+ * Stage one callable for kernel-mode launches, outside ACLGraph capture.
+ *
+ * `callable` points to a canonical ChipCallable image of exactly
+ * `callable_size` bytes. Validating every flexible-array offset before the
+ * image is hashed or uploaded is the implementation's obligation; the shared
+ * entry validation checks only the image's alignment, its size floor, and the
+ * callable id range. Preparation may allocate persistent state and
+ * enqueue asynchronous device work on `caller_stream`, but never synchronizes
+ * a stream or device — preparation errors surface through the caller's own
+ * warmup + synchronize. The stream is borrowed for this call only.
+ */
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+);
+
+/**
+ * Enqueue one bounded asynchronous kernel-mode operator invocation.
+ *
+ * `args` points to a ChipStorageTaskArgs POD whose tensor addresses are
+ * caller-owned device addresses; they are passed through without ever being
+ * dereferenced on the host. A launch performs no device malloc/free, no
+ * tensor staging, no synchronize, no capture-state query, and no
+ * stream-to-model attachment: KernelLaunchOps is the vocabulary that makes
+ * those unrepresentable, and routing every runtime call through it is the
+ * implementation's obligation. A return of 0 means the sequence was enqueued;
+ * device execution may still be in flight and may still fail asynchronously.
+ */
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream);
 
 #ifdef __cplusplus
 }

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -157,7 +157,10 @@ typedef enum PipelineResourceKind {
 typedef struct PipelineResource {
     uint32_t kind;
     uint32_t resource_class;
-    /* Size of one copy. Reserved: currently declared as 0 and required to be 0. */
+    /* Program: reserved, must be 0. Kernel: arena kinds declare nonzero
+       required usable bytes per copy, not committed HBM or capacity budgets.
+       Streams and TASK_ARGS must be 0; task-argument byte limits are not
+       represented by this field. */
     uint64_t bytes_per_copy;
 } PipelineResource;
 

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -543,7 +543,7 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  * above. simpler_kernel_mode_init latches kernel mode, which borrows the
  * caller's already-current device and caller-owned stream to enqueue one
  * bounded asynchronous operator per launch: no device reset, no internal
- * stream/device synchronize on the prepare/launch/close paths, zero
+ * stream/device synchronize on the launch path, zero
  * allocation at launch, and no capture/model-state queries, so a launch is
  * capturable by ACLGraph as an ordinary node.
  *
@@ -555,8 +555,8 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  * simpler_init latches PROGRAM before touching any process or runner state, so
  * the mutual exclusion is enforced on every program init. Every kernel-mode
  * guard on the device/ACL lifecycle and arena paths keys on the latch reading
- * kernel; none of the entries below latches yet, so today only program
- * contexts exist and those guards never fire.
+ * kernel. Onboard kernel init latches the identity before creating resources;
+ * simulated kernel init remains unsupported.
  *
  * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
  * context-static, so each pooled arena region is committed at most once and
@@ -566,17 +566,15 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  * CallConfig.runtime_env like everywhere else.
  *
  * All four entries below are part of the required dlsym surface: every
- * host_runtime.so exports them, and variants without kernel-mode support
- * export stubs that run the same structural validation and then refuse —
- * supported returns 0, init reports PTO_RUNTIME_ERR_UNSUPPORTED, and
- * prepare_callable and launch report PTO_RUNTIME_ERR_INVALID_STATE because
- * no kernel context is live. The fifth lifecycle entry is the existing
- * finalize_device(): in kernel mode it releases only context-owned resources
- * and never resets the device or finalizes ACL. device_id_ records which
- * device a context is on rather than a claim on it, so a kernel context
- * reaches that teardown path; the platform finalize() skips the per-thread
- * device bind on a kernel latch, because the caller already holds its own
- * device current.
+ * host_runtime.so exports them. Onboard implements init and prepare; launch
+ * remains a rejecting stub and supported returns 0. Simulated init reports
+ * PTO_RUNTIME_ERR_UNSUPPORTED; simulated prepare and launch report
+ * PTO_RUNTIME_ERR_INVALID_STATE after structural validation.
+ * The fifth lifecycle entry is the existing
+ * finalize_device(): in kernel mode it must release only context-owned
+ * resources and never reset the device or finalize ACL. Onboard kernel init
+ * records the borrowed device id, allowing explicit close to release the
+ * context-owned resources while the kernel-mode latch guards device reset.
  *
  * These entries accept only POD structs, serialized blobs, and device/stream
  * pointers — never framework objects. The caller stream is always an explicit
@@ -589,16 +587,22 @@ int simpler_kernel_mode_supported(DeviceContextHandle ctx);
 /**
  * Initialize a kernel-mode context on the caller's already-current device.
  *
- * A successful call latches kernel mode on the context — mutually exclusive
- * with the program-mode simpler_init — and the claim is what arms the
+ * After structural and lifecycle validation, the call latches kernel mode
+ * permanently, including on subsequent initialization failure. This is
+ * mutually exclusive with program-mode simpler_init and arms the
  * kernel-mode guards on the platform's device/ACL lifecycle and arena paths.
  *
- * Takes no device ownership: no device reset, no ACL init/finalize, and no
- * stream or device synchronize on this path. Creates only context-owned
- * persistent handles used by asynchronous preparation and launch. `config`
+ * Takes no device ownership: no device reset or ACL init/finalize. Bootstrap
+ * and AICPU initialization synchronize the context's dedicated AICPU stream
+ * outside capture. Creates context-owned persistent handles for preparation
+ * and launch. `config`
  * is context-static; launches never mutate it. `context_generation` is a
  * nonzero host-process-unique identity minted by the caller for sequential
  * contexts; generation zero is invalid.
+ * Repeated init is rejected without changing the existing context. An init
+ * failure after device binding retains kernel mode and requires explicit
+ * finalize_device() before destruction; initialization cannot be retried on
+ * that context.
  */
 int simpler_kernel_mode_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
@@ -611,15 +615,16 @@ int simpler_kernel_mode_init(
  *
  * `callable` points to a canonical ChipCallable image of exactly
  * `callable_size` bytes. Validating every flexible-array offset before the
- * image is hashed or uploaded is the implementation's obligation; the shared
- * entry validation checks only the image's alignment, its size floor, and the
- * callable id range. Preparation may allocate persistent state and
- * enqueue asynchronous device work on `caller_stream`, but never synchronizes
- * a stream or device — preparation errors surface through the caller's own
- * warmup + synchronize. The stream is borrowed for this call only.
+ * image is hashed or uploaded is the implementation's obligation. Shared
+ * entry validation checks the canonical image bounds, signature counts,
+ * symbol names, alignment, and callable id range. Preparation may allocate persistent state and
+ * enqueue device work on the context's own AICPU stream. It takes no caller
+ * stream: nothing it enqueues belongs on one, and the ordering a caller
+ * stream would have provided comes from that stream's own FIFO, which every
+ * later launch enqueues onto behind this registration.
  */
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 );
 
 /**

--- a/src/common/worker/tmr_kernel_invocation.h
+++ b/src/common/worker/tmr_kernel_invocation.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstring>
+#include <limits>
+#include <new>
+#include <utility>
+#include <vector>
+
+#include "task_interface/task_args.h"
+#include "tensormap_and_ringbuffer/kernel_invocation.h"
+
+namespace simpler::tmr {
+
+class TmrEncodingCache;
+class TmrEncodingCandidate;
+inline InvocationStatus encode_tmr_invocation(
+    const ChipStorageTaskArgs &, const PreparedInvocationView &, const TmrExecutionBindingView &,
+    const TmrEncodingCache &, TmrEncodingCandidate *
+);
+
+// Each candidate owns a distinct packet through the native copy operation.
+// A successfully encoded candidate can be committed only after the full
+// native enqueue sequence succeeds; device failures are asynchronous.
+class TmrEncodingCandidate {
+public:
+    TmrEncodingCandidate() = default;
+    TmrEncodingCandidate(TmrEncodingCandidate &&) noexcept = default;
+    TmrEncodingCandidate &operator=(TmrEncodingCandidate &&) noexcept = default;
+    TmrEncodingCandidate(const TmrEncodingCandidate &) = delete;
+    TmrEncodingCandidate &operator=(const TmrEncodingCandidate &) = delete;
+
+    ByteSpan packet() const noexcept { return {packet_.data(), packet_.size()}; }
+    bool structural_hit() const noexcept { return structural_hit_; }
+    bool same_invocation(const TmrEncodingCandidate &other) const noexcept {
+        return !packet_.empty() && packet_ == other.packet_;
+    }
+
+private:
+    std::vector<uint8_t> packet_;
+    std::vector<uint8_t> pending_template_;
+    bool structural_hit_{false};
+    friend class TmrEncodingCache;
+    friend InvocationStatus encode_tmr_invocation(
+        const ChipStorageTaskArgs &, const PreparedInvocationView &, const TmrExecutionBindingView &,
+        const TmrEncodingCache &, TmrEncodingCandidate *
+    );
+};
+
+// One entry per prepared callable. The owner serializes reads, commit and
+// destruction with lookup/enqueue/close; this class has no internal lock.
+// Submitted tasks never reference the cache's host storage.
+class TmrEncodingCache {
+public:
+    TmrEncodingCache() = default;
+    TmrEncodingCache(const TmrEncodingCache &) = delete;
+    TmrEncodingCache &operator=(const TmrEncodingCache &) = delete;
+
+    void commit(TmrEncodingCandidate &&candidate) noexcept {
+        if (!candidate.pending_template_.empty()) {
+            template_.swap(candidate.pending_template_);
+            candidate.pending_template_.clear();
+        }
+    }
+
+    size_t bytes() const noexcept { return template_.size(); }
+
+private:
+    // Canonical packet with tensor addresses and scalar bits zeroed. Scope,
+    // generations, geometry, offset and backing size remain in the key.
+    std::vector<uint8_t> template_;
+    friend InvocationStatus encode_tmr_invocation(
+        const ChipStorageTaskArgs &, const PreparedInvocationView &, const TmrExecutionBindingView &,
+        const TmrEncodingCache &, TmrEncodingCandidate *
+    );
+};
+
+inline InvocationStatus encode_tmr_invocation(
+    const ChipStorageTaskArgs &args, const PreparedInvocationView &callable, const TmrExecutionBindingView &binding,
+    const TmrEncodingCache &cache, TmrEncodingCandidate *out
+) {
+    if (out == nullptr) return InvocationStatus::InvalidArgument;
+    size_t bytes = 0;
+    auto status = tmr_invocation_size(callable, &bytes);
+    if (status != InvocationStatus::Ok) return status;
+    if (binding.device_binding_addr == 0 || binding.context_generation == 0) return InvocationStatus::InvalidBinding;
+    if (args.tensor_count() != callable.tensor_count || args.scalar_count() != callable.scalar_count)
+        return InvocationStatus::InvalidCounts;
+
+    try {
+        TmrEncodingCandidate candidate;
+        SimplerKernelInvocationHeader header;
+        std::memset(&header, 0, sizeof(header));
+        header.mode = SIMPLER_MODE_KERNEL;
+        header.callable_id = callable.callable_id;
+        header.generation = callable.slot_generation;
+        header.payload_bytes = bytes - sizeof(header);
+        header.tensor_count = callable.tensor_count;
+        header.scalar_count = callable.scalar_count;
+        const TmrBindingRef reference{binding.device_binding_addr, binding.context_generation};
+        const size_t tensors_offset = sizeof(header) + sizeof(reference);
+        bool matches = cache.template_.size() == bytes &&
+                       std::memcmp(cache.template_.data(), &header, sizeof(header)) == 0 &&
+                       std::memcmp(cache.template_.data() + sizeof(header), &reference, sizeof(reference)) == 0;
+        std::vector<ChipTensor> normalized(static_cast<size_t>(callable.tensor_count));
+        for (int32_t i = 0; i < callable.tensor_count; ++i) {
+            auto &tensor = normalized[static_cast<size_t>(i)];
+            status = normalize_invocation_tensor(args.tensor(i), &tensor);
+            if (status != InvocationStatus::Ok) return status;
+            tensor.buffer.addr = 0;
+            if (matches && std::memcmp(
+                               cache.template_.data() + tensors_offset + static_cast<size_t>(i) * sizeof(tensor),
+                               &tensor, sizeof(tensor)
+                           ) != 0)
+                matches = false;
+        }
+        candidate.structural_hit_ = matches;
+        if (matches) {
+            candidate.packet_ = cache.template_;
+        } else {
+            candidate.packet_.resize(bytes, 0);
+            std::memcpy(candidate.packet_.data(), &header, sizeof(header));
+            std::memcpy(candidate.packet_.data() + sizeof(header), &reference, sizeof(reference));
+            if (!normalized.empty())
+                std::memcpy(
+                    candidate.packet_.data() + tensors_offset, normalized.data(), normalized.size() * sizeof(ChipTensor)
+                );
+            candidate.pending_template_ = candidate.packet_;
+        }
+        for (int32_t i = 0; i < callable.tensor_count; ++i) {
+            const size_t addr_offset = tensors_offset + static_cast<size_t>(i) * sizeof(ChipTensor) +
+                                       offsetof(ChipTensor, buffer) + offsetof(PTOBufferHandle, addr);
+            std::memcpy(candidate.packet_.data() + addr_offset, &args.tensor(i).buffer.addr, sizeof(uint64_t));
+        }
+        const size_t scalar_offset = tensors_offset + static_cast<size_t>(callable.tensor_count) * sizeof(ChipTensor);
+        if (callable.scalar_count != 0)
+            std::memcpy(
+                candidate.packet_.data() + scalar_offset, args.scalar_data(),
+                static_cast<size_t>(callable.scalar_count) * sizeof(uint64_t)
+            );
+        *out = std::move(candidate);
+        return InvocationStatus::Ok;
+    } catch (const std::bad_alloc &) {
+        return InvocationStatus::AllocationFailure;
+    }
+}
+
+// The SDK stores argsSize in uint32_t. Actual packet length is taken from
+// owned storage, never from an unvalidated payload_bytes field.
+inline InvocationStatus validate_tmr_submission(
+    const TmrEncodingCandidate &candidate, const PreparedInvocationView &callable,
+    const TmrExecutionBindingView &binding
+) noexcept {
+    if (candidate.packet().size > std::numeric_limits<uint32_t>::max()) return InvocationStatus::InvalidSize;
+    TmrInvocationView view;
+    return decode_tmr_invocation(candidate.packet(), callable, binding, &view);
+}
+
+}  // namespace simpler::tmr

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -450,6 +450,22 @@ add_hierarchical_test(test_remote_wire hierarchical/test_remote_wire.cpp)
 add_hierarchical_test(test_remote_endpoint hierarchical/test_remote_endpoint.cpp)
 add_hierarchical_test(test_pipeline_contract hierarchical/test_pipeline_contract.cpp)
 
+# Exercise ChipWorker's actual dlopen/dlsym admission before a sentinel factory,
+# then the four built sim runtimes through the unchanged public kernel ABI.
+add_library(pipeline_contract_runtime SHARED stubs/pipeline_contract_runtime.cpp)
+target_include_directories(pipeline_contract_runtime PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+)
+add_hierarchical_test(test_pipeline_contract_loader hierarchical/test_pipeline_contract_loader.cpp)
+add_dependencies(test_pipeline_contract_loader pipeline_contract_runtime)
+target_compile_definitions(test_pipeline_contract_loader PRIVATE
+    PIPELINE_FIXTURE_PATH="$<TARGET_FILE:pipeline_contract_runtime>"
+    SIM_CONTEXT_PATH="${CMAKE_SOURCE_DIR}/../../../build/lib/libcpu_sim_context.so"
+    RUNTIME_LIBRARY_ROOT="${CMAKE_SOURCE_DIR}/../../../build/lib"
+)
+
 # Run-stream pair state machine: publication-aware AICore stream reuse,
 # submitter-gated retirement, and failed-destroy ownership. Header-only with
 # injected create/destroy, so it needs no runtime objects and no device.

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -594,6 +594,14 @@ add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_arg
 add_task_interface_test(test_callable_scalar_count types/test_callable_scalar_count.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
 add_task_interface_test(test_kernel_invocation_header types/test_kernel_invocation_header.cpp)
+add_task_interface_test(test_kernel_invocation_validation types/test_kernel_invocation_validation.cpp)
+add_common_utils_test(test_tmr_kernel_invocation common/test_tmr_kernel_invocation.cpp)
+target_include_directories(test_tmr_kernel_invocation PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_sources(test_tmr_kernel_invocation PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface/assert_compat.cpp
+)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -500,6 +500,37 @@ set_tests_properties(test_native_run_acceptance PROPERTIES LABELS "no_hardware")
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)
 
+# Kernel-mode entry argument validation: shared by every host-runtime
+# component (real implementation and stub alike), so its rejection rules are
+# provable here without any device or built .so.
+add_executable(test_kernel_entry_validation common/test_kernel_entry_validation.cpp)
+target_include_directories(test_kernel_entry_validation PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_kernel_entry_validation PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_entry_validation COMMAND test_kernel_entry_validation)
+set_tests_properties(test_kernel_entry_validation PROPERTIES LABELS "no_hardware")
+
+# Kernel-mode phase machine and restricted-vocabulary tables, table-driven with
+# fake ops: init/close balance, poison, sticky CLOSING with retry, and the
+# separate runtime-error vs teardown-error slots.
+add_executable(test_kernel_execution_state
+    common/test_kernel_execution_state.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/kernel_execution_state.cpp
+)
+target_include_directories(test_kernel_execution_state PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_kernel_execution_state PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_execution_state COMMAND test_kernel_execution_state)
+set_tests_properties(test_kernel_execution_state PROPERTIES LABELS "no_hardware")
+
 # Runtime extension payloads are per-run state even though the collector's
 # shared-memory resources remain resident across runs.
 add_executable(test_chip_swimlane_collector
@@ -544,7 +575,9 @@ set_tests_properties(test_sim_run_completion PROPERTIES LABELS "no_hardware")
 add_task_interface_test(test_buffer types/test_buffer.cpp)
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
+add_task_interface_test(test_callable_scalar_count types/test_callable_scalar_count.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
+add_task_interface_test(test_kernel_invocation_header types/test_kernel_invocation_header.cpp)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -719,6 +719,7 @@ add_test(NAME test_kernel_persistent_args COMMAND test_kernel_persistent_args)
 set_tests_properties(test_kernel_persistent_args PROPERTIES LABELS "no_hardware")
 
 add_executable(test_trb_runtime_temp_buffer
+    common/test_kernel_execution_inputs.cpp
     common/test_trb_runtime_temp_buffer.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -747,6 +748,7 @@ add_test(NAME test_trb_runtime_temp_buffer COMMAND test_trb_runtime_temp_buffer)
 set_tests_properties(test_trb_runtime_temp_buffer PROPERTIES LABELS "no_hardware")
 
 add_executable(test_a5_trb_runtime_temp_buffer
+    common/test_kernel_execution_inputs.cpp
     common/test_trb_runtime_temp_buffer.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -1233,6 +1235,14 @@ target_sources(test_hbg_tensor_access PRIVATE
 )
 add_a2a3_runtime_test(test_dep_list_pool    a2a3/test_dep_list_pool.cpp)
 add_a2a3_runtime_test(test_scheduler_state  a2a3/test_scheduler_state.cpp)
+add_a2a3_runtime_test(test_tmr_scheduler_execution_inputs common/test_tmr_scheduler_execution_inputs.cpp
+    a2a3/test_tmr_scheduler_platform_stubs.cpp
+    ${A2A3_RUNTIME_DIR}/scheduler/scheduler_cold_path.cpp
+    ${A2A3_RUNTIME_DIR}/scheduler/scheduler_dispatch.cpp
+    ${A2A3_RUNTIME_DIR}/scheduler/scheduler_completion.cpp
+    ${A2A3_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/shared/aicpu/pmu_collector_aicpu.cpp
+)
 add_a2a3_runtime_test(test_task_state       a2a3/test_task_state.cpp)
 add_a2a3_runtime_test(test_ready_queue      a2a3/test_ready_queue.cpp)
 add_a2a3_runtime_test(test_shared_memory    a2a3/test_shared_memory.cpp)
@@ -1259,6 +1269,23 @@ add_a5_runtime_test(test_a5_task_allocator   a5/test_task_allocator.cpp)
 add_a5_runtime_test(test_a5_scope_deadlock_detection common/test_scope_deadlock_detection.cpp)
 add_a5_runtime_test(test_a5_dep_list_pool    a5/test_dep_list_pool.cpp)
 add_a5_runtime_test(test_a5_scheduler_state  a5/test_scheduler_state.cpp)
+add_a5_runtime_test(test_a5_tmr_scheduler_execution_inputs common/test_tmr_scheduler_execution_inputs.cpp)
+target_sources(test_a5_tmr_scheduler_execution_inputs PRIVATE
+    a5/test_tmr_scheduler_platform_stubs.cpp
+    ${A5_RUNTIME_DIR}/scheduler/scheduler_cold_path.cpp
+    ${A5_RUNTIME_DIR}/scheduler/scheduler_dispatch.cpp
+    ${A5_RUNTIME_DIR}/scheduler/scheduler_completion.cpp
+    ${A5_RUNTIME_DIR}/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/shared/aicpu/pmu_collector_aicpu.cpp
+)
+foreach(target test_tmr_scheduler_execution_inputs test_a5_tmr_scheduler_execution_inputs)
+    target_sources(${target} PRIVATE
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/aicpu_device_config.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/args_dump_aicpu.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/chip_swimlane_collector_aicpu.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/device_phase_aicpu.cpp
+    )
+endforeach()
 add_a5_runtime_test(test_a5_task_state       a5/test_task_state.cpp)
 add_a5_runtime_test(test_a5_ready_queue      a5/test_ready_queue.cpp)
 add_a5_runtime_test(test_a5_shared_memory    a5/test_shared_memory.cpp)
@@ -1268,6 +1295,83 @@ add_a5_orchestrator_runtime_test(test_a5_orchestrator_fanin a5/test_orchestrator
 add_a5_orchestrator_runtime_test(test_a5_wiring a5/test_wiring.cpp)
 add_a5_orchestrator_runtime_test(test_a5_args_dump a5/test_args_dump.cpp)
 add_a5_runtime_test(test_a5_aicore_completion_mailbox a5/test_aicore_completion_mailbox.cpp)
+
+foreach(arch a2a3 a5)
+    set(executor_test test_${arch}_tmr_executor_execution_inputs)
+    set(executor_runtime ${CMAKE_SOURCE_DIR}/../../../src/${arch}/runtime/tensormap_and_ringbuffer)
+    set(executor_platform ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
+    add_library(${arch}_tmr_executor_orch_fixture MODULE
+        common/tmr_executor_orch_fixture.cpp
+        ${executor_runtime}/orchestration/common.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/unified_log_host.cpp
+    )
+    target_include_directories(${arch}_tmr_executor_orch_fixture PRIVATE
+        $<TARGET_PROPERTY:${arch}_rt_objs,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+    add_executable(${executor_test}
+        common/test_tmr_executor_execution_inputs.cpp
+        ${executor_runtime}/aicpu/aicpu_executor.cpp
+        ${executor_runtime}/orchestration/common.cpp
+        ${executor_runtime}/runtime/runtime_core.cpp
+        ${executor_runtime}/runtime/orchestrator.cpp
+        ${executor_runtime}/runtime/ring_buffer.cpp
+        ${executor_runtime}/runtime/shared/runtime.cpp
+        ${executor_runtime}/runtime/shared/runtime_init.cpp
+        ${executor_runtime}/runtime/shared/shared_memory.cpp
+        ${executor_runtime}/runtime/shared/tensormap.cpp
+        ${executor_runtime}/runtime/scheduler/scheduler.cpp
+        ${executor_runtime}/runtime/scheduler/scheduler_cold_path.cpp
+        ${executor_runtime}/runtime/scheduler/scheduler_dispatch.cpp
+        ${executor_runtime}/runtime/scheduler/scheduler_completion.cpp
+        ${executor_platform}/shared/aicpu/aicpu_device_config.cpp
+        ${executor_platform}/shared/aicpu/args_dump_aicpu.cpp
+        ${executor_platform}/shared/aicpu/chip_swimlane_collector_aicpu.cpp
+        ${executor_platform}/shared/aicpu/dep_gen_collector_aicpu.cpp
+        ${executor_platform}/shared/aicpu/device_phase_aicpu.cpp
+        ${executor_platform}/shared/aicpu/scope_stats_collector_aicpu.cpp
+        ${executor_platform}/sim/aicpu/cache_ops.cpp
+        ${executor_platform}/sim/aicpu/device_log.cpp
+        ${executor_platform}/sim/aicpu/device_time.cpp
+        ${executor_platform}/sim/aicpu/orch_so_file.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/${arch}/platform/shared/aicpu/pmu_collector_aicpu.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/host_log.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/log/unified_log_host.cpp
+    )
+    target_include_directories(${executor_test} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        $<TARGET_PROPERTY:${arch}_rt_objs,INTERFACE_INCLUDE_DIRECTORIES>
+    )
+    target_compile_definitions(${executor_test} PRIVATE
+        TMR_EXECUTOR_ORCH_FIXTURE="$<TARGET_FILE:${arch}_tmr_executor_orch_fixture>"
+    )
+    target_link_libraries(${executor_test} PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread ${CMAKE_DL_LIBS})
+    add_dependencies(${executor_test} ${arch}_tmr_executor_orch_fixture)
+    add_test(NAME ${executor_test} COMMAND ${executor_test})
+    set_tests_properties(${executor_test} PROPERTIES LABELS "no_hardware" TIMEOUT 30)
+endforeach()
+target_sources(test_a2a3_tmr_executor_execution_inputs PRIVATE a2a3/test_tmr_executor_platform_stubs.cpp)
+target_sources(test_a5_tmr_executor_execution_inputs PRIVATE a5/test_tmr_scheduler_platform_stubs.cpp)
+
+add_a5_runtime_test(test_a5_kernel_persistent_args common/test_kernel_persistent_args.cpp)
+target_sources(test_a5_kernel_persistent_args PRIVATE
+    ${KERNEL_PERSISTENT_ARGS_SRC}
+    ${A5_RUNTIME_DIR}/shared/runtime.cpp
+)
+target_compile_definitions(test_a5_kernel_persistent_args PRIVATE SIMPLER_UT_TRB_RUNTIME)
+target_include_directories(test_a5_kernel_persistent_args PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+)
+add_a5_hbg_runtime_test(test_a5_hbg_kernel_persistent_args common/test_kernel_persistent_args.cpp)
+target_sources(test_a5_hbg_kernel_persistent_args PRIVATE
+    ${KERNEL_PERSISTENT_ARGS_SRC}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/host_build_graph/shared/runtime.cpp
+)
+target_include_directories(test_a5_hbg_kernel_persistent_args PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+)
 
 # Host logger silent/off behavior — no runtime deps, just compile the same
 # self-contained host logger sources used by production consumers.
@@ -1562,6 +1666,44 @@ if(SIMPLER_ENABLE_HARDWARE_TESTS)
             ${ASCEND_HOME_PATH}/runtime/lib64
             ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/lib64
         NO_DEFAULT_PATH REQUIRED)
+
+    # Transport-only fault injection into the actual a5 host runtime. An
+    # architecture-specific package build may not provide this DSO; registering
+    # the test requires it, but executing the test never needs an NPU.
+    if(EXISTS "${PROJECT_ROOT}/build/lib/a5/onboard/tensormap_and_ringbuffer/libhost_runtime.so")
+        add_executable(test_a5_kernel_topology_lifecycle hardware/test_a5_kernel_topology_lifecycle.cpp)
+        target_include_directories(test_a5_kernel_topology_lifecycle PRIVATE
+            ${GTEST_INCLUDE_DIRS}
+            ${PROJECT_ROOT}/src/a5/platform/onboard/host
+            ${PROJECT_ROOT}/src/a5/platform/include
+            ${PROJECT_ROOT}/src/common/platform/onboard/host
+            ${PROJECT_ROOT}/src/common/platform/include
+            ${PROJECT_ROOT}/src/common/task_interface
+            ${PROJECT_ROOT}/src/common/worker
+            ${PROJECT_ROOT}/src/common/log/include
+            ${PROJECT_ROOT}/src/common
+            ${PROJECT_ROOT}/src/a5/runtime/tensormap_and_ringbuffer/runtime
+            ${PROJECT_ROOT}/src/a5/runtime/tensormap_and_ringbuffer/common
+            ${PROJECT_ROOT}/src/a5/runtime
+            ${ASCEND_HOME_PATH}/include
+            ${ASCEND_HOME_PATH}/pkg_inc
+            ${ASCEND_HOME_PATH}/pkg_inc/runtime
+            ${ASCEND_HOME_PATH}/pkg_inc/runtime/runtime
+            ${ASCEND_HOME_PATH}/pkg_inc/profiling
+        )
+        target_link_libraries(test_a5_kernel_topology_lifecycle PRIVATE
+            "${PROJECT_ROOT}/build/lib/a5/onboard/tensormap_and_ringbuffer/libhost_runtime.so"
+            ${GTEST_MAIN_LIB}
+            ${GTEST_LIB}
+            ${ASCENDCL_LIB}
+            ${RUNTIME_LIB}
+            pthread
+            dl
+        )
+        target_link_options(test_a5_kernel_topology_lifecycle PRIVATE -Wl,--export-dynamic)
+        add_test(NAME test_a5_kernel_topology_lifecycle COMMAND test_a5_kernel_topology_lifecycle)
+        set_tests_properties(test_a5_kernel_topology_lifecycle PROPERTIES LABELS "no_hardware")
+    endif()
 
     # Black-box lifecycle UT for the comm_* C API on Path D. See the file
     # header for the contract it pins down.

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -681,6 +681,43 @@ target_include_directories(test_profiler_device_engine PRIVATE
 add_common_utils_test(test_worker_chip_orch_comm common/test_worker_chip_orch_comm.cpp)
 add_common_utils_test(test_file_marker_handshake common/test_file_marker_handshake.cpp)
 
+# Context-lifetime AICore argument owner. Built once per runtime variant
+# because the device image length it copies is a per-runtime decision
+# (runtime_device_copy_size): trb narrows to the `dev` descriptor, hbg copies
+# the whole Runtime. The injected alloc/free/copy vocabulary keeps both builds
+# free of CANN.
+set(KERNEL_PERSISTENT_ARGS_SRC
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host/kernel_persistent_args.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/kernel_execution_state.cpp)
+
+add_executable(test_kernel_persistent_args
+    common/test_kernel_persistent_args.cpp
+    ${KERNEL_PERSISTENT_ARGS_SRC}
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+)
+target_compile_definitions(test_kernel_persistent_args PRIVATE SIMPLER_UT_TRB_RUNTIME)
+target_include_directories(test_kernel_persistent_args PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/orchestration
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/common
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_kernel_persistent_args PRIVATE
+    a2a3_rt_objs
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_kernel_persistent_args COMMAND test_kernel_persistent_args)
+set_tests_properties(test_kernel_persistent_args PROPERTIES LABELS "no_hardware")
+
 add_executable(test_trb_runtime_temp_buffer
     common/test_trb_runtime_temp_buffer.cpp
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -1015,6 +1052,16 @@ add_a2a3_hbg_runtime_test(test_hbg_tensor_access a2a3/test_hbg_tensor_access.cpp
 # links the Runtime implementation to pin the contract without a device.
 add_a2a3_hbg_runtime_test(test_dispatch_table a2a3/test_dispatch_table.cpp
     ${HBG_SHARED_DIR}/runtime.cpp)
+
+# The hbg half of the per-runtime pair started above: same assertions, whole-
+# Runtime device image.
+add_a2a3_hbg_runtime_test(test_hbg_kernel_persistent_args common/test_kernel_persistent_args.cpp
+    ${KERNEL_PERSISTENT_ARGS_SRC}
+    ${HBG_SHARED_DIR}/runtime.cpp)
+target_include_directories(test_hbg_kernel_persistent_args PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/onboard/host
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+)
 add_a2a3_hbg_runtime_test(test_hbg_core_tracker common/test_hbg_core_tracker.cpp)
 # The seed test calls the real ready_queue_init_data_from_layout, so it links the
 # shared init TU (and the orchestrator/SM members that TU refers to).

--- a/tests/ut/cpp/a2a3/test_tmr_executor_platform_stubs.cpp
+++ b/tests/ut/cpp/a2a3/test_tmr_executor_platform_stubs.cpp
@@ -9,15 +9,12 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#pragma once
+#include "aicpu/platform_regs.h"
 
-#include "worker/runtime_c_api.h"
-
-// Internal host-runtime hook, not a dlsym lifecycle API. Input is borrowed and
-// immutable during the call; output is caller-exclusive and unchanged on error.
-// No device resources are acquired or retained. Separate calls may run concurrently.
-extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out);
-
-class Runtime;
-// Host-only preparation of runtime-specific static fields; no device work.
-int configure_kernel_runtime_impl(Runtime &runtime, bool serial_orch_sched);
+int32_t platform_retire_aicore_group(const AicoreExitTarget *, size_t count, uint64_t, bool *released) {
+    if (released != nullptr) {
+        for (size_t i = 0; i < count; ++i)
+            released[i] = true;
+    }
+    return 0;
+}

--- a/tests/ut/cpp/a2a3/test_tmr_scheduler_platform_stubs.cpp
+++ b/tests/ut/cpp/a2a3/test_tmr_scheduler_platform_stubs.cpp
@@ -9,15 +9,6 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#pragma once
+#include "aicpu/platform_regs.h"
 
-#include "worker/runtime_c_api.h"
-
-// Internal host-runtime hook, not a dlsym lifecycle API. Input is borrowed and
-// immutable during the call; output is caller-exclusive and unchanged on error.
-// No device resources are acquired or retained. Separate calls may run concurrently.
-extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out);
-
-class Runtime;
-// Host-only preparation of runtime-specific static fields; no device work.
-int configure_kernel_runtime_impl(Runtime &runtime, bool serial_orch_sched);
+int32_t platform_retire_aicore_group(const AicoreExitTarget *, size_t, uint64_t, bool *) { return 0; }

--- a/tests/ut/cpp/a5/test_tmr_scheduler_platform_stubs.cpp
+++ b/tests/ut/cpp/a5/test_tmr_scheduler_platform_stubs.cpp
@@ -9,15 +9,9 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#pragma once
+#include "aicpu/platform_regs.h"
 
-#include "worker/runtime_c_api.h"
-
-// Internal host-runtime hook, not a dlsym lifecycle API. Input is borrowed and
-// immutable during the call; output is caller-exclusive and unchanged on error.
-// No device resources are acquired or retained. Separate calls may run concurrently.
-extern "C" int build_kernel_pipeline_contract_impl(const CallConfig *config, PipelineContract *out);
-
-class Runtime;
-// Host-only preparation of runtime-specific static fields; no device work.
-int configure_kernel_runtime_impl(Runtime &runtime, bool serial_orch_sched);
+void write_reg(uint64_t base, RegId reg, uint64_t value) {
+    reg_store_release(reinterpret_cast<volatile uint32_t *>(base + reg_offset(reg)), static_cast<uint32_t>(value));
+}
+int32_t platform_deinit_aicore_regs(uint64_t) { return 0; }

--- a/tests/ut/cpp/common/test_buffer_pool_manager.cpp
+++ b/tests/ut/cpp/common/test_buffer_pool_manager.cpp
@@ -1069,6 +1069,44 @@ TEST(BufferPoolManagerShardingTest, FreeBufferAllowsAllocationAddressReuse) {
     EXPECT_EQ(released, (std::vector<void *>{dev_ptr, dev_ptr}));
 }
 
+TEST(BufferPoolManagerShardingTest, ReleaseAllOwnedDeduplicatesBlocksAndClearsEveryQueue) {
+    profiling_common::BufferPoolManager<TestModule> manager;
+    profiling_common::MemoryOps ops;
+    ops.alloc = [](size_t) {
+        return ptr(0x4000);
+    };
+    ops.reg = [](void *dev_ptr, size_t, int, void **host_ptr) {
+        *host_ptr = dev_ptr;
+        return 0;
+    };
+    manager.set_memory_context(std::move(ops), nullptr, nullptr, 0, 0);
+    void *host_ptr = nullptr;
+    ASSERT_EQ(manager.alloc_and_register_block(256, &host_ptr), ptr(0x4000));
+    manager.register_mapping(ptr(0x4040), ptr(0x4040));
+    manager.register_mapping(ptr(0x4080), ptr(0x4080));
+    manager.register_mapping(ptr(0x1000), nullptr);
+    manager.register_mapping(nullptr, nullptr);
+    ASSERT_TRUE(manager.push_recycled(0, ptr(0x4040), 0));
+    ASSERT_TRUE(manager.notify_copy_done(ptr(0x4000), 0, 1));
+    ASSERT_TRUE(manager.push_to_ready(TestReadyBufferInfo{ptr(0x4080), 2}, 2));
+    ASSERT_TRUE(manager.retire_unqueued_buffer(1, ptr(0x1000), 3));
+
+    std::vector<void *> released;
+    auto release = [&](void *p) {
+        released.push_back(p);
+    };
+    manager.release_all_owned(release);
+    ASSERT_EQ(released.size(), 2u);
+    EXPECT_EQ(std::set<void *>(released.begin(), released.end()), (std::set<void *>{ptr(0x1000), ptr(0x4000)}));
+    EXPECT_TRUE(manager.recycled_empty());
+    EXPECT_EQ(manager.drain_done_into_recycled(), 0u);
+    TestReadyBufferInfo ready;
+    EXPECT_FALSE(manager.try_pop_ready(ready, 2));
+    manager.release_owned_buffers(release);
+    manager.release_all_owned(release);
+    EXPECT_EQ(released.size(), 2u);
+}
+
 TEST(BufferPoolManagerShardingTest, ReleaseOwnedBuffersVisitsAllShards) {
     profiling_common::BufferPoolManager<TestModule> manager;
     ASSERT_TRUE(manager.push_recycled(/*kind=*/0, ptr(0x1000)));

--- a/tests/ut/cpp/common/test_kernel_entry_validation.cpp
+++ b/tests/ut/cpp/common/test_kernel_entry_validation.cpp
@@ -11,6 +11,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #include "host/kernel_entry_validation.h"
 
 namespace {
@@ -73,43 +75,34 @@ TEST(KernelEntryValidation, InitRejectsEachStructuralViolation) {
 }
 
 TEST(KernelEntryValidation, PrepareCallableChecksIdRangeAndImageSize) {
-    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), kStream), 0);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable)), 0);
     EXPECT_EQ(
         validate_kernel_prepare_callable_args(
-            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable), kStream
+            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable)
         ),
         0
     );
     EXPECT_EQ(
-        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable), kStream),
+        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable)),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable)), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable)), PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable)),
         PTO_RUNTIME_ERR_INTERNAL
     );
     EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable), kStream), PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), nullptr),
-        PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable), kStream),
-        PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(
-            kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable), kStream
-        ),
-        PTO_RUNTIME_ERR_INTERNAL
-    );
-    EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1, kStream),
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1),
         PTO_RUNTIME_ERR_INTERNAL
     );
     // storage_ sits at a CALLABLE_CHILD_ALIGN offset from the header, so an
     // image the caller placed off-alignment puts every child off-alignment.
     static_assert(alignof(ChipCallable) > 1, "a misaligned image must be expressible");
     EXPECT_EQ(
-        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable), kStream),
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable)),
         PTO_RUNTIME_ERR_INTERNAL
     );
 }
@@ -123,6 +116,79 @@ TEST(KernelEntryValidation, LaunchChecksPointersAndIdRange) {
     EXPECT_EQ(
         validate_kernel_launch_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, kStream),
         PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, PrepareRejectsInvalidInvocationSignatureBeforeRegistration) {
+    alignas(ChipCallable) unsigned char image[sizeof(ChipCallable)] = {};
+    auto set_count = [&](size_t offset, int32_t count) {
+        std::memcpy(image + offset, &count, sizeof(count));
+    };
+    auto set_direction = [&](int32_t index, ArgDirection direction) {
+        std::memcpy(
+            image + offsetof(ChipCallable, signature_) + index * sizeof(direction), &direction, sizeof(direction)
+        );
+    };
+    set_count(offsetof(ChipCallable, sig_count_), -1);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_count(offsetof(ChipCallable, sig_count_), CHIP_MAX_TENSOR_ARGS + 1);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_count(offsetof(ChipCallable, sig_count_), 2);
+    set_direction(0, ArgDirection::IN);
+    set_direction(1, ArgDirection::SCALAR);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), 0);
+    set_count(offsetof(ChipCallable, scalar_count_), 1);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), 0);
+    set_count(offsetof(ChipCallable, scalar_count_), 2);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_count(offsetof(ChipCallable, scalar_count_), 0);
+    set_direction(0, ArgDirection::SCALAR);
+    set_direction(1, ArgDirection::OUT);
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+    set_direction(0, static_cast<ArgDirection>(99));
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image, sizeof(image)), PTO_RUNTIME_ERR_INTERNAL);
+}
+
+TEST(KernelEntryValidation, PrepareBoundsCanonicalImageBeforeHashOrUpload) {
+    const uint8_t binary[] = {1, 2, 3};
+    const auto child = make_callable<CORE_MAX_TENSOR_ARGS>(nullptr, 0, binary, sizeof(binary));
+    const int32_t func_id = 0;
+    const auto valid = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        nullptr, 0, 0, "entry", binary, sizeof(binary), &func_id, &child, 1, "config"
+    );
+    ASSERT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, valid.data(), valid.size()), 0);
+    const auto *header = reinterpret_cast<const ChipCallable *>(valid.data());
+    const size_t child_start = offsetof(ChipCallable, storage_) + header->child_offset(0);
+    auto reject_word = [&](size_t offset, uint32_t value) {
+        auto image = valid;
+        std::memcpy(image.data() + offset, &value, sizeof(value));
+        EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, image.data(), image.size()), PTO_RUNTIME_ERR_INTERNAL);
+    };
+    reject_word(offsetof(ChipCallable, binary_size_), UINT32_MAX);
+    reject_word(offsetof(ChipCallable, child_count_), UINT32_MAX);
+    reject_word(offsetof(ChipCallable, child_count_), 1025);
+    reject_word(offsetof(ChipCallable, child_offsets_), UINT32_MAX);
+    reject_word(offsetof(ChipCallable, child_offsets_), 1);
+    reject_word(offsetof(ChipCallable, child_offsets_), 0);
+    reject_word(child_start + offsetof(CoreCallable, binary_size_), UINT32_MAX);
+    reject_word(child_start + offsetof(CoreCallable, sig_count_), CORE_MAX_TENSOR_ARGS + 1);
+    reject_word(offsetof(ChipCallable, func_name_len_), CALLABLE_FUNC_NAME_MAX);
+    reject_word(offsetof(ChipCallable, config_name_len_), CALLABLE_FUNC_NAME_MAX);
+    auto unterminated = valid;
+    std::memset(unterminated.data() + offsetof(ChipCallable, func_name_), 'x', CALLABLE_FUNC_NAME_MAX);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, unterminated.data(), unterminated.size()),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, valid.data(), child_start + sizeof(CoreCallable) - 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, valid.data(), valid.size() - 1), PTO_RUNTIME_ERR_INTERNAL);
+    auto trailing = valid;
+    trailing.push_back(0);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, trailing.data(), trailing.size()), PTO_RUNTIME_ERR_INTERNAL
     );
 }
 

--- a/tests/ut/cpp/common/test_kernel_entry_validation.cpp
+++ b/tests/ut/cpp/common/test_kernel_entry_validation.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "host/kernel_entry_validation.h"
+
+namespace {
+
+int dummy_ctx_storage = 0;
+void *const kCtx = &dummy_ctx_storage;
+const uint8_t kBinary[4] = {1, 2, 3, 4};
+const int kConfigStorage = 0;
+const void *const kConfig = &kConfigStorage;
+int dummy_stream_storage = 0;
+void *const kStream = &dummy_stream_storage;
+alignas(ChipCallable) const unsigned char kCallableImage[sizeof(ChipCallable)] = {};
+
+TEST(KernelEntryValidation, BinarySpanRequiresPointerAndSizeTogether) {
+    EXPECT_TRUE(kernel_binary_span_is_consistent(nullptr, 0));
+    EXPECT_TRUE(kernel_binary_span_is_consistent(kBinary, sizeof(kBinary)));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(nullptr, 4));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(kBinary, 0));
+}
+
+TEST(KernelEntryValidation, InitAcceptsConsistentArgs) {
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        0
+    );
+}
+
+TEST(KernelEntryValidation, InitRejectsEachStructuralViolation) {
+    EXPECT_EQ(
+        validate_kernel_init_args(
+            nullptr, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1
+        ),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, nullptr, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, -1, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 0),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    // One inconsistent span per position, in both directions.
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, nullptr, 4, kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, 0, nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), kBinary, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, PrepareCallableChecksIdRangeAndImageSize) {
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), kStream), 0);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        0
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable), kStream), PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), nullptr),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1, kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    // storage_ sits at a CALLABLE_CHILD_ALIGN offset from the header, so an
+    // image the caller placed off-alignment puts every child off-alignment.
+    static_assert(alignof(ChipCallable) > 1, "a misaligned image must be expressible");
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, LaunchChecksPointersAndIdRange) {
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, kStream), 0);
+    EXPECT_EQ(validate_kernel_launch_args(nullptr, 0, kCallableImage, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, nullptr, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, nullptr), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, -1, kCallableImage, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(
+        validate_kernel_launch_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_execution_inputs.cpp
+++ b/tests/ut/cpp/common/test_kernel_execution_inputs.cpp
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "callable.h"
+#include "host/kernel_static_config.h"
+#include "tensormap_and_ringbuffer/kernel_execution_inputs.h"
+#include "worker/tmr_kernel_invocation.h"
+
+namespace {
+using namespace simpler::tmr;
+
+TEST(KernelStaticConfig, OwnsPackedInputAndRejectsReplacement) {
+    CallConfig input;
+    input.aicpu_thread_num = 0;
+    input.runtime_env.ring_task_window[0] = 32;
+    std::array<uint8_t, sizeof(CallConfig) + 1> packed{};
+    std::memcpy(packed.data() + 1, &input, sizeof(input));
+    KernelStaticConfig config;
+    ASSERT_EQ(config.initialize(reinterpret_cast<const CallConfig *>(packed.data() + 1), 9, true), 0);
+    std::memset(packed.data(), 0, packed.size());
+    uint64_t saved_window = 0;
+    std::memcpy(&saved_window, &config.request().runtime_env.ring_task_window[0], sizeof(saved_window));
+    EXPECT_EQ(saved_window, 32u);
+    EXPECT_EQ(config.request().aicpu_thread_num, 0);
+    EXPECT_EQ(config.generation(), 9u);
+    EXPECT_TRUE(config.serial_orch_sched());
+    EXPECT_FALSE(config.frozen());
+    EXPECT_EQ(config.freeze(), 0);
+    input.aicpu_thread_num = 3;
+    EXPECT_EQ(config.initialize(&input, 10, false), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(config.request().aicpu_thread_num, 0);
+    EXPECT_EQ(config.generation(), 9u);
+}
+
+TEST(KernelStaticConfig, RejectsInvalidAndUnsupportedRequestsWithoutInitialization) {
+    KernelStaticConfig config;
+    EXPECT_EQ(config.freeze(), PTO_RUNTIME_ERR_INVALID_STATE);
+    CallConfig input;
+    input.aicpu_thread_num = 1;
+    EXPECT_EQ(config.initialize(&input, 7, false), PTO_RUNTIME_ERR_INTERNAL);
+    input.aicpu_thread_num = -1;
+    EXPECT_EQ(config.initialize(&input, 7, false), PTO_RUNTIME_ERR_INTERNAL);
+    input.aicpu_thread_num = PLATFORM_MAX_AICPU_THREADS + 1;
+    EXPECT_EQ(config.initialize(&input, 7, false), PTO_RUNTIME_ERR_INTERNAL);
+    input.aicpu_thread_num = 0;
+    input.enable_dump_args = 1;
+    EXPECT_EQ(config.initialize(&input, 7, false), PTO_RUNTIME_ERR_UNSUPPORTED);
+    input.enable_dump_args = 0;
+    EXPECT_EQ(config.initialize(&input, 0, false), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_FALSE(config.initialized());
+    EXPECT_EQ(config.initialize(&input, 7, false), 0);
+}
+
+class KernelExecutionInputsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        uint64_t windows[CHIP_MAX_RING_DEPTH] = {16, 16, 16, 16};
+        uint64_t heaps[CHIP_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
+        int32_t deps[CHIP_MAX_RING_DEPTH] = {4, 4, 4, 4};
+        layout = runtime_reserve_layout(arena, windows, heaps, deps);
+        ASSERT_NE(arena.commit(), nullptr);
+        const size_t sm_size = SharedMemoryHandle::calculate_size_per_ring(windows);
+        const size_t sm_offset = sm.reserve(sm_size, CHIP_ALIGN_SIZE);
+        ASSERT_NE(sm.commit(), nullptr);
+        void *sm_base = sm.region_ptr(sm_offset);
+        heap.resize(4096);
+        ASSERT_NE(
+            runtime_init_data_from_layout(arena, layout, MODE_EXECUTE, sm_base, sm_size, heap.data(), heaps), nullptr
+        );
+        binding = {
+            {reinterpret_cast<uint64_t>(&identity), 13},
+            resident.get(),
+            {sm_base, sm_size, sm_size},
+            {arena.base(), layout.offsets.arena_size, layout.offsets.arena_size},
+            layout.offsets.off_runtime
+        };
+    }
+
+    ChipStorageTaskArgs arguments(uint64_t scalar) {
+        ChipStorageTaskArgs args;
+        const uint32_t shape[] = {2, 4};
+        args.add_tensor(make_tensor_external(data.data(), shape, 2, DataType::FLOAT32, AddressSpace::DEVICE));
+        args.add_scalar(scalar);
+        return args;
+    }
+
+    std::unique_ptr<Runtime> resident{std::make_unique<Runtime>()};
+    std::unique_ptr<KernelInvocationState> state{std::make_unique<KernelInvocationState>()};
+    DeviceArena arena;
+    DeviceArena sm;
+    RuntimeArenaLayout layout{};
+    std::vector<char> heap;
+    std::array<float, 8> data{};
+    uint64_t identity{0};
+    KernelBindingView binding{};
+    const PreparedInvocationView callable{3, 1, 1, 17};
+};
+
+TEST_F(KernelExecutionInputsTest, ConfigAndOrchestrationShareStableBorrowedArguments) {
+    auto args = arguments(19);
+    TmrEncodingCandidate packet;
+    TmrEncodingCache cache;
+    ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+    ASSERT_EQ(state->admit(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+    ChipTaskArgs converted;
+    auto config = +[](const ChipTaskArgs &entry) {
+        EXPECT_EQ(entry.scalar(0), 19u);
+        EXPECT_EQ(entry.tensor(0).ref().shapes[1], 4u);
+        return OrchestrationConfig{2};
+    };
+    ASSERT_TRUE(configure_orchestration_args(state->inputs(), converted, config));
+    const auto *tensor = &converted.tensor(0).ref();
+    EXPECT_EQ(tensor, &state->inputs().args->tensor(0));
+    EXPECT_EQ(state->inputs().callable_id, callable.callable_id);
+    EXPECT_EQ(state->inputs().sm, binding.sm.base);
+    EXPECT_EQ(state->inputs().arena, binding.arena.base);
+    EXPECT_EQ(resident->get_active_callable_id(), -1);
+    EXPECT_EQ(resident->get_orch_args().tensor_count(), 0);
+    auto orchestration = +[](const ChipTaskArgs &entry) {
+        auto *values = reinterpret_cast<float *>(entry.tensor(0).ref().buffer.addr);
+        values[0] = static_cast<float>(entry.scalar(0));
+    };
+    orchestration(converted);
+    EXPECT_EQ(data[0], 19.0f);
+    EXPECT_EQ(&converted.tensor(0).ref(), tensor);
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {}}, binding), InvocationStatus::InvalidArgument);
+    EXPECT_EQ(converted.scalar(0), 19u);
+    converted.reset();
+    state->clear();
+    EXPECT_FALSE(state->active());
+}
+
+TEST_F(KernelExecutionInputsTest, FailureDoesNotPublishOrModifyPreviousInputs) {
+    auto args = arguments(23);
+    TmrEncodingCandidate packet;
+    TmrEncodingCache cache;
+    ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+    auto invalid = binding;
+    invalid.arena.capacity = invalid.arena.required_bytes - 1;
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {}}, invalid), InvocationStatus::InvalidBinding);
+    invalid = binding;
+    invalid.runtime_offset = invalid.arena.capacity;
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {}}, invalid), InvocationStatus::InvalidBinding);
+    invalid = binding;
+    invalid.sm.base = static_cast<char *>(invalid.sm.base) + 1;
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {}}, invalid), InvocationStatus::InvalidBinding);
+    invalid = binding;
+    invalid.identity.context_generation++;
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {}}, invalid), InvocationStatus::InvalidBinding);
+    auto stale = callable;
+    stale.slot_generation++;
+    EXPECT_EQ(state->admit(packet.packet(), {stale, {}}, binding), InvocationStatus::StaleCallable);
+    EXPECT_FALSE(state->active());
+    EXPECT_EQ(state->inputs().args, nullptr);
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+    const auto *storage = state->inputs().args;
+    EXPECT_EQ(state->admit({}, {callable, {}}, binding), InvocationStatus::InvalidArgument);
+    EXPECT_EQ(state->inputs().args, storage);
+    EXPECT_EQ(storage->scalar(0), 23u);
+}
+
+TEST_F(KernelExecutionInputsTest, AlternateCallablesNeverRewriteResidentFunctionTable) {
+    const uint8_t binary[] = {1, 2, 3, 4};
+    auto a = make_callable<CORE_MAX_TENSOR_ARGS>(nullptr, 0, binary, sizeof(binary));
+    auto b = make_callable<CORE_MAX_TENSOR_ARGS>(nullptr, 0, binary, sizeof(binary));
+    const std::array<uint64_t, 1> table_a{reinterpret_cast<uint64_t>(a.data())};
+    const std::array<uint64_t, 1> table_b{reinterpret_cast<uint64_t>(b.data())};
+    const auto original = resident->dev;
+    for (const auto *table : {&table_a, &table_b, &table_a}) {
+        TmrEncodingCandidate packet;
+        TmrEncodingCache cache;
+        auto args = arguments(table == &table_a ? 31 : 37);
+        ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+        ASSERT_EQ(
+            state->admit(packet.packet(), {callable, {table->data(), table->size()}}, binding), InvocationStatus::Ok
+        );
+        EXPECT_EQ(state->inputs().functions.lookup(0), table->front());
+        EXPECT_EQ(state->inputs().functions.lookup(-1), 0u);
+        EXPECT_EQ(state->inputs().functions.lookup(1), 0u);
+        EXPECT_EQ(std::memcmp(&resident->dev, &original, sizeof(original)), 0);
+        state->clear();
+    }
+}
+
+TEST_F(KernelExecutionInputsTest, EmptyTensorStorageMatchesTheProgramConversion) {
+    const uint32_t shapes[][3] = {{0, 1, 1}, {0, 8, 1}, {8, 0, 1}, {2, 0, 3}};
+    const uint32_t ranks[] = {1, 2, 2, 3};
+    for (size_t i = 0; i < std::size(ranks); ++i) {
+        auto args = arguments(43);
+        args.tensor(0) = make_tensor_external(nullptr, shapes[i], ranks[i], DataType::FLOAT32, AddressSpace::DEVICE);
+        TmrEncodingCandidate packet;
+        TmrEncodingCache cache;
+        ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+        ASSERT_EQ(state->admit(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+        ChipTaskArgs converted;
+        ASSERT_TRUE(configure_orchestration_args(state->inputs(), converted, nullptr));
+        const auto program_tensor = Tensor::from_boundary(args.tensor(0));
+        EXPECT_EQ(converted.tensor(0).ref().numel(), 0u);
+        EXPECT_EQ(converted.tensor(0).ref().buffer.addr, 0u);
+        EXPECT_EQ(converted.tensor(0).ref().extent_elem(), program_tensor.extent_elem());
+        EXPECT_EQ(converted.scalar(0), 43u);
+        converted.reset();
+        state->clear();
+    }
+}
+
+TEST_F(KernelExecutionInputsTest, RejectsInvalidFunctionTableBeforePublishingStorage) {
+    auto args = arguments(47);
+    TmrEncodingCandidate packet;
+    TmrEncodingCache cache;
+    ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+    const uint64_t table[] = {0};
+    const CallableTableView invalid[] = {
+        {nullptr, 1},
+        {table, RUNTIME_MAX_FUNC_ID + 1},
+        {reinterpret_cast<const uint64_t *>(reinterpret_cast<const char *>(table) + 1), 1}
+    };
+    for (const auto &functions : invalid) {
+        EXPECT_EQ(state->admit(packet.packet(), {callable, functions}, binding), InvocationStatus::InvalidBinding);
+        EXPECT_FALSE(state->active());
+        EXPECT_EQ(state->inputs().args, nullptr);
+    }
+    EXPECT_EQ(state->admit(packet.packet(), {callable, {table, 1}}, binding), InvocationStatus::Ok);
+    EXPECT_EQ(state->inputs().args->scalar(0), 47u);
+}
+
+TEST_F(KernelExecutionInputsTest, ProgramWrapperBorrowsOriginalStorage) {
+    resident->dev.active_callable_id_ = 2;
+    resident->dev.func_id_to_addr_[5] = 0x1200;
+    resident->dev.orch_args_storage_.scalar_count_ = 1;
+    resident->dev.orch_args_storage_.scalars_[0] = 29;
+    const auto input = program_execution_inputs(*resident);
+    EXPECT_EQ(input.callable_id, 2);
+    EXPECT_EQ(input.args, &resident->dev.orch_args_storage_);
+    EXPECT_EQ(input.args->scalar(0), 29u);
+    EXPECT_EQ(input.functions.lookup(5), 0x1200u);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_execution_state.cpp
+++ b/tests/ut/cpp/common/test_kernel_execution_state.cpp
@@ -35,6 +35,8 @@ struct FakeContextOps {
     int events_created{0};
     int events_destroyed{0};
     uintptr_t next_handle{1};
+    uint32_t requested_event_flag{0};
+    std::vector<uint32_t> event_flags_seen;
 
     static FakeContextOps *self(void *context) { return static_cast<FakeContextOps *>(context); }
 
@@ -60,10 +62,11 @@ struct FakeContextOps {
         ops->streams_destroyed++;
         return 0;
     }
-    static int create_event(void *context, void **event) {
+    static int create_event(void *context, uint32_t flag, void **event) {
         auto *ops = self(context);
         if (ops->create_event_rc_after >= 0 && ops->events_created == ops->create_event_rc_after) return -44;
         ops->events_created++;
+        ops->event_flags_seen.push_back(flag);
         *event = reinterpret_cast<void *>(ops->next_handle++);
         return 0;
     }
@@ -78,13 +81,54 @@ struct FakeContextOps {
     }
 
     KernelContextOps table() {
-        return KernelContextOps{this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream,
-                                &create_event, &destroy_event};
+        return KernelContextOps{
+            this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream, requested_event_flag,
+            &create_event, &destroy_event
+        };
     }
 };
 
 constexpr size_t kStreamCount = static_cast<size_t>(KernelStreamKind::Count);
 constexpr size_t kEventCount = static_cast<size_t>(KernelEventKind::Count);
+
+class KernelContextCreationFailure : public ::testing::TestWithParam<int> {};
+
+TEST_P(KernelContextCreationFailure, EveryCreationPointRollsBackAndCanRetry) {
+    FakeContextOps fake;
+    const int point = GetParam();
+    if (point < static_cast<int>(kStreamCount)) {
+        fake.create_stream_rc_after = point;
+    } else {
+        fake.create_event_rc_after = point - kStreamCount;
+    }
+    KernelExecutionState state;
+    EXPECT_NE(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_created, fake.streams_destroyed);
+    EXPECT_EQ(fake.events_created, fake.events_destroyed);
+    EXPECT_EQ(fake.streams_created + fake.events_created, point);
+    fake.create_stream_rc_after = -1;
+    fake.create_event_rc_after = -1;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(fake.streams_created, fake.streams_destroyed);
+    EXPECT_EQ(fake.events_created, fake.events_destroyed);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllStreamsAndEvents, KernelContextCreationFailure, ::testing::Range(0, static_cast<int>(kStreamCount + kEventCount))
+);
+
+TEST(KernelExecutionState, DestructionWithoutCloseMakesNoRuntimeCalls) {
+    FakeContextOps fake;
+    {
+        KernelExecutionState state;
+        ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    }
+    EXPECT_EQ(fake.streams_destroyed, 0);
+    EXPECT_EQ(fake.events_destroyed, 0);
+}
 
 TEST(KernelContextOpsVocabulary, IncompleteTableIsInvalid) {
     FakeContextOps fake;
@@ -121,6 +165,7 @@ TEST(ExecutionModeLatch, ModesAreMutuallyExclusiveInBothDirections) {
     EXPECT_FALSE(program.is_kernel());
 
     ExecutionModeLatch kernel;
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
     EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
     EXPECT_EQ(kernel.latch(SIMPLER_MODE_PROGRAM), PTO_RUNTIME_ERR_INVALID_STATE);
     EXPECT_TRUE(kernel.is_kernel());
@@ -160,6 +205,20 @@ TEST(KernelExecutionState, EmptyContextInitThenCloseIsClean) {
     EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
     EXPECT_EQ(fake.events_destroyed, fake.events_created);
     // Idempotent close.
+    EXPECT_EQ(state.close(), 0);
+}
+
+TEST(KernelExecutionState, EveryEventCarriesTheFlagTheOpsTableAsksFor) {
+    constexpr uint32_t kPlatformEventFlag = 0x8;
+    FakeContextOps fake;
+    fake.requested_event_flag = kPlatformEventFlag;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+
+    ASSERT_EQ(fake.event_flags_seen.size(), kEventCount);
+    for (uint32_t flag : fake.event_flags_seen) {
+        EXPECT_EQ(flag, kPlatformEventFlag);
+    }
     EXPECT_EQ(state.close(), 0);
 }
 

--- a/tests/ut/cpp/common/test_kernel_execution_state.cpp
+++ b/tests/ut/cpp/common/test_kernel_execution_state.cpp
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "host/execution_mode_latch.h"
+#include "host/kernel_execution_state.h"
+
+namespace {
+
+/**
+ * Fake ops backing the restricted context vocabulary. Handles are small
+ * integers cast to pointers; create/destroy counters prove balance, and the
+ * failure knobs drive the CLOSING-retry and partial-init paths.
+ */
+struct FakeContextOps {
+    int current_device{3};
+    int get_device_rc{0};
+    int create_stream_rc_after{-1};  // fail the Nth create_hidden_stream (0-based); -1 = never
+    int create_event_rc_after{-1};
+    int destroy_failures_remaining{0};
+
+    int streams_created{0};
+    int streams_destroyed{0};
+    int events_created{0};
+    int events_destroyed{0};
+    uintptr_t next_handle{1};
+
+    static FakeContextOps *self(void *context) { return static_cast<FakeContextOps *>(context); }
+
+    static int get_current_device(void *context, int *device_id) {
+        auto *ops = self(context);
+        if (ops->get_device_rc != 0) return ops->get_device_rc;
+        *device_id = ops->current_device;
+        return 0;
+    }
+    static int create_hidden_stream(void *context, void **stream) {
+        auto *ops = self(context);
+        if (ops->create_stream_rc_after >= 0 && ops->streams_created == ops->create_stream_rc_after) return -42;
+        ops->streams_created++;
+        *stream = reinterpret_cast<void *>(ops->next_handle++);
+        return 0;
+    }
+    static int destroy_hidden_stream(void *context, void *) {
+        auto *ops = self(context);
+        if (ops->destroy_failures_remaining > 0) {
+            ops->destroy_failures_remaining--;
+            return -43;
+        }
+        ops->streams_destroyed++;
+        return 0;
+    }
+    static int create_event(void *context, void **event) {
+        auto *ops = self(context);
+        if (ops->create_event_rc_after >= 0 && ops->events_created == ops->create_event_rc_after) return -44;
+        ops->events_created++;
+        *event = reinterpret_cast<void *>(ops->next_handle++);
+        return 0;
+    }
+    static int destroy_event(void *context, void *) {
+        auto *ops = self(context);
+        if (ops->destroy_failures_remaining > 0) {
+            ops->destroy_failures_remaining--;
+            return -43;
+        }
+        ops->events_destroyed++;
+        return 0;
+    }
+
+    KernelContextOps table() {
+        return KernelContextOps{this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream,
+                                &create_event, &destroy_event};
+    }
+};
+
+constexpr size_t kStreamCount = static_cast<size_t>(KernelStreamKind::Count);
+constexpr size_t kEventCount = static_cast<size_t>(KernelEventKind::Count);
+
+TEST(KernelContextOpsVocabulary, IncompleteTableIsInvalid) {
+    FakeContextOps fake;
+    KernelContextOps ops = fake.table();
+    EXPECT_TRUE(ops.valid());
+    ops.create_event = nullptr;
+    EXPECT_FALSE(ops.valid());
+}
+
+TEST(KernelLaunchOpsVocabulary, IncompleteTableIsInvalid) {
+    KernelLaunchOps ops{};
+    EXPECT_FALSE(ops.valid());
+}
+
+TEST(ExecutionModeLatch, StartsUnlatched) {
+    ExecutionModeLatch latch;
+    EXPECT_FALSE(latch.is_latched());
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, LatchingIsIdempotentForTheHeldMode) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_TRUE(latch.is_latched());
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, ModesAreMutuallyExclusiveInBothDirections) {
+    ExecutionModeLatch program;
+    EXPECT_EQ(program.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(program.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_FALSE(program.is_kernel());
+
+    ExecutionModeLatch kernel;
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_PROGRAM), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(kernel.is_kernel());
+}
+
+// finalize resets a runner's device state but not its identity, so the
+// init -> finalize -> init sequence the program path already supports must
+// still latch cleanly the second time.
+TEST(ExecutionModeLatch, SameModeRelatchesAfterAFinalizedLifetime) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+TEST(KernelExecutionState, EmptyContextInitThenCloseIsClean) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Collecting);
+    EXPECT_TRUE(state.accepts_dispatch());
+    EXPECT_EQ(state.device_id(), 3);
+    EXPECT_EQ(fake.streams_created, static_cast<int>(kStreamCount));
+    EXPECT_EQ(fake.events_created, static_cast<int>(kEventCount));
+    for (size_t i = 0; i < kStreamCount; ++i) {
+        EXPECT_NE(state.hidden_stream(static_cast<KernelStreamKind>(i)), nullptr);
+    }
+    for (size_t i = 0; i < kEventCount; ++i) {
+        EXPECT_NE(state.event(static_cast<KernelEventKind>(i)), nullptr);
+    }
+
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+    // Idempotent close.
+    EXPECT_EQ(state.close(), 0);
+}
+
+TEST(KernelExecutionState, CloseOnNewContextIsANoOpSuccess) {
+    KernelExecutionState state;
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, RepeatedInitializeRejected) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Collecting);
+}
+
+TEST(KernelExecutionState, PreEnqueueValidationLeavesStateUnchanged) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(-1, fake.table()), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    KernelContextOps incomplete = fake.table();
+    incomplete.destroy_event = nullptr;
+    EXPECT_EQ(state.initialize(3, incomplete), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+    // The context stays usable after the clean rejections.
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+}
+
+TEST(KernelExecutionState, DeviceMismatchRejectedBeforeAnyCreation) {
+    FakeContextOps fake;
+    fake.current_device = 7;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, PartialInitFailureRollsBackCleanly) {
+    FakeContextOps fake;
+    fake.create_event_rc_after = 1;  // second event creation fails
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -44);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+    // The rolled-back context is reusable.
+    fake.create_event_rc_after = -1;
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+}
+
+TEST(KernelExecutionState, StreamCreateFailureRollsBackCleanly) {
+    FakeContextOps fake;
+    fake.create_stream_rc_after = 1;  // second hidden-stream creation fails
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -42);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, GetCurrentDeviceFailurePropagates) {
+    FakeContextOps fake;
+    fake.get_device_rc = -51;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -51);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, InitFailureWithFailedCleanupLandsInClosing) {
+    FakeContextOps fake;
+    fake.create_event_rc_after = 0;       // first event creation fails
+    fake.destroy_failures_remaining = 1;  // the rollback's first destroy also fails
+    KernelExecutionState state;
+    // The reported error is the create failure; the cleanup failure is
+    // latched in the separate teardown slot.
+    EXPECT_EQ(state.initialize(3, fake.table()), -44);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+    EXPECT_TRUE(state.has_live_resources());
+    EXPECT_FALSE(state.accepts_dispatch());
+    // The kept ops table lets an explicit close retry release the remainder.
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+}
+
+TEST(KernelExecutionState, ReadyEnqueuedKeepsAdmissionOpen) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.mark_ready_enqueued(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::ReadyEnqueued);
+    EXPECT_EQ(state.mark_ready_enqueued(), 0);  // append admission stays open
+    EXPECT_TRUE(state.accepts_dispatch());
+}
+
+TEST(KernelExecutionState, MarkReadyEnqueuedRejectedOffPath) {
+    KernelExecutionState state;
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+TEST(KernelExecutionState, PoisonRejectsDispatchButAllowsClose) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    ASSERT_EQ(state.mark_ready_enqueued(), 0);
+    state.poison(-7);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Poisoned);
+    EXPECT_FALSE(state.accepts_dispatch());
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    // First poison cause wins; later ones do not overwrite it.
+    state.poison(-8);
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, PoisonOutsideDispatchPhasesIsIgnored) {
+    KernelExecutionState state;
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, PoisonDuringClosingIsIgnored) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 1;
+    ASSERT_EQ(state.close(), -43);
+    ASSERT_EQ(state.phase(), KernelContextPhase::Closing);
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, PoisonAfterCloseIsIgnored) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    ASSERT_EQ(state.close(), 0);
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, InitializeRejectedFromEveryNonNewPhase) {
+    FakeContextOps fake;
+
+    KernelExecutionState ready;
+    ASSERT_EQ(ready.initialize(3, fake.table()), 0);
+    ASSERT_EQ(ready.mark_ready_enqueued(), 0);
+    EXPECT_EQ(ready.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(ready.phase(), KernelContextPhase::ReadyEnqueued);
+
+    KernelExecutionState poisoned;
+    ASSERT_EQ(poisoned.initialize(3, fake.table()), 0);
+    poisoned.poison(-7);
+    EXPECT_EQ(poisoned.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(poisoned.phase(), KernelContextPhase::Poisoned);
+
+    KernelExecutionState closing;
+    ASSERT_EQ(closing.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 1;
+    ASSERT_EQ(closing.close(), -43);
+    ASSERT_EQ(closing.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(closing.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(closing.phase(), KernelContextPhase::Closing);
+
+    KernelExecutionState closed;
+    EXPECT_EQ(closed.close(), 0);
+    EXPECT_EQ(closed.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(closed.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, ClosingIsStickyAndRetriable) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 2;
+    const int rc = state.close();
+    EXPECT_EQ(rc, -43);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_FALSE(state.accepts_dispatch());
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(state.has_live_resources());
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+
+    // Retry succeeds and releases only what is still live.
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+}
+
+TEST(KernelExecutionState, TeardownErrorSlotIsSeparateFromRuntimeError) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    state.poison(-7);
+    fake.destroy_failures_remaining = 1;
+    EXPECT_EQ(state.close(), -43);
+    // The controlled poison cause and the real teardown failure are reported
+    // through separate slots; neither masks the other.
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+    EXPECT_EQ(state.close(), 0);
+    // The first teardown failure stays latched after a successful retry.
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_persistent_args.cpp
+++ b/tests/ut/cpp/common/test_kernel_persistent_args.cpp
@@ -109,6 +109,7 @@ struct FakeArgsOps {
         void *block = alloc(context, kBlockAlign);
         if (block == nullptr) return kInjectedRc;
         args->regs = reinterpret_cast<uint64_t>(block);
+        if (ops->fail_after_arch_alloc) return kInjectedRc;
         return 0;
     }
 
@@ -128,6 +129,7 @@ struct FakeArgsOps {
     int fail_free_on = 0;
     int fail_copy_on = 0;
     int fail_fill_on = 0;
+    bool fail_after_arch_alloc = false;
     uint64_t last_device_id = 0;
     std::vector<Copy> copies;
     std::vector<void *> free_order;
@@ -420,11 +422,11 @@ TEST(PersistentKernelArgs, FinalizeRetryRedoesOnlyTheRemainder) {
     // still releases the remaining two and keeps only the failed address.
     ops.fail_free_on = ops.free_calls + 1;
     EXPECT_EQ(args.finalize_once(), kInjectedRc);
-    EXPECT_NE(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.device_k_args(), nullptr);
     EXPECT_EQ(args.args().runtime_args, nullptr);
     EXPECT_EQ(args.args().regs, 0u);
     EXPECT_EQ(ops.live_blocks(), 1u);
-    EXPECT_TRUE(args.is_prepared());
+    EXPECT_FALSE(args.is_prepared());
 
     ops.fail_free_on = 0;
     const int frees_before_retry = ops.free_calls;
@@ -433,6 +435,81 @@ TEST(PersistentKernelArgs, FinalizeRetryRedoesOnlyTheRemainder) {
     EXPECT_EQ(ops.live_blocks(), 0u);
     EXPECT_EQ(args.device_k_args(), nullptr);
     EXPECT_FALSE(args.is_prepared());
+}
+
+TEST(PersistentKernelArgs, FailedRollbackRetainsOwnershipAndRejectsPrepare) {
+    for (int copy = 1; copy <= 2; ++copy) {
+        FakeArgsOps ops;
+        Runtime runtime;
+        PersistentKernelArgs args;
+        ops.fail_copy_on = copy;
+        ops.fail_free_on = 1;
+        ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), kInjectedRc);
+        EXPECT_FALSE(args.is_prepared());
+        EXPECT_EQ(args.device_k_args(), nullptr);
+        ASSERT_EQ(ops.live_blocks(), 1u);
+        const int allocs = ops.alloc_calls;
+        EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), PTO_RUNTIME_ERR_INVALID_STATE);
+        EXPECT_EQ(ops.alloc_calls, allocs);
+        EXPECT_EQ(args.finalize_once(), 0);
+        EXPECT_EQ(ops.live_blocks(), 0u);
+    }
+}
+
+TEST(PersistentKernelArgs, PartialArchFailureRetainsFailedRelease) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+    ops.fail_after_arch_alloc = true;
+    ops.fail_free_on = 1;
+    EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), kInjectedRc);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_TRUE(args.has_live_resources());
+    EXPECT_EQ(ops.live_blocks(), 1u);
+    EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_FALSE(args.has_live_resources());
+    EXPECT_EQ(ops.live_blocks(), 0u);
+}
+
+TEST(PersistentKernelArgs, EveryReleaseFailureRevokesReadinessAndRetriesOnlyLiveBlocks) {
+    for (int failed_release = 1; failed_release <= 3; ++failed_release) {
+        FakeArgsOps ops;
+        Runtime runtime;
+        PersistentKernelArgs args;
+        ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+        ops.fail_free_on = failed_release;
+        EXPECT_EQ(args.finalize_once(), kInjectedRc);
+        EXPECT_FALSE(args.is_prepared());
+        EXPECT_EQ(args.device_k_args(), nullptr);
+        EXPECT_TRUE(args.has_live_resources());
+        EXPECT_EQ(ops.live_blocks(), 1u);
+        const int allocs = ops.alloc_calls;
+        EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), PTO_RUNTIME_ERR_INVALID_STATE);
+        EXPECT_EQ(ops.alloc_calls, allocs);
+        const int frees = ops.free_calls;
+        EXPECT_EQ(args.finalize_once(), 0);
+        EXPECT_EQ(ops.free_calls, frees + 1);
+        EXPECT_FALSE(args.has_live_resources());
+        EXPECT_EQ(ops.live_blocks(), 0u);
+    }
+}
+
+TEST(PersistentKernelArgs, AbandonAfterFailedRollbackDropsOnlyBookkeeping) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+    ops.fail_copy_on = 2;
+    ops.fail_free_on = 1;
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), kInjectedRc);
+    ASSERT_TRUE(args.has_live_resources());
+    const int frees = ops.free_calls;
+    args.abandon();
+    EXPECT_FALSE(args.has_live_resources());
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees);
+    // The test allocator owns the backing after simulated device invalidation.
+    EXPECT_EQ(ops.live_blocks(), 1u);
 }
 
 TEST(PersistentKernelArgs, AbandonNeverReachesTheOpsTable) {

--- a/tests/ut/cpp/common/test_kernel_persistent_args.cpp
+++ b/tests/ut/cpp/common/test_kernel_persistent_args.cpp
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * PersistentKernelArgs lifecycle, driven through a fake PersistentArgsOps so
+ * allocation balance, partial-failure rollback and the exact bytes that reach
+ * the device are all observable without a device.
+ *
+ * Compiled once per runtime variant: the trb build defines
+ * SIMPLER_UT_TRB_RUNTIME and copies only the `dev` descriptor, the hbg build
+ * copies the whole Runtime.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "kernel_persistent_args.h"
+#include "host/kernel_execution_state.h"
+#include "runtime_c_api.h"
+
+namespace {
+
+constexpr size_t kBlockAlign = 64;
+constexpr int kInjectedRc = -1701;
+constexpr uint64_t kDeviceId = 3;
+
+/**
+ * Records every allocation, release and host-to-device copy, and can fail the
+ * n-th of any of them. Blocks are 64-byte aligned so a recorded device image
+ * can be read back through the type that was copied into it.
+ *
+ * Its fill_arch_fields draws the register table from its own alloc, which is
+ * the obligation the real arch implementations carry too — otherwise the
+ * balance assertions below would not hold.
+ */
+struct FakeArgsOps {
+    struct Copy {
+        void *dst;
+        size_t dst_bytes;
+        size_t src_bytes;
+    };
+
+    ~FakeArgsOps() {
+        for (void *block : live)
+            ::free(block);
+    }
+
+    static FakeArgsOps *self(void *context) { return static_cast<FakeArgsOps *>(context); }
+
+    static void *alloc(void *context, size_t bytes) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("alloc");
+        ++ops->alloc_calls;
+        if (ops->alloc_calls == ops->fail_alloc_on) return nullptr;
+        const size_t rounded = ((bytes + kBlockAlign - 1) / kBlockAlign) * kBlockAlign;
+        void *block = ::aligned_alloc(kBlockAlign, rounded);
+        if (block != nullptr) {
+            std::memset(block, 0, rounded);
+            ops->live.insert(block);
+            ops->sizes[block] = bytes;
+        }
+        return block;
+    }
+
+    static int free_(void *context, void *ptr) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("free");
+        ++ops->free_calls;
+        ops->free_order.push_back(ptr);
+        if (ops->free_calls == ops->fail_free_on) return kInjectedRc;
+        if (ops->live.erase(ptr) == 0) {
+            ADD_FAILURE() << "release of a block this table does not own";
+            return kInjectedRc;
+        }
+        ops->sizes.erase(ptr);
+        ::free(ptr);
+        return 0;
+    }
+
+    static int copy_h2d(void *context, void *dst, size_t dst_bytes, const void *src, size_t src_bytes) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("copy");
+        ++ops->copy_calls;
+        ops->copies.push_back(Copy{dst, dst_bytes, src_bytes});
+        if (ops->copy_calls == ops->fail_copy_on) return kInjectedRc;
+        std::memcpy(dst, src, src_bytes < dst_bytes ? src_bytes : dst_bytes);
+        return 0;
+    }
+
+    static int fill_arch_fields(void *context, KernelArgs *args, uint64_t device_id) {
+        FakeArgsOps *ops = self(context);
+        ops->calls.push_back("arch");
+        ++ops->fill_calls;
+        ops->last_device_id = device_id;
+        if (ops->fill_calls == ops->fail_fill_on) return kInjectedRc;
+        void *block = alloc(context, kBlockAlign);
+        if (block == nullptr) return kInjectedRc;
+        args->regs = reinterpret_cast<uint64_t>(block);
+        return 0;
+    }
+
+    PersistentArgsOps table() { return PersistentArgsOps{this, &alloc, &free_, &copy_h2d, &fill_arch_fields}; }
+
+    size_t live_blocks() const { return live.size(); }
+    size_t block_size(void *block) const {
+        const auto it = sizes.find(block);
+        return it == sizes.end() ? 0 : it->second;
+    }
+
+    int alloc_calls = 0;
+    int free_calls = 0;
+    int copy_calls = 0;
+    int fill_calls = 0;
+    int fail_alloc_on = 0;
+    int fail_free_on = 0;
+    int fail_copy_on = 0;
+    int fail_fill_on = 0;
+    uint64_t last_device_id = 0;
+    std::vector<Copy> copies;
+    std::vector<void *> free_order;
+    std::set<void *> live;
+    std::map<void *, size_t> sizes;
+    std::vector<std::string> calls;
+};
+
+struct FakeLifecycleOps {
+    FakeArgsOps memory;
+    uintptr_t next_handle{1};
+    std::set<void *> handles;
+    std::vector<std::string> &calls() { return memory.calls; }
+
+    static int create(void *context, void **handle, const char *kind) {
+        auto &fake = *static_cast<FakeLifecycleOps *>(context);
+        *handle = reinterpret_cast<void *>(fake.next_handle++);
+        fake.handles.insert(*handle);
+        fake.calls().push_back(std::string("create_") + kind);
+        return 0;
+    }
+    static int destroy(void *context, void *handle, const char *kind) {
+        auto &fake = *static_cast<FakeLifecycleOps *>(context);
+        EXPECT_EQ(fake.handles.erase(handle), 1u);
+        fake.calls().push_back(
+            std::string("destroy_") + kind + ":" + std::to_string(reinterpret_cast<uintptr_t>(handle))
+        );
+        return 0;
+    }
+    KernelContextOps context_ops() {
+        return {
+            this,
+            [](void *context, int *device) {
+                static_cast<FakeLifecycleOps *>(context)->calls().push_back("get_device");
+                *device = kDeviceId;
+                return 0;
+            },
+            [](void *context, void **stream) {
+                return create(context, stream, "stream");
+            },
+            [](void *context, void *stream) {
+                return destroy(context, stream, "stream");
+            },
+            0,
+            [](void *context, uint32_t, void **event) {
+                return create(context, event, "event");
+            },
+            [](void *context, void *event) {
+                return destroy(context, event, "event");
+            },
+        };
+    }
+
+    // Test-only downstream consumer; this does not implement or qualify the
+    // future binder's event protocol. It consumes the real owners' resources.
+    void launch(KernelExecutionState &state, const PersistentKernelArgs &args) {
+        ASSERT_TRUE(state.accepts_dispatch());
+        ASSERT_TRUE(args.is_prepared());
+        const KernelArgs *image = args.device_k_args();
+        ASSERT_NE(image, nullptr);
+        EXPECT_EQ(image->runtime_args, args.args().runtime_args);
+        EXPECT_EQ(image->regs, args.args().regs);
+        for (auto kind : {KernelStreamKind::Aicpu, KernelStreamKind::Aicore}) {
+            EXPECT_EQ(handles.count(state.hidden_stream(kind)), 1u);
+        }
+        for (size_t i = 0; i < static_cast<size_t>(KernelEventKind::Count); ++i) {
+            EXPECT_EQ(handles.count(state.event(static_cast<KernelEventKind>(i))), 1u);
+        }
+        calls().push_back("fake_launch");
+    }
+};
+
+class KernelResourceLifecycle : public ::testing::TestWithParam<int> {};
+
+TEST_P(KernelResourceLifecycle, HasExactResourceCallOrder) {
+    FakeLifecycleOps fake;
+    std::vector<std::string> expected{"get_device", "create_stream", "create_stream"};
+    expected.insert(expected.end(), static_cast<size_t>(KernelEventKind::Count), "create_event");
+    {
+        KernelExecutionState state;
+        Runtime runtime;
+        PersistentKernelArgs args;
+        ASSERT_EQ(state.initialize(kDeviceId, fake.context_ops()), 0);
+        EXPECT_EQ(fake.calls(), expected);
+        ASSERT_EQ(args.prepare_once(runtime, fake.memory.table(), kDeviceId), 0);
+        ASSERT_EQ(state.mark_ready_enqueued(), 0);
+        expected.insert(expected.end(), {"alloc", "copy", "arch", "alloc", "alloc", "copy"});
+        EXPECT_EQ(fake.calls(), expected);
+        const auto *device_args = args.device_k_args();
+        const auto *runtime_args = args.args().runtime_args;
+        const auto regs = args.args().regs;
+        for (int i = 0; i < GetParam(); ++i) {
+            SCOPED_TRACE(i);
+            ASSERT_EQ(args.prepare_once(runtime, fake.memory.table(), kDeviceId), 0);
+            fake.launch(state, args);
+            expected.push_back("fake_launch");
+            EXPECT_EQ(fake.calls(), expected);
+            EXPECT_EQ(args.device_k_args(), device_args);
+            EXPECT_EQ(args.args().runtime_args, runtime_args);
+            EXPECT_EQ(args.args().regs, regs);
+        }
+        ASSERT_EQ(args.finalize_once(), 0);
+        expected.insert(expected.end(), {"free", "free", "free"});
+        EXPECT_EQ(fake.calls(), expected);
+        ASSERT_EQ(state.close(), 0);
+        for (uintptr_t id = 2 + static_cast<size_t>(KernelEventKind::Count); id > 2; --id)
+            expected.push_back("destroy_event:" + std::to_string(id));
+        expected.insert(expected.end(), {"destroy_stream:2", "destroy_stream:1"});
+        EXPECT_EQ(fake.calls(), expected);
+        EXPECT_TRUE(fake.handles.empty());
+        EXPECT_EQ(fake.memory.live_blocks(), 0u);
+        EXPECT_EQ(args.finalize_once(), 0);
+        EXPECT_EQ(state.close(), 0);
+    }
+    EXPECT_EQ(fake.calls(), expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(LaunchCounts, KernelResourceLifecycle, ::testing::Values(0, 1, 128));
+
+// ---------------------------------------------------------------------------
+// UT-P1 / UT-P2: prepare once, then reuse.
+// ---------------------------------------------------------------------------
+
+TEST(PersistentKernelArgs, ReusesTheSameAddressesForEveryLaunch) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    ASSERT_TRUE(args.is_prepared());
+    EXPECT_EQ(ops.last_device_id, kDeviceId);
+
+    KernelArgs *const device_args = args.device_k_args();
+    Runtime *const runtime_args = args.args().runtime_args;
+    const uint64_t regs = args.args().regs;
+    ASSERT_NE(device_args, nullptr);
+    ASSERT_NE(runtime_args, nullptr);
+    ASSERT_NE(regs, 0u);
+
+    const int allocs_after_prepare = ops.alloc_calls;
+    const int copies_after_prepare = ops.copy_calls;
+    for (int i = 0; i < 128; ++i) {
+        EXPECT_EQ(args.device_k_args(), device_args);
+        EXPECT_EQ(args.args().runtime_args, runtime_args);
+        EXPECT_EQ(args.args().regs, regs);
+    }
+    EXPECT_EQ(ops.alloc_calls, allocs_after_prepare);
+    EXPECT_EQ(ops.copy_calls, copies_after_prepare);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, PrepareOnceIsIdempotent) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    const int allocs = ops.alloc_calls;
+    const int copies = ops.copy_calls;
+    const int fills = ops.fill_calls;
+    KernelArgs *const device_args = args.device_k_args();
+
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    EXPECT_EQ(ops.alloc_calls, allocs);
+    EXPECT_EQ(ops.copy_calls, copies);
+    EXPECT_EQ(ops.fill_calls, fills);
+    EXPECT_EQ(args.device_k_args(), device_args);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, IncompleteOpsTableIsRejectedBeforeAnyAllocation) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    PersistentArgsOps incomplete = ops.table();
+    EXPECT_TRUE(incomplete.valid());
+    incomplete.fill_arch_fields = nullptr;
+    EXPECT_FALSE(incomplete.valid());
+
+    EXPECT_EQ(args.prepare_once(runtime, incomplete, kDeviceId), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(ops.alloc_calls, 0);
+}
+
+// ---------------------------------------------------------------------------
+// UT-P3 / UT-F2: every failing step rolls back to "never prepared".
+// ---------------------------------------------------------------------------
+
+struct RollbackCase {
+    const char *name;
+    int fail_alloc_on;
+    int fail_copy_on;
+    int fail_fill_on;
+};
+
+class PersistentKernelArgsRollback : public ::testing::TestWithParam<RollbackCase> {};
+
+TEST_P(PersistentKernelArgsRollback, ReleasesEverythingItAllocated) {
+    const RollbackCase &c = GetParam();
+    FakeArgsOps ops;
+    ops.fail_alloc_on = c.fail_alloc_on;
+    ops.fail_copy_on = c.fail_copy_on;
+    ops.fail_fill_on = c.fail_fill_on;
+
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    const int rc = args.prepare_once(runtime, ops.table(), kDeviceId);
+    EXPECT_NE(rc, 0) << c.name;
+    EXPECT_FALSE(args.is_prepared()) << c.name;
+    EXPECT_EQ(args.device_k_args(), nullptr) << c.name;
+    EXPECT_EQ(args.args().runtime_args, nullptr) << c.name;
+    EXPECT_EQ(args.args().regs, 0u) << c.name;
+    EXPECT_EQ(ops.live_blocks(), 0u) << c.name;
+
+    // A second attempt on a rolled-back owner starts from scratch and succeeds.
+    ops.fail_alloc_on = 0;
+    ops.fail_copy_on = 0;
+    ops.fail_fill_on = 0;
+    EXPECT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0) << c.name;
+    EXPECT_TRUE(args.is_prepared()) << c.name;
+    EXPECT_EQ(args.finalize_once(), 0) << c.name;
+    EXPECT_EQ(ops.live_blocks(), 0u) << c.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    EveryAllocatingStep, PersistentKernelArgsRollback,
+    ::testing::Values(
+        RollbackCase{"runtime_args alloc", 1, 0, 0}, RollbackCase{"runtime_args copy", 0, 1, 0},
+        RollbackCase{"arch fields", 0, 0, 1}, RollbackCase{"arch fields alloc", 2, 0, 0},
+        RollbackCase{"device KernelArgs alloc", 3, 0, 0}, RollbackCase{"device KernelArgs copy", 0, 2, 0}
+    ),
+    [](const ::testing::TestParamInfo<RollbackCase> &info) {
+        std::string name(info.param.name);
+        for (char &ch : name) {
+            if (ch == ' ') ch = '_';
+        }
+        return name;
+    }
+);
+
+// ---------------------------------------------------------------------------
+// UT-P4 / UT-P5 / UT-F4 / UT-F5: release, abandon, retry.
+// ---------------------------------------------------------------------------
+
+TEST(PersistentKernelArgs, FinalizeOnceBalancesAndIsIdempotent) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    KernelArgs *const device_args = args.device_k_args();
+    Runtime *const runtime_args = args.args().runtime_args;
+    const uint64_t regs = args.args().regs;
+    ASSERT_EQ(args.finalize_once(), 0);
+
+    // Reverse allocation order: the device copy that names the other two
+    // blocks is released before either of them.
+    ASSERT_EQ(ops.free_order.size(), 3u);
+    EXPECT_EQ(ops.free_order[0], device_args);
+    EXPECT_EQ(ops.free_order[1], reinterpret_cast<void *>(regs));
+    EXPECT_EQ(ops.free_order[2], runtime_args);
+
+    EXPECT_EQ(ops.free_calls, ops.alloc_calls);
+    EXPECT_EQ(ops.live_blocks(), 0u);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.args().runtime_args, nullptr);
+    EXPECT_EQ(args.args().regs, 0u);
+
+    const int frees = ops.free_calls;
+    for (int i = 0; i < 4; ++i)
+        EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees);
+}
+
+TEST(PersistentKernelArgs, FinalizeRetryRedoesOnlyTheRemainder) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    // The device KernelArgs block is released first; failing that one release
+    // still releases the remaining two and keeps only the failed address.
+    ops.fail_free_on = ops.free_calls + 1;
+    EXPECT_EQ(args.finalize_once(), kInjectedRc);
+    EXPECT_NE(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.args().runtime_args, nullptr);
+    EXPECT_EQ(args.args().regs, 0u);
+    EXPECT_EQ(ops.live_blocks(), 1u);
+    EXPECT_TRUE(args.is_prepared());
+
+    ops.fail_free_on = 0;
+    const int frees_before_retry = ops.free_calls;
+    EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees_before_retry + 1);
+    EXPECT_EQ(ops.live_blocks(), 0u);
+    EXPECT_EQ(args.device_k_args(), nullptr);
+    EXPECT_FALSE(args.is_prepared());
+}
+
+TEST(PersistentKernelArgs, AbandonNeverReachesTheOpsTable) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    const int frees = ops.free_calls;
+
+    args.abandon();
+
+    EXPECT_EQ(ops.free_calls, frees);
+    EXPECT_FALSE(args.is_prepared());
+    EXPECT_EQ(args.device_k_args(), nullptr);
+    EXPECT_EQ(args.args().runtime_args, nullptr);
+    EXPECT_EQ(args.args().regs, 0u);
+
+    // A later release attempt on an abandoned owner still reaches no table.
+    EXPECT_EQ(args.finalize_once(), 0);
+    EXPECT_EQ(ops.free_calls, frees);
+}
+
+TEST(PersistentKernelArgs, DestructionReleasesNothing) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    {
+        PersistentKernelArgs args;
+        ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    }
+    EXPECT_EQ(ops.free_calls, 0);
+    EXPECT_NE(ops.live_blocks(), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// UT-P6 / UT-P7: what actually crosses to the device.
+// ---------------------------------------------------------------------------
+
+TEST(PersistentKernelArgs, CopiesExactlyTheRuntimeDeviceImage) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+    ASSERT_EQ(ops.copies.size(), 2u);
+
+    const size_t image_bytes = runtime_device_copy_size(runtime);
+#if defined(SIMPLER_UT_TRB_RUNTIME)
+    EXPECT_EQ(image_bytes, sizeof(DeviceRuntimeLaunchDesc));
+    EXPECT_LT(image_bytes, sizeof(Runtime));
+#else
+    EXPECT_EQ(image_bytes, sizeof(Runtime));
+#endif
+
+    EXPECT_EQ(ops.copies[0].src_bytes, image_bytes);
+    EXPECT_EQ(ops.copies[0].dst_bytes, image_bytes);
+    EXPECT_EQ(ops.copies[0].dst, args.args().runtime_args);
+    EXPECT_EQ(ops.block_size(args.args().runtime_args), image_bytes);
+    EXPECT_EQ(std::memcmp(args.args().runtime_args, &runtime, image_bytes), 0);
+
+    EXPECT_EQ(ops.copies[1].src_bytes, sizeof(KernelArgs));
+    EXPECT_EQ(ops.copies[1].dst, args.device_k_args());
+    EXPECT_EQ(std::memcmp(args.device_k_args(), &args.args(), sizeof(KernelArgs)), 0);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, LeavesThePerCallableDispatchFieldsAtTheirSentinels) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    // The device image starts at offset 0 of Runtime under both variants, so
+    // the uploaded bytes answer the accessors the device-side code uses.
+    const Runtime *const uploaded = reinterpret_cast<const Runtime *>(args.args().runtime_args);
+    EXPECT_EQ(uploaded->get_active_callable_id(), -1);
+    for (int func_id = 0; func_id < RUNTIME_MAX_FUNC_ID; ++func_id) {
+        ASSERT_EQ(uploaded->get_function_bin_addr(func_id), 0u) << "func_id=" << func_id;
+    }
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+TEST(PersistentKernelArgs, LeavesEveryDfxFieldZero) {
+    FakeArgsOps ops;
+    Runtime runtime;
+    PersistentKernelArgs args;
+
+    ASSERT_EQ(args.prepare_once(runtime, ops.table(), kDeviceId), 0);
+
+    const KernelArgs *const uploaded = args.device_k_args();
+    EXPECT_EQ(uploaded->dump_data_base, 0u);
+    EXPECT_EQ(uploaded->chip_swimlane_data_base, 0u);
+    EXPECT_EQ(uploaded->pmu_data_base, 0u);
+    EXPECT_EQ(uploaded->dep_gen_data_base, 0u);
+    EXPECT_EQ(uploaded->scope_stats_data_base, 0u);
+    EXPECT_EQ(uploaded->chip_swimlane_aicore_rotation_table, 0u);
+    EXPECT_EQ(uploaded->device_wall_data_base, 0u);
+    EXPECT_EQ(uploaded->enable_profiling_flag, 0u);
+
+    EXPECT_EQ(args.finalize_once(), 0);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_tmr_executor_execution_inputs.cpp
+++ b/tests/ut/cpp/common/test_tmr_executor_execution_inputs.cpp
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "aicpu/device_log.h"
+#include "aicpu/platform_aicpu_affinity.h"
+#include "aicpu/platform_regs.h"
+#include "common/kernel_args.h"
+#include "host_log.h"
+#include "tensormap_and_ringbuffer/kernel_execution_inputs.h"
+#include "worker/tmr_kernel_invocation.h"
+
+namespace {
+thread_local int affinity_index = 0;
+std::array<uint64_t, PLATFORM_MAX_CORES> register_bases{};
+std::array<uint64_t, 3> register_cells{};
+std::atomic<int> opened_windows{0};
+}  // namespace
+
+// The orchestration submits only dependency tasks, never AICore work. These
+// platform fixtures supply ready-core reports and idle register windows.
+int platform_aicpu_affinity_thread_idx() { return affinity_index; }
+void platform_aicpu_affinity_set_thread_idx(int index) { affinity_index = index; }
+extern "C" uint64_t get_platform_regs() { return reinterpret_cast<uint64_t>(register_bases.data()); }
+extern "C" uint64_t get_platform_pmu_reg_addrs() { return 0; }
+uint32_t platform_get_physical_cores_count() { return PLATFORM_MAX_CORES; }
+volatile uint32_t *get_reg_ptr(uint64_t base, RegId) { return reinterpret_cast<volatile uint32_t *>(base); }
+uint64_t read_reg(uint64_t base, RegId) { return *reinterpret_cast<uint64_t *>(base); }
+uint32_t reg_load_acquire(const volatile uint32_t *ptr) { return *ptr; }
+void reg_store_release(volatile uint32_t *, uint32_t) {}
+void platform_init_aicore_regs(uint64_t) { ++opened_windows; }
+uint64_t platform_aicore_exit_deadline() { return 0; }
+
+extern "C" int simpler_aicpu_register_callable(void *);
+
+namespace {
+using namespace simpler::tmr;
+
+class TmrExecutorExecutionInputsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        ASSERT_EQ(set_host_log_state(HostLogger::get_instance().state()), 0);
+        uint64_t windows[CHIP_MAX_RING_DEPTH] = {16, 16, 16, 16};
+        uint64_t heaps[CHIP_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
+        int32_t deps[CHIP_MAX_RING_DEPTH] = {4, 4, 4, 4};
+        layout = runtime_reserve_layout(arena, windows, heaps, deps);
+        ASSERT_NE(arena.commit(), nullptr);
+        const size_t sm_size = SharedMemoryHandle::calculate_size_per_ring(windows);
+        const size_t sm_offset = sm.reserve(sm_size, CHIP_ALIGN_SIZE);
+        ASSERT_NE(sm.commit(), nullptr);
+        SharedMemoryHandle initialized_sm;
+        ASSERT_TRUE(initialized_sm.init_per_ring(sm.region_ptr(sm_offset), sm_size, windows, heaps));
+        heap.resize(4096);
+        auto *runtime = runtime_init_data_from_layout(
+            arena, layout, MODE_EXECUTE, sm.region_ptr(sm_offset), sm_size, heap.data(), heaps
+        );
+        ASSERT_NE(runtime, nullptr);
+        runtime->prebuilt_layout = layout;
+        binding = {
+            {reinterpret_cast<uint64_t>(&identity), 13},
+            resident.get(),
+            {sm.region_ptr(sm_offset), sm_size, sm_size},
+            {arena.base(), layout.offsets.arena_size, layout.offsets.arena_size},
+            layout.offsets.off_runtime
+        };
+        resident->dev.worker_count = 3;
+        resident->dev.aicpu_thread_num = 2;
+        for (size_t i = 0; i < register_cells.size(); ++i) {
+            register_bases[i] = reinterpret_cast<uint64_t>(&register_cells[i]);
+        }
+        std::ifstream library(TMR_EXECUTOR_ORCH_FIXTURE, std::ios::binary);
+        ASSERT_TRUE(library.is_open());
+        binary.assign(std::istreambuf_iterator<char>(library), std::istreambuf_iterator<char>());
+        ASSERT_FALSE(binary.empty());
+        register_orchestration(3, "orchestration_a", "config_a");
+        register_orchestration(4, "orchestration_b", "config_b");
+    }
+
+    void TearDown() override { release_kernel_execution(); }
+
+    void register_orchestration(int id, const char *entry, const char *config) {
+        RegisterCallableArgs args{};
+        args.active_callable_id = id;
+        args.dev_orch_so_addr = reinterpret_cast<uint64_t>(binary.data());
+        args.dev_orch_so_size = binary.size();
+        std::strcpy(args.device_orch_func_name, entry);
+        std::strcpy(args.device_orch_config_name, config);
+        ASSERT_EQ(simpler_aicpu_register_callable(&args), 0);
+    }
+
+    void report_ready_cores() {
+        opened_windows = 0;
+        for (int i = 0; i < 3; ++i) {
+            auto &worker = resident->get_workers()[i];
+            worker.physical_core_id = i;
+            worker.core_type = i == 0 ? CoreType::AIC : CoreType::AIV;
+            worker.aicore_done = i + 1;
+        }
+    }
+
+    ChipStorageTaskArgs arguments(uint64_t value) {
+        ChipStorageTaskArgs args;
+        const uint32_t shape[] = {static_cast<uint32_t>(output.size() * 2)};
+        args.add_tensor(make_tensor_external(output.data(), shape, 1, DataType::INT32, AddressSpace::DEVICE));
+        args.add_scalar(value);
+        return args;
+    }
+
+    std::array<int, 2> initialize_group() {
+        std::array<int, 2> results{};
+        std::thread scheduler([&] {
+            affinity_index = 0;
+            results[0] = init_kernel_execution();
+        });
+        std::thread orchestrator([&] {
+            affinity_index = 1;
+            results[1] = init_kernel_execution();
+        });
+        scheduler.join();
+        orchestrator.join();
+        return results;
+    }
+
+    void expect_successful_reuse() {
+        EXPECT_EQ(kernel_execution_status(), -1);
+        EXPECT_EQ(init_kernel_execution(), -1);
+        EXPECT_EQ(run_kernel_execution(), -1);
+        output.fill(0);
+        PreparedInvocationView callable{3, 1, 1, 17};
+        TmrEncodingCandidate packet;
+        TmrEncodingCache cache;
+        auto args = arguments(71);
+        ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+        ASSERT_EQ(admit_kernel_execution(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+        report_ready_cores();
+        const auto initialized = initialize_group();
+        ASSERT_EQ(initialized[0], 0);
+        ASSERT_EQ(initialized[1], 0);
+        affinity_index = 1;
+        ASSERT_EQ(run_kernel_execution(), 0);
+        affinity_index = 0;
+        ASSERT_EQ(run_kernel_execution(), 0);
+        EXPECT_EQ(kernel_execution_status(), 0);
+        EXPECT_EQ(output[0], 3u);
+        EXPECT_EQ(output[1], 71u);
+        EXPECT_EQ(output[3], 3u);
+        EXPECT_EQ(output[4], 71u);
+        EXPECT_NE(output[2], 0u);
+        EXPECT_EQ(output[2], output[5]);
+        expect_resident_configuration(resident->dev.serial_orch_sched);
+        release_kernel_execution();
+        EXPECT_EQ(kernel_execution_status(), -1);
+    }
+
+    void expect_resident_configuration(bool serial) {
+        EXPECT_EQ(resident->get_active_callable_id(), -1);
+        EXPECT_EQ(resident->get_orch_args().tensor_count(), 0);
+        EXPECT_EQ(resident->get_orch_args().scalar_count(), 0);
+        for (uint64_t address : resident->dev.func_id_to_addr_)
+            EXPECT_EQ(address, 0u);
+        EXPECT_EQ(resident->dev.worker_count, 3);
+        EXPECT_EQ(resident->dev.aicpu_thread_num, 2);
+        EXPECT_EQ(resident->dev.serial_orch_sched, serial);
+        EXPECT_EQ(resident->dev.ready_queue_shards, RUNTIME_DEFAULT_READY_QUEUE_SHARDS);
+        EXPECT_EQ(resident->dev.aicpu_allowed_cpu_count, 0);
+        EXPECT_EQ(resident->dev.aicpu_launch_count, 0);
+        EXPECT_EQ(resident->get_gm_sm_ptr(), nullptr);
+        EXPECT_EQ(resident->get_prebuilt_arena_base(), nullptr);
+        EXPECT_EQ(resident->get_prebuilt_runtime_offset(), 0u);
+    }
+
+    std::unique_ptr<Runtime> resident{std::make_unique<Runtime>()};
+    DeviceArena arena;
+    DeviceArena sm;
+    RuntimeArenaLayout layout{};
+    KernelBindingView binding{};
+    std::vector<char> heap;
+    std::vector<char> binary;
+    std::array<uint64_t, 6> output{};
+    uint64_t identity{0};
+};
+
+TEST_F(TmrExecutorExecutionInputsTest, ActualKernelPhasesKeepConfigAndOrchestrationInputsAcrossABA) {
+    EXPECT_EQ(kernel_execution_status(), -1);
+    EXPECT_EQ(init_kernel_execution(), -1);
+    EXPECT_EQ(run_kernel_execution(), -1);
+    uint64_t invocation = 40;
+    uint64_t storage_address = 0;
+    for (bool serial : {false, true}) {
+        SCOPED_TRACE(serial);
+        resident->dev.serial_orch_sched = serial;
+        for (int id : {3, 4, 3}) {
+            SCOPED_TRACE(id);
+            output.fill(0);
+            PreparedInvocationView callable{id, 1, 1, 17};
+            TmrEncodingCandidate packet;
+            TmrEncodingCache cache;
+            auto args = arguments(++invocation);
+            ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+            const auto encoded = packet.packet();
+            std::vector<uint8_t> transport(encoded.data, encoded.data + encoded.size);
+            const ByteSpan submitted{transport.data(), transport.size()};
+            ASSERT_EQ(admit_kernel_execution(submitted, {callable, {}}, binding), InvocationStatus::Ok);
+            EXPECT_EQ(admit_kernel_execution(submitted, {callable, {}}, binding), InvocationStatus::InvalidArgument);
+            // Admission owns the decoded arguments; the transport storage can die
+            // before either execution phase consumes them.
+            std::memset(transport.data(), 0, transport.size());
+            transport = {};
+            packet = {};
+            args = {};
+            report_ready_cores();
+            std::array<int, 2> init_results{};
+            std::thread scheduler([&] {
+                affinity_index = 0;
+                init_results[0] = init_kernel_execution();
+            });
+            std::thread orchestrator([&] {
+                affinity_index = 1;
+                init_results[1] = init_kernel_execution();
+            });
+            scheduler.join();
+            orchestrator.join();
+            ASSERT_EQ(init_results[0], 0);
+            ASSERT_EQ(init_results[1], 0);
+            affinity_index = 1;
+            ASSERT_EQ(opened_windows.load(), 3);
+            ASSERT_EQ(run_kernel_execution(), 0);
+            affinity_index = 0;
+            ASSERT_EQ(run_kernel_execution(), 0);
+            EXPECT_EQ(kernel_execution_status(), 0);
+            auto *header = static_cast<SharedMemoryHeader *>(binding.sm.base);
+            header->sched_error_code.store(SIMPLER_ERROR_INVALID_ARGS);
+            EXPECT_EQ(kernel_execution_status(), -SIMPLER_ERROR_INVALID_ARGS);
+            header->sched_error_code.store(SIMPLER_ERROR_NONE);
+            EXPECT_EQ(output[0], static_cast<uint64_t>(id));
+            EXPECT_EQ(output[1], invocation);
+            EXPECT_EQ(output[3], static_cast<uint64_t>(id));
+            EXPECT_EQ(output[4], invocation);
+            EXPECT_NE(output[2], 0u);
+            EXPECT_EQ(output[2], output[5]);
+            if (storage_address != 0) EXPECT_EQ(output[2], storage_address);
+            storage_address = output[2];
+            expect_resident_configuration(serial);
+            release_kernel_execution();
+            expect_resident_configuration(serial);
+            EXPECT_EQ(kernel_execution_status(), -1);
+            EXPECT_EQ(init_kernel_execution(), -1);
+            EXPECT_EQ(run_kernel_execution(), -1);
+        }
+    }
+}
+
+TEST_F(TmrExecutorExecutionInputsTest, FailedInitializationCanReleaseAndReuseExecutor) {
+    for (bool serial : {false, true}) {
+        SCOPED_TRACE(serial);
+        resident->dev.serial_orch_sched = serial;
+        resident->dev.aicpu_thread_num = -1;
+        PreparedInvocationView callable{3, 1, 1, 17};
+        TmrEncodingCandidate packet;
+        TmrEncodingCache cache;
+        auto args = arguments(9);
+        ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+        ASSERT_EQ(admit_kernel_execution(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+        opened_windows = 0;
+        const auto initialized = initialize_group();
+        EXPECT_EQ(initialized[0], -1);
+        EXPECT_EQ(initialized[1], -1);
+        EXPECT_EQ(opened_windows.load(), 0);
+        release_kernel_execution();
+        resident->dev.aicpu_thread_num = 2;
+        ASSERT_NO_FATAL_FAILURE(expect_successful_reuse());
+    }
+}
+
+TEST_F(TmrExecutorExecutionInputsTest, FailedConfigurationCanReleaseAndReuseExecutor) {
+    register_orchestration(5, "orchestration_a", "config_mismatch");
+    for (bool serial : {false, true}) {
+        SCOPED_TRACE(serial);
+        resident->dev.serial_orch_sched = serial;
+        output.fill(0);
+        PreparedInvocationView callable{5, 1, 1, 17};
+        TmrEncodingCandidate packet;
+        TmrEncodingCache cache;
+        auto args = arguments(9);
+        ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+        ASSERT_EQ(admit_kernel_execution(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+        report_ready_cores();
+        const auto initialized = initialize_group();
+        ASSERT_EQ(initialized[0], 0);
+        ASSERT_EQ(initialized[1], 0);
+        std::array<int, 2> results{};
+        std::thread scheduler([&] {
+            affinity_index = 0;
+            results[0] = run_kernel_execution();
+        });
+        std::thread orchestrator([&] {
+            affinity_index = 1;
+            results[1] = run_kernel_execution();
+        });
+        scheduler.join();
+        orchestrator.join();
+        EXPECT_EQ(results[0], 0);
+        EXPECT_EQ(results[1], -1);
+        EXPECT_EQ(output[0], 5u);
+        EXPECT_EQ(output[1], 9u);
+        EXPECT_NE(output[2], 0u);
+        EXPECT_EQ(output[3], 0u);
+        EXPECT_EQ(output[4], 0u);
+        EXPECT_EQ(output[5], 0u);
+        expect_resident_configuration(serial);
+        release_kernel_execution();
+        ASSERT_NO_FATAL_FAILURE(expect_successful_reuse());
+    }
+}
+
+TEST_F(TmrExecutorExecutionInputsTest, RejectedAdmissionLeavesActualExecutorInactive) {
+    PreparedInvocationView callable{3, 1, 1, 17};
+    TmrEncodingCandidate packet;
+    TmrEncodingCache cache;
+    auto args = arguments(9);
+    ASSERT_EQ(encode_tmr_invocation(args, callable, binding.identity, cache, &packet), InvocationStatus::Ok);
+    auto invalid_binding = binding;
+    invalid_binding.arena.capacity = 0;
+    EXPECT_EQ(
+        admit_kernel_execution(packet.packet(), {callable, {}}, invalid_binding), InvocationStatus::InvalidBinding
+    );
+    EXPECT_EQ(init_kernel_execution(), -1);
+    EXPECT_EQ(run_kernel_execution(), -1);
+    EXPECT_EQ(kernel_execution_status(), -1);
+    auto stale = callable;
+    ++stale.slot_generation;
+    EXPECT_EQ(admit_kernel_execution(packet.packet(), {stale, {}}, binding), InvocationStatus::StaleCallable);
+    EXPECT_EQ(init_kernel_execution(), -1);
+    EXPECT_EQ(run_kernel_execution(), -1);
+    EXPECT_EQ(kernel_execution_status(), -1);
+    ASSERT_EQ(admit_kernel_execution(packet.packet(), {callable, {}}, binding), InvocationStatus::Ok);
+    EXPECT_EQ(kernel_execution_status(), 0);
+    release_kernel_execution();
+    EXPECT_EQ(kernel_execution_status(), -1);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
+++ b/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
@@ -92,6 +92,49 @@ TEST(TmrKernelInvocation, CacheHitStillUsesCurrentAddressesAndScalars) {
     EXPECT_EQ(cache.bytes(), first.packet().size);
 }
 
+TEST(TmrKernelInvocation, ConsumptionRejectsBeforeChangingCallerStorage) {
+    auto args = make_args();
+    TmrEncodingCache cache;
+    TmrEncodingCandidate packet;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &packet), InvocationStatus::Ok);
+    EntryArgsStorage storage{};
+    storage.scalar_count_ = 1;
+    storage.scalars_[0] = 1234;
+    auto stale = kCallable;
+    ++stale.slot_generation;
+    EXPECT_EQ(consume_tmr_invocation(packet.packet(), stale, kBinding, &storage), InvocationStatus::StaleCallable);
+    EXPECT_EQ(storage.scalar_count(), 1);
+    EXPECT_EQ(storage.scalar(0), 1234u);
+    auto wrong_binding = kBinding;
+    ++wrong_binding.context_generation;
+    EXPECT_EQ(
+        consume_tmr_invocation(packet.packet(), kCallable, wrong_binding, &storage), InvocationStatus::InvalidBinding
+    );
+    EXPECT_EQ(storage.scalar(0), 1234u);
+    EXPECT_EQ(
+        consume_tmr_invocation({packet.packet().data, packet.packet().size - 1}, kCallable, kBinding, &storage),
+        InvocationStatus::InvalidSize
+    );
+    EXPECT_EQ(storage.scalar(0), 1234u);
+    ASSERT_EQ(consume_tmr_invocation(packet.packet(), kCallable, kBinding, &storage), InvocationStatus::Ok);
+    EXPECT_EQ(storage.tensor_count(), 1);
+    EXPECT_EQ(storage.scalar(0), 19u);
+}
+
+TEST(TmrKernelInvocation, RetainedCacheIsBoundedAcrossRepeatedInvocations) {
+    TmrEncodingCache cache;
+    size_t expected_bytes = 0;
+    ASSERT_EQ(tmr_invocation_size(kCallable, &expected_bytes), InvocationStatus::Ok);
+    for (uint64_t i = 0; i < 10000; ++i) {
+        auto args = make_args(0x20000 + i * 64, i);
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+        EXPECT_EQ(candidate.structural_hit(), i != 0);
+        cache.commit(std::move(candidate));
+        EXPECT_EQ(cache.bytes(), expected_bytes);
+    }
+}
+
 TEST(TmrKernelInvocation, FailedCandidateAndUnsubmittedCandidatePreserveCache) {
     TmrEncodingCache cache;
     auto args = make_args();

--- a/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
+++ b/tests/ut/cpp/common/test_tmr_kernel_invocation.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "tensormap_and_ringbuffer/kernel_invocation_args.h"
+#include "worker/tmr_kernel_invocation.h"
+
+namespace {
+using namespace simpler::tmr;
+
+const PreparedInvocationView kCallable{3, 1, 1, 4};
+const TmrExecutionBindingView kBinding{0x10000, 8};
+
+ChipStorageTaskArgs make_args(uint64_t address = 0x20000, uint64_t scalar = 19) {
+    ChipStorageTaskArgs args{};
+    const uint32_t shape[] = {2, 4};
+    args.add_tensor(
+        make_tensor_external(reinterpret_cast<void *>(address), shape, 2, DataType::FLOAT32, AddressSpace::DEVICE)
+    );
+    args.add_scalar(scalar);
+    return args;
+}
+
+TEST(TmrKernelInvocation, RoundtripAndBorrowedConversion) {
+    auto args = make_args();
+    TmrEncodingCache cache;
+    TmrEncodingCandidate candidate;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    EXPECT_EQ(
+        candidate.packet().size,
+        sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef) + sizeof(ChipTensor) + sizeof(uint64_t)
+    );
+    EXPECT_FALSE(candidate.structural_hit());
+    TmrInvocationView view;
+    ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    EntryArgsStorage storage{};
+    ASSERT_EQ(materialize_tmr_entry_args(view, &storage), InvocationStatus::Ok);
+    EXPECT_EQ(storage.tensor_count(), 1);
+    EXPECT_EQ(storage.scalar(0), 19u);
+    EXPECT_EQ(storage.tensor(0).buffer.addr, 0x20000u);
+    EXPECT_EQ(storage.tensor(0).numel(), 8u);
+    EXPECT_EQ(storage.tensor(0).version, 0);
+    EXPECT_FALSE(storage.tensor(0).manual_dep);
+    ChipTensor tensor{};
+    EXPECT_FALSE(view.tensor(-1, &tensor));
+    EXPECT_FALSE(view.tensor(1, &tensor));
+    EXPECT_FALSE(view.tensor(0, nullptr));
+}
+
+TEST(TmrKernelInvocation, CacheHitStillUsesCurrentAddressesAndScalars) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    TmrEncodingCandidate first;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &first), InvocationStatus::Ok);
+    cache.commit(std::move(first));
+    TmrEncodingCandidate equal;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &equal), InvocationStatus::Ok);
+    EXPECT_TRUE(equal.structural_hit());
+    EXPECT_TRUE(first.same_invocation(equal));
+    auto changed = make_args(0x30000, 77);
+    TmrEncodingCandidate next;
+    ASSERT_EQ(encode_tmr_invocation(changed, kCallable, kBinding, cache, &next), InvocationStatus::Ok);
+    EXPECT_TRUE(next.structural_hit());
+    EXPECT_FALSE(first.same_invocation(next));
+    TmrInvocationView view;
+    ASSERT_EQ(decode_tmr_invocation(next.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    ChipTensor tensor{};
+    uint64_t scalar{};
+    ASSERT_TRUE(view.tensor(0, &tensor));
+    ASSERT_TRUE(view.scalar(0, &scalar));
+    EXPECT_EQ(tensor.buffer.addr, 0x30000u);
+    EXPECT_EQ(scalar, 77u);
+    ASSERT_EQ(decode_tmr_invocation(first.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    ASSERT_TRUE(view.scalar(0, &scalar));
+    EXPECT_EQ(scalar, 19u);
+    EXPECT_EQ(cache.bytes(), first.packet().size);
+}
+
+TEST(TmrKernelInvocation, FailedCandidateAndUnsubmittedCandidatePreserveCache) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    TmrEncodingCandidate candidate;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    cache.commit(std::move(candidate));
+    const auto saved = std::vector<uint8_t>(candidate.packet().data, candidate.packet().data + candidate.packet().size);
+    auto bad = args;
+    bad.tensor(0).buffer.addr = 0;
+    EXPECT_EQ(encode_tmr_invocation(bad, kCallable, kBinding, cache, &candidate), InvocationStatus::InvalidTensor);
+    EXPECT_EQ(std::memcmp(candidate.packet().data, saved.data(), saved.size()), 0);
+    {
+        TmrEncodingCandidate unsubmitted;
+        auto other = args;
+        other.tensor(0).shapes[0] = 1;
+        ASSERT_EQ(encode_tmr_invocation(other, kCallable, kBinding, cache, &unsubmitted), InvocationStatus::Ok);
+        EXPECT_FALSE(unsubmitted.structural_hit());
+    }
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    EXPECT_TRUE(candidate.structural_hit());
+}
+
+TEST(TmrKernelInvocation, CanonicalFieldsIgnoreUnusedDimensionsAndPadding) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    TmrEncodingCandidate first, second;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &first), InvocationStatus::Ok);
+    cache.commit(std::move(first));
+    ChipTensor noisy;
+    std::memset(&noisy, 0xa5, sizeof(noisy));
+    noisy.buffer = args.tensor(0).buffer;
+    noisy.start_offset = 0;
+    noisy.ndims = 2;
+    noisy.dtype = DataType::FLOAT32;
+    noisy.address_space = AddressSpace::DEVICE;
+    for (int i = 0; i < 2; ++i) {
+        noisy.shapes[i] = args.tensor(0).shapes[i];
+        noisy.strides[i] = args.tensor(0).strides[i];
+    }
+    args.tensor(0) = noisy;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &second), InvocationStatus::Ok);
+    EXPECT_TRUE(second.structural_hit());
+    EXPECT_TRUE(first.same_invocation(second));
+}
+
+TEST(TmrKernelInvocation, GeometryBackingAndGenerationsInvalidateTemplate) {
+    TmrEncodingCache cache;
+    auto args = make_args();
+    args.tensor(0).buffer.size = 128;
+    TmrEncodingCandidate first;
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &first), InvocationStatus::Ok);
+    cache.commit(std::move(first));
+    for (int change = 0; change < 7; ++change) {
+        auto current = args;
+        auto callable = kCallable;
+        auto binding = kBinding;
+        if (change == 0) current.tensor(0).shapes[0] = 1;
+        if (change == 1) current.tensor(0).strides[0] = 8;
+        if (change == 2) current.tensor(0).start_offset = 1;
+        if (change == 3) current.tensor(0).buffer.size = 132;
+        if (change == 4) ++callable.slot_generation;
+        if (change == 5) ++binding.context_generation;
+        if (change == 6) current.tensor(0).dtype = DataType::FLOAT16;
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(current, callable, binding, cache, &candidate), InvocationStatus::Ok);
+        EXPECT_FALSE(candidate.structural_hit());
+    }
+}
+
+TEST(TmrKernelInvocation, DecoderRejectsCorruptionTruncationAndPreservesView) {
+    TmrEncodingCache cache;
+    TmrEncodingCandidate candidate;
+    auto args = make_args();
+    ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    TmrInvocationView good;
+    ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &good), InvocationStatus::Ok);
+    std::vector<uint8_t> unaligned(candidate.packet().size + 1);
+    std::memcpy(unaligned.data() + 1, candidate.packet().data, candidate.packet().size);
+    TmrInvocationView view;
+    ASSERT_EQ(
+        decode_tmr_invocation({unaligned.data() + 1, candidate.packet().size}, kCallable, kBinding, &view),
+        InvocationStatus::Ok
+    );
+    for (size_t length = 0; length < candidate.packet().size; ++length) {
+        EXPECT_NE(
+            decode_tmr_invocation({candidate.packet().data, length}, kCallable, kBinding, &good), InvocationStatus::Ok
+        );
+        EXPECT_TRUE(good.valid());
+    }
+    auto stale = kCallable;
+    ++stale.slot_generation;
+    EXPECT_EQ(validate_tmr_submission(candidate, stale, kBinding), InvocationStatus::StaleCallable);
+    auto other_binding = kBinding;
+    ++other_binding.context_generation;
+    EXPECT_EQ(validate_tmr_submission(candidate, kCallable, other_binding), InvocationStatus::InvalidBinding);
+    other_binding = kBinding;
+    other_binding.device_binding_addr += 64;
+    EXPECT_EQ(validate_tmr_submission(candidate, kCallable, other_binding), InvocationStatus::InvalidBinding);
+    other_binding.device_binding_addr = 0;
+    EXPECT_EQ(validate_tmr_submission(candidate, kCallable, other_binding), InvocationStatus::InvalidBinding);
+    const size_t tensor_offset = sizeof(SimplerKernelInvocationHeader) + sizeof(TmrBindingRef);
+    const uint64_t bad_packet_scalar = 77;
+    std::memcpy(
+        unaligned.data() + 1 + tensor_offset + sizeof(ChipTensor), &bad_packet_scalar, sizeof(bad_packet_scalar)
+    );
+    uint8_t bad_dtype = 255;
+    std::memcpy(unaligned.data() + 1 + tensor_offset + offsetof(ChipTensor, dtype), &bad_dtype, sizeof(bad_dtype));
+    EXPECT_EQ(
+        decode_tmr_invocation({unaligned.data() + 1, candidate.packet().size}, kCallable, kBinding, &good),
+        InvocationStatus::InvalidTensor
+    );
+    uint64_t scalar{};
+    ASSERT_TRUE(good.scalar(0, &scalar));
+    EXPECT_EQ(scalar, 19u);
+}
+
+TEST(TmrKernelInvocation, SelfConsistentEnvelopeStillRequiresExactTmrSize) {
+    TmrEncodingCache cache;
+    TmrEncodingCandidate candidate;
+    ASSERT_EQ(encode_tmr_invocation(make_args(), kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+    TmrInvocationView view;
+    ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+    for (const size_t length : {candidate.packet().size - 1, candidate.packet().size + 1}) {
+        std::vector<uint8_t> packet(candidate.packet().data, candidate.packet().data + candidate.packet().size);
+        packet.resize(length);
+        SimplerKernelInvocationHeader header{};
+        std::memcpy(&header, packet.data(), sizeof(header));
+        header.payload_bytes = length - sizeof(header);
+        std::memcpy(packet.data(), &header, sizeof(header));
+        SimplerKernelInvocationHeader checked{};
+        ASSERT_EQ(
+            simpler::kernel::validate_invocation_header({packet.data(), packet.size()}, kCallable, &checked),
+            InvocationStatus::Ok
+        );
+        EXPECT_EQ(
+            decode_tmr_invocation({packet.data(), packet.size()}, kCallable, kBinding, &view),
+            InvocationStatus::InvalidSize
+        );
+        uint64_t scalar{};
+        ASSERT_TRUE(view.scalar(0, &scalar));
+        EXPECT_EQ(scalar, 19u);
+    }
+}
+
+TEST(TmrKernelInvocation, InvalidTensorArithmeticAndHostBackingAreRejected) {
+    auto args = make_args();
+    for (int change = 0; change < 8; ++change) {
+        auto t = args.tensor(0);
+        if (change == 0) t.address_space = AddressSpace::HOST;
+        if (change == 1) t.ndims = 0;
+        if (change == 2) t.ndims = MAX_TENSOR_DIMS + 1;
+        if (change == 3) t.strides[0] = 0;
+        if (change == 4) t.buffer.size = 31;
+        if (change == 5) t.start_offset = std::numeric_limits<uint64_t>::max();
+        if (change == 6) t.buffer.addr = std::numeric_limits<uint64_t>::max();
+        if (change == 7) {
+            t.ndims = 5;
+            for (int i = 0; i < 5; ++i)
+                t.shapes[i] = t.strides[i] = std::numeric_limits<uint32_t>::max();
+        }
+        ChipTensor out = args.tensor(0);
+        EXPECT_EQ(normalize_invocation_tensor(t, &out), InvocationStatus::InvalidTensor);
+        EXPECT_EQ(out.buffer.addr, args.tensor(0).buffer.addr);
+    }
+}
+
+TEST(TmrKernelInvocation, EmptyTensorMatchesBoundaryConversionWithoutBacking) {
+    const uint32_t shapes[][3] = {{0, 1, 1}, {0, 8, 1}, {8, 0, 1}, {2, 0, 3}};
+    const uint32_t ranks[] = {1, 2, 2, 3};
+    TmrEncodingCache cache;
+    for (int i = 0; i < 4; ++i) {
+        auto args = make_args();
+        args.tensor(0) = make_tensor_external(nullptr, shapes[i], ranks[i], DataType::FLOAT32, AddressSpace::DEVICE);
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+        TmrInvocationView view;
+        ASSERT_EQ(decode_tmr_invocation(candidate.packet(), kCallable, kBinding, &view), InvocationStatus::Ok);
+        EntryArgsStorage storage{};
+        ASSERT_EQ(materialize_tmr_entry_args(view, &storage), InvocationStatus::Ok);
+        EXPECT_EQ(storage.tensor(0).numel(), 0u);
+        EXPECT_EQ(storage.tensor(0).extent_elem(), Tensor::from_boundary(args.tensor(0)).extent_elem());
+    }
+    auto args = make_args();
+    auto parent = Tensor::from_boundary(args.tensor(0));
+    const uint32_t empty_shape[] = {0, 4}, beyond[] = {100, 0};
+    args.tensor(0) = parent.view(empty_shape, beyond).to_boundary();
+    TmrEncodingCandidate candidate;
+    EXPECT_EQ(encode_tmr_invocation(args, kCallable, kBinding, cache, &candidate), InvocationStatus::Ok);
+}
+
+TEST(TmrKernelInvocation, MinimumMaximumAndScalarOnlyPackets) {
+    TmrEncodingCache cache;
+    const PreparedInvocationView cases[] = {{0, 0, 0, 1}, {0, 256, 0, 1}, {0, 0, 128, 1}, {0, 128, 128, 1}};
+    for (const auto &callable : cases) {
+        ChipStorageTaskArgs args{};
+        auto sample = make_args();
+        for (int i = 0; i < callable.tensor_count; ++i)
+            args.add_tensor(sample.tensor(0));
+        for (int i = 0; i < callable.scalar_count; ++i)
+            args.add_scalar(static_cast<uint64_t>(i));
+        TmrEncodingCandidate candidate;
+        ASSERT_EQ(encode_tmr_invocation(args, callable, kBinding, cache, &candidate), InvocationStatus::Ok);
+        EXPECT_EQ(validate_tmr_submission(candidate, callable, kBinding), InvocationStatus::Ok);
+    }
+}
+
+TEST(TmrKernelInvocation, IndependentCallsAndOwnerSerializedSharedCache) {
+    TmrEncodingCache shared;
+    std::mutex owner;
+    std::atomic<int> failures{0};
+    std::vector<std::thread> threads;
+    for (int worker = 0; worker < 4; ++worker) {
+        threads.emplace_back([&, worker] {
+            TmrEncodingCache local;
+            for (int iteration = 0; iteration < 100; ++iteration) {
+                auto args = make_args(0x20000 + worker * 0x1000, iteration);
+                TmrEncodingCandidate independent;
+                if (encode_tmr_invocation(args, kCallable, kBinding, local, &independent) != InvocationStatus::Ok)
+                    ++failures;
+                local.commit(std::move(independent));
+                std::lock_guard<std::mutex> guard(owner);
+                TmrEncodingCandidate candidate;
+                if (encode_tmr_invocation(args, kCallable, kBinding, shared, &candidate) != InvocationStatus::Ok ||
+                    !candidate.same_invocation(independent))
+                    ++failures;
+                shared.commit(std::move(candidate));
+            }
+        });
+    }
+    for (auto &thread : threads)
+        thread.join();
+    EXPECT_EQ(failures, 0);
+}
+}  // namespace

--- a/tests/ut/cpp/common/test_tmr_scheduler_execution_inputs.cpp
+++ b/tests/ut/cpp/common/test_tmr_scheduler_execution_inputs.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "callable.h"
+#include "runtime.h"
+#include "scheduler/scheduler.h"
+
+#define private public
+#include "scheduler/scheduler_context.h"
+#undef private
+
+namespace {
+int register_writes = 0;
+volatile uint32_t *last_register = nullptr;
+uint32_t last_token = 0;
+void callable_a() {}
+void callable_b() {}
+}  // namespace
+
+// Only platform register I/O is replaced; every scheduler consumer is linked
+// from its production translation unit.
+uint64_t read_reg(uint64_t, RegId) { return 0; }
+uint32_t reg_load_acquire(const volatile uint32_t *p) { return *p; }
+void reg_store_release(volatile uint32_t *p, uint32_t value) {
+    ++register_writes;
+    last_register = p;
+    last_token = value;
+}
+extern "C" uint64_t get_platform_regs() { return 0; }
+extern "C" uint64_t get_platform_pmu_reg_addrs() { return 0; }
+int platform_aicpu_affinity_thread_idx() { return 0; }
+void platform_init_aicore_regs(uint64_t) {}
+uint64_t platform_aicore_exit_deadline() { return 0; }
+uint32_t platform_get_physical_cores_count() { return PLATFORM_MAX_CORES; }
+
+extern void reset_test_reg_stub();
+extern uint64_t get_test_reg_stub_value();
+
+namespace {
+
+class TmrSchedulerExecutionInputsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        sm_handle = SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        auto layout = SchedulerState::reserve_layout(sched_arena);
+        ASSERT_NE(sched_arena.commit(), nullptr);
+        ASSERT_TRUE(sched.init_data_from_layout(layout, sched_arena, sm_handle->header));
+        sched.wire_arena_pointers(layout, sched_arena);
+        context->sched_ = &sched;
+        resident->dev.worker_count = 3;
+        const uint8_t binary[] = {1, 2, 3, 4};
+        a = make_callable<CORE_MAX_TENSOR_ARGS>(nullptr, 0, binary, sizeof(binary));
+        b = make_callable<CORE_MAX_TENSOR_ARGS>(nullptr, 0, binary, sizeof(binary));
+        reinterpret_cast<CoreCallable *>(a.data())->set_resolved_addr(reinterpret_cast<uint64_t>(&callable_a));
+        reinterpret_cast<CoreCallable *>(b.data())->set_resolved_addr(reinterpret_cast<uint64_t>(&callable_b));
+        table_a[0] = reinterpret_cast<uint64_t>(a.data());
+        table_b[0] = reinterpret_cast<uint64_t>(b.data());
+        init_slot();
+    }
+
+    void TearDown() override {
+        sched.destroy();
+        sched_arena.release();
+        sm_arena.release();
+    }
+
+    void init_slot() {
+        std::memset(&slot, 0, sizeof(slot));
+        std::memset(&task, 0, sizeof(task));
+        std::memset(&payload, 0, sizeof(payload));
+        slot.task = &task;
+        slot.payload = &payload;
+        slot.task_state.store(CHIP_TASK_PENDING);
+        slot.active_mask = ActiveMask(SUBTASK_MASK_AIC);
+        slot.logical_block_num = 1;
+        slot.total_required_subtasks = 1;
+        payload.scalar_count = 1;
+        payload.scalars[0] = 73;
+        register_writes = 0;
+        last_register = nullptr;
+        last_token = 0;
+        reset_test_reg_stub();
+    }
+
+    void initialize(simpler::tmr::CallableTableView table) {
+        ASSERT_EQ(context->pre_handshake_init(resident.get(), 1, 1, 0, table, sm_handle->header), 0);
+        EXPECT_EQ(context->get_function_bin_addr(0), table.lookup(0));
+        // Hardware discovery writes this classification before the serial
+        // post-handshake initializer; the test does not run a hardware handshake.
+        context->core_type_compact_[0] = static_cast<uint8_t>(CoreType::AIC);
+        context->core_type_compact_[1] = static_cast<uint8_t>(CoreType::AIV);
+        context->core_type_compact_[2] = static_cast<uint8_t>(CoreType::AIV);
+        ASSERT_EQ(context->post_handshake_init(resident.get(), table), 0);
+        EXPECT_EQ(context->get_function_bin_addr(0), table.lookup(0));
+        context->core_exec_states_[0].reg_addr = reinterpret_cast<uint64_t>(registers.data());
+    }
+
+    void expect_unpublished() {
+        EXPECT_EQ(register_writes, 0);
+        EXPECT_EQ(get_test_reg_stub_value(), 0u);
+        EXPECT_EQ(sched.sm_header->sched_error_code.load(), SIMPLER_ERROR_INVALID_ARGS);
+        EXPECT_EQ(context->core_exec_states_[0].running_slot_state, nullptr);
+        EXPECT_EQ(context->core_exec_states_[0].pending_slot_state, nullptr);
+        EXPECT_TRUE(context->core_trackers_[0].is_aic_core_idle(0));
+        for (int w = 0; w < EARLY_DISPATCH_CORE_MASK_WORDS; ++w) {
+            EXPECT_EQ(payload.staged_core_mask[w].load(), 0u);
+        }
+        EXPECT_EQ(sched.early_dispatch_doorbell_table[0].addr, 0u);
+        EXPECT_EQ(sched.early_dispatch_doorbell_table[0].token, 0u);
+    }
+
+    std::unique_ptr<Runtime> resident{std::make_unique<Runtime>()};
+    std::unique_ptr<SchedulerContext> context{std::make_unique<SchedulerContext>()};
+    SchedulerState sched;
+    SharedMemoryHandle *sm_handle{nullptr};
+    DeviceArena sm_arena;
+    DeviceArena sched_arena;
+    ChipTaskSlotState slot{};
+    TaskDescriptor task{};
+    TaskPayload payload{};
+    std::array<uint32_t, 1024> registers{};
+    std::vector<uint8_t> a;
+    std::vector<uint8_t> b;
+    std::array<uint64_t, 1> table_a{};
+    std::array<uint64_t, 1> table_b{};
+};
+
+TEST_F(TmrSchedulerExecutionInputsTest, ExplicitTableSurvivesHandshakeAndOrdinaryPublicationAcrossABA) {
+    for (const auto *table : {&table_a, &table_b, &table_a}) {
+        init_slot();
+        initialize({table->data(), table->size()});
+        const auto handle = context->prepare_subtask_to_core(0, 0, slot, SubtaskSlot::AIC, false, 0, false);
+        ASSERT_TRUE(handle.valid);
+        const auto &dispatch = context->payload_per_core_[0][handle.reg_task_id & 1u];
+        EXPECT_EQ(
+            dispatch.function_bin_addr,
+            table == &table_a ? reinterpret_cast<uint64_t>(&callable_a) : reinterpret_cast<uint64_t>(&callable_b)
+        );
+        EXPECT_EQ(dispatch.src_payload, 0u);
+        EXPECT_EQ(dispatch.args[0], 73u);
+        context->publish_subtask_to_core(handle, 0, 0);
+        EXPECT_EQ(register_writes, 1);
+        EXPECT_EQ(last_token, handle.reg_task_id);
+        EXPECT_EQ(
+            last_register, reinterpret_cast<volatile uint32_t *>(handle.reg_addr + reg_offset(RegId::DATA_MAIN_BASE))
+        );
+        EXPECT_EQ(resident->dev.func_id_to_addr_[0], 0u);
+    }
+}
+
+TEST_F(TmrSchedulerExecutionInputsTest, ExplicitTableBuildsEarlyPayloadAcrossABA) {
+    for (const auto *table : {&table_a, &table_b, &table_a}) {
+        init_slot();
+        initialize({table->data(), table->size()});
+        payload.early_dispatch_state.store(EARLY_DISPATCH_STAGING);
+        auto idle = CoreTracker::BitStates::bit(0);
+        CoreTracker::BitStates pending;
+        ASSERT_EQ(context->stage_consumer_blocks(0, &slot, ResourceShape::AIC, 0, 1, idle, pending), 1);
+        const auto &core = context->core_exec_states_[0];
+        const auto &dispatch = context->payload_per_core_[0][core.running_reg_task_id & 1u];
+        EXPECT_EQ(
+            dispatch.function_bin_addr,
+            table == &table_a ? reinterpret_cast<uint64_t>(&callable_a) : reinterpret_cast<uint64_t>(&callable_b)
+        );
+        EXPECT_EQ(dispatch.src_payload, reinterpret_cast<uint64_t>(&payload));
+        EXPECT_EQ(register_writes, 1);
+        EXPECT_EQ(payload.staged_core_mask[0].load(), 1u);
+        EXPECT_EQ(sched.early_dispatch_doorbell_table[0].addr, core.reg_addr);
+        EXPECT_EQ(resident->dev.func_id_to_addr_[0], 0u);
+    }
+}
+
+TEST_F(TmrSchedulerExecutionInputsTest, InvalidMappingDoesNotPublishOrdinaryOrReleasedEarlyWork) {
+    const std::array<uint64_t, 1> null_entry{0};
+    const std::array<uint64_t, 1> misaligned_entry{table_a[0] + 1};
+    reinterpret_cast<CoreCallable *>(b.data())->set_resolved_addr(0);
+    struct InvalidMapping {
+        simpler::tmr::CallableTableView table;
+        int32_t func_id;
+    };
+    const InvalidMapping invalid[] = {
+        {{}, 0},
+        {{table_a.data(), table_a.size()}, -1},
+        {{table_a.data(), table_a.size()}, 1},
+        {{null_entry.data(), null_entry.size()}, 0},
+        {{misaligned_entry.data(), misaligned_entry.size()}, 0},
+        {{table_b.data(), table_b.size()}, 0},
+    };
+    for (const auto &mapping : invalid) {
+        for (bool early : {false, true}) {
+            init_slot();
+            sched.sm_header->sched_error_code.store(SIMPLER_ERROR_NONE);
+            initialize(mapping.table);
+            task.kernel_id[0] = mapping.func_id;
+            if (early) {
+                payload.early_dispatch_state.store(EARLY_DISPATCH_DISPATCHED);
+                auto idle = CoreTracker::BitStates::bit(0);
+                CoreTracker::BitStates pending;
+                context->stage_consumer_blocks(0, &slot, ResourceShape::AIC, 0, 1, idle, pending);
+            } else {
+                auto handle = context->prepare_subtask_to_core(0, 0, slot, SubtaskSlot::AIC, false, 0, false);
+                EXPECT_FALSE(handle.valid);
+                context->publish_subtask_to_core(handle, 0, 0);
+            }
+            expect_unpublished();
+        }
+    }
+}
+
+TEST_F(TmrSchedulerExecutionInputsTest, InvalidMappingDoesNotPublishGatedSyncStartCompletionPath) {
+    initialize({});
+    payload.early_dispatch_state.store(EARLY_DISPATCH_STAGING);
+    const auto result = context->stage_sync_start_cores(&slot, 1, 0, true, false);
+    EXPECT_EQ(result.staged_blocks, 1);
+    expect_unpublished();
+}
+
+TEST_F(TmrSchedulerExecutionInputsTest, ExplicitTableBuildsGatedSyncStartPayloadAcrossABA) {
+    for (const auto *table : {&table_a, &table_b, &table_a}) {
+        init_slot();
+        initialize({table->data(), table->size()});
+        payload.early_dispatch_state.store(EARLY_DISPATCH_STAGING);
+        const auto result = context->stage_sync_start_cores(&slot, 1, 0, true, false);
+        ASSERT_EQ(result.staged_blocks, 1);
+        const auto &core = context->core_exec_states_[0];
+        const auto &dispatch = context->payload_per_core_[0][core.running_reg_task_id & 1u];
+        EXPECT_EQ(
+            dispatch.function_bin_addr,
+            table == &table_a ? reinterpret_cast<uint64_t>(&callable_a) : reinterpret_cast<uint64_t>(&callable_b)
+        );
+        EXPECT_EQ(dispatch.src_payload, reinterpret_cast<uint64_t>(&payload));
+        EXPECT_EQ(register_writes, 1);
+        EXPECT_EQ(payload.staged_core_mask[0].load(), 1u);
+        EXPECT_EQ(sched.early_dispatch_doorbell_table[0].addr, core.reg_addr);
+        EXPECT_EQ(resident->dev.func_id_to_addr_[0], 0u);
+    }
+}
+
+TEST_F(TmrSchedulerExecutionInputsTest, ProgramHandshakeWrappersConsumeResidentTable) {
+    resident->dev.func_id_to_addr_[0] = table_b[0];
+    resident->set_gm_sm_ptr(sm_handle->header);
+    ASSERT_EQ(context->pre_handshake_init(resident.get(), 1, 1, 0), 0);
+    EXPECT_EQ(context->get_function_bin_addr(0), table_b[0]);
+    context->core_type_compact_[0] = static_cast<uint8_t>(CoreType::AIC);
+    context->core_type_compact_[1] = static_cast<uint8_t>(CoreType::AIV);
+    context->core_type_compact_[2] = static_cast<uint8_t>(CoreType::AIV);
+    ASSERT_EQ(context->post_handshake_init(resident.get()), 0);
+    DispatchPayload dispatch{};
+    ASSERT_TRUE(context->build_payload(dispatch, slot, SubtaskSlot::AIC, 0, false));
+    EXPECT_EQ(dispatch.function_bin_addr, reinterpret_cast<uint64_t>(&callable_b));
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -18,23 +18,29 @@
 // fake only remembers the slot and records malloc/copy counts.
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <thread>
 #include <unordered_set>
 #include <vector>
 
 #include <gtest/gtest.h>
 
 #include "arg_direction.h"
+#include "call_config.h"
 #include "common/host_api.h"
+#include "host/kernel_pipeline_contract.h"
 #include "runtime_status.h"
 #include "runtime_types.h"
 #include "shared_memory.h"
 #include "runtime.h"
 #include "task_args.h"
 #include "worker/runtime_c_api.h"
+#include "worker/pipeline_contract.h"
 
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
@@ -483,4 +489,168 @@ TEST_F(TrbRuntimeTempBufferTest, PreparedRuntimeEnvRequiresTheActiveArenaKey) {
     heap[2] = 2048;
     EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 0);
     EXPECT_NE(fake_.observed_key, fake_.compatibility_key);
+}
+
+namespace {
+
+CallConfig small_kernel_config() {
+    CallConfig config;
+    for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+        config.runtime_env.ring_task_window[i] = 4;
+        config.runtime_env.ring_heap[i] = 1024;
+        config.runtime_env.ring_dep_pool[i] = 4;
+    }
+    return config;
+}
+
+uint64_t required_bytes(const PipelineContract &contract, PipelineResourceKind kind) {
+    for (uint32_t i = 0; i < contract.resource_count; ++i) {
+        if (contract.resources[i].kind == kind) return contract.resources[i].bytes_per_copy;
+    }
+    ADD_FAILURE() << "Missing resource " << kind;
+    return 0;
+}
+
+void expect_same_contract(const PipelineContract &a, const PipelineContract &b) {
+    EXPECT_EQ(a.abi_version, b.abi_version);
+    EXPECT_EQ(a.pipeline_depth, b.pipeline_depth);
+    ASSERT_EQ(a.resource_count, b.resource_count);
+    for (uint32_t i = 0; i < a.resource_count; ++i) {
+        EXPECT_EQ(a.resources[i].kind, b.resources[i].kind);
+        EXPECT_EQ(a.resources[i].resource_class, b.resources[i].resource_class);
+        EXPECT_EQ(a.resources[i].bytes_per_copy, b.resources[i].bytes_per_copy);
+    }
+}
+
+}  // namespace
+
+TEST(KernelPipelineBuilder, DefaultAndPackedInputsPreserveProgramContract) {
+    const PipelineContract program_before = *get_pipeline_contract();
+    CallConfig defaults;
+    PipelineContract contract{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&defaults, &contract), 0);
+    EXPECT_TRUE(is_valid_tmr_kernel_pipeline_contract(&contract));
+    EXPECT_EQ(contract.pipeline_depth, 1u);
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_TASK_ARGS), 0u);
+
+    // CallConfig is packed and may start at any byte; use a genuinely unaligned input.
+    alignas(uint64_t) std::array<unsigned char, sizeof(CallConfig) + 1> packed{};
+    ASSERT_NE(
+        reinterpret_cast<uintptr_t>(packed.data() + 1 + offsetof(CallConfig, runtime_env)) % alignof(uint64_t), 0u
+    );
+    const CallConfig small = small_kernel_config();
+    std::memcpy(packed.data() + 1, &small, sizeof(small));
+    const auto before = packed;
+    PipelineContract expected{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&small, &expected), 0);
+    ASSERT_EQ(
+        build_kernel_pipeline_contract_impl(reinterpret_cast<const CallConfig *>(packed.data() + 1), &contract), 0
+    );
+    expect_same_contract(contract, expected);
+    EXPECT_EQ(packed, before);
+    expect_same_contract(*get_pipeline_contract(), program_before);
+    EXPECT_TRUE(is_valid_pipeline_contract(get_pipeline_contract()));
+    EXPECT_EQ(get_pipeline_contract()->pipeline_depth, 2u);
+}
+
+TEST(KernelPipelineBuilder, InvalidSizesLeaveOutputUntouched) {
+    PipelineContract output;
+    std::memset(&output, 0x5a, sizeof(output));
+    std::array<unsigned char, sizeof(output)> original{};
+    std::memcpy(original.data(), &output, sizeof(output));
+    auto reject = [&](const CallConfig *config) {
+        EXPECT_EQ(build_kernel_pipeline_contract_impl(config, &output), PTO_RUNTIME_ERR_INTERNAL);
+        EXPECT_EQ(std::memcmp(&output, original.data(), sizeof(output)), 0);
+    };
+    reject(nullptr);
+    auto config = small_kernel_config();
+    EXPECT_EQ(build_kernel_pipeline_contract_impl(&config, nullptr), PTO_RUNTIME_ERR_INTERNAL);
+    for (uint64_t bad : {uint64_t{1}, uint64_t{3}, uint64_t{6}, uint64_t{1} << 31}) {
+        config = small_kernel_config();
+        config.runtime_env.ring_task_window[0] = bad;
+        reject(&config);
+    }
+    config = small_kernel_config();
+    config.runtime_env.ring_task_window[0] = uint64_t{1} << 30;
+    config.runtime_env.ring_task_window[1] = uint64_t{1} << 30;
+    reject(&config);
+    config = small_kernel_config();
+    config.runtime_env.ring_heap[0] = 1023;
+    reject(&config);
+    config.runtime_env.ring_heap[0] = std::numeric_limits<uint64_t>::max();
+    reject(&config);
+    for (uint64_t bad : {uint64_t{3}, uint64_t{INT32_MAX} + 1}) {
+        config = small_kernel_config();
+        config.runtime_env.ring_dep_pool[0] = bad;
+        reject(&config);
+    }
+    // Sum fits uint64_t but adding DeviceArena base-alignment slack would overflow.
+    config = small_kernel_config();
+    config.runtime_env.ring_heap[0] = std::numeric_limits<uint64_t>::max() - 3 * 1024;
+    reject(&config);
+    // Last usable byte before that alignment limit is legal; reserve must not allocate it.
+    config.runtime_env.ring_heap[0] -= 1023;
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &output), 0);
+    EXPECT_EQ(required_bytes(output, PTO_PIPELINE_GM_HEAP), std::numeric_limits<uint64_t>::max() - 1023);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, KernelRequirementsMatchRealBindWithoutQuerySideEffects) {
+    auto config = small_kernel_config();
+    PipelineContract contract{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &contract), 0);
+    EXPECT_EQ(fake_.setup_static_arena_count, 0);
+    EXPECT_EQ(fake_.device_malloc_count, 0);
+    EXPECT_EQ(fake_.copy_to_count, 0);
+    Runtime runtime = make_runtime();
+    ChipStorageTaskArgs args;
+    ASSERT_EQ(bind_runtime(runtime, api_, args, nullptr, 0), 0);
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_GM_HEAP), fake_.gm_heap.size());
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_GM_SM), fake_.gm_sm.size());
+    EXPECT_EQ(required_bytes(contract, PTO_PIPELINE_RUNTIME_IMAGE), fake_.runtime_arena.size());
+    ASSERT_EQ(validate_runtime_impl(&runtime, &api_, 0), 0);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, LargestRingCountsOnlyReserveLayout) {
+    auto config = small_kernel_config();
+    PipelineContract small{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &small), 0);
+    config.runtime_env.ring_task_window[0] = uint64_t{1} << 30;
+    for (int r = 0; r < CHIP_MAX_RING_DEPTH; ++r) {
+        config.runtime_env.ring_dep_pool[r] = INT32_MAX;
+    }
+    PipelineContract large{};
+    ASSERT_EQ(build_kernel_pipeline_contract_impl(&config, &large), 0);
+    EXPECT_TRUE(is_valid_tmr_kernel_pipeline_contract(&large));
+    EXPECT_EQ(required_bytes(large, PTO_PIPELINE_GM_HEAP), required_bytes(small, PTO_PIPELINE_GM_HEAP));
+    EXPECT_GT(required_bytes(large, PTO_PIPELINE_GM_SM), required_bytes(small, PTO_PIPELINE_GM_SM));
+    EXPECT_GT(required_bytes(large, PTO_PIPELINE_RUNTIME_IMAGE), required_bytes(small, PTO_PIPELINE_RUNTIME_IMAGE));
+    EXPECT_EQ(fake_.setup_static_arena_count, 0);
+    EXPECT_EQ(fake_.device_malloc_count, 0);
+    EXPECT_EQ(fake_.copy_to_count, 0);
+}
+
+TEST(KernelPipelineBuilder, IndependentCallsCanInterleave) {
+    constexpr size_t count = 4;
+    std::array<CallConfig, count> configs;
+    std::array<PipelineContract, count> expected{};
+    std::array<std::thread, count> threads;
+    for (size_t i = 0; i < count; ++i) {
+        configs[i] = small_kernel_config();
+        configs[i].runtime_env.ring_task_window[0] = uint64_t{4} << i;
+        configs[i].runtime_env.ring_heap[0] = 1024 * (i + 1);
+        configs[i].runtime_env.ring_dep_pool[0] = 4 + i;
+        ASSERT_EQ(build_kernel_pipeline_contract_impl(&configs[i], &expected[i]), 0);
+    }
+    for (size_t i = 0; i < count; ++i) {
+        threads[i] = std::thread([&, i] {
+            const CallConfig config = configs[i];
+            for (int iteration = 0; iteration < 32; ++iteration) {
+                PipelineContract actual{};
+                EXPECT_EQ(build_kernel_pipeline_contract_impl(&config, &actual), 0);
+                expect_same_contract(actual, expected[i]);
+            }
+        });
+    }
+    for (auto &thread : threads)
+        thread.join();
 }

--- a/tests/ut/cpp/common/tmr_executor_orch_fixture.cpp
+++ b/tests/ut/cpp/common/tmr_executor_orch_fixture.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "orchestration_api.h"
+
+namespace {
+OrchestrationConfig configure(const ChipTaskArgs &args, uint64_t id) {
+    auto *output = reinterpret_cast<uint64_t *>(args.tensor(0).ref().buffer.addr);
+    output[0] = id;
+    output[1] = args.scalar(0);
+    output[2] = reinterpret_cast<uint64_t>(&args.tensor(0).ref());
+    return OrchestrationConfig{2};
+}
+
+void execute(const ChipTaskArgs &args, uint64_t id) {
+    auto *output = reinterpret_cast<uint64_t *>(args.tensor(0).ref().buffer.addr);
+    output[3] = id;
+    output[4] = args.scalar(0);
+    output[5] = reinterpret_cast<uint64_t>(&args.tensor(0).ref());
+    CoreTaskArgs empty;
+    rt_submit_dummy_task(empty);
+}
+}  // namespace
+
+extern "C" OrchestrationConfig config_a(const ChipTaskArgs &args) { return configure(args, 3); }
+extern "C" OrchestrationConfig config_b(const ChipTaskArgs &args) { return configure(args, 4); }
+extern "C" OrchestrationConfig config_mismatch(const ChipTaskArgs &args) {
+    configure(args, 5);
+    return OrchestrationConfig{3};
+}
+extern "C" void orchestration_a(const ChipTaskArgs &args) { execute(args, 3); }
+extern "C" void orchestration_b(const ChipTaskArgs &args) { execute(args, 4); }

--- a/tests/ut/cpp/hardware/test_a5_kernel_topology_lifecycle.cpp
+++ b/tests/ut/cpp/hardware/test_a5_kernel_topology_lifecycle.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <set>
+#include <sstream>
+
+#include <acl/acl.h>
+#include "device_runner_base.h"
+
+#define private public
+#include "device_runner.h"
+#undef private
+
+namespace {
+
+constexpr int kInjectedError = 1701;
+
+struct FakeTopologyTransport {
+    int alloc_error{0};
+    int copy_fail_on{0};
+    int launch_error{0};
+    int sync_error{0};
+    int free_error{0};
+    int set_device_error{0};
+    int alloc_calls{0};
+    int copy_calls{0};
+    int launch_calls{0};
+    int sync_calls{0};
+    int free_calls{0};
+    int reset_calls{0};
+    void *pending_result{nullptr};
+    void *last_stream{nullptr};
+    std::set<void *> live;
+};
+
+FakeTopologyTransport fake;
+
+class TopologyRunner : public DeviceRunner {
+public:
+    void attach_for_test() {
+        ASSERT_EQ(execution_mode_latch().latch(SIMPLER_MODE_KERNEL), 0);
+        device_id_ = 0;
+        KernelContextOps ops{};
+        ops.get_current_device = [](void *, int *device) {
+            *device = 0;
+            return 0;
+        };
+        ops.create_hidden_stream = [](void *, void **stream) {
+            *stream = &fake;
+            return 0;
+        };
+        ops.destroy_hidden_stream = [](void *, void *) {
+            return 0;
+        };
+        ops.create_event = [](void *, uint32_t, void **event) {
+            *event = &fake;
+            return 0;
+        };
+        ops.destroy_event = [](void *, void *) {
+            return 0;
+        };
+        ASSERT_EQ(kernel_execution_state().initialize(0, ops), 0);
+    }
+};
+
+class KernelTopologyLifecycle : public ::testing::Test {
+protected:
+    void SetUp() override {
+        fake = {};
+        runner.attach_for_test();
+    }
+
+    void TearDown() override {
+        fake.sync_error = 0;
+        fake.free_error = 0;
+        fake.set_device_error = 0;
+        EXPECT_EQ(runner.finalize(), 0);
+        EXPECT_TRUE(fake.live.empty());
+        EXPECT_EQ(fake.reset_calls, 0);
+    }
+
+    int query() { return runner.query_aicpu_device_occupancy(output, &stream_token); }
+
+    void expect_retained(bool in_flight) {
+        EXPECT_NE(runner.kernel_topology_result_, nullptr);
+        EXPECT_EQ(runner.kernel_topology_stream_ != nullptr, in_flight);
+        EXPECT_EQ(runner.committed_device_memory(), sizeof(AicpuTopologyQueryResult));
+        EXPECT_EQ(fake.live.size(), 1U);
+    }
+
+    TopologyRunner runner;
+    pto::a5::AicpuDeviceOccupancy output;
+    int stream_token{0};
+};
+
+}  // namespace
+
+// These definitions interpose the linked onboard library's transport only.
+// DeviceRunner's query, allocator bookkeeping and finalize run unchanged.
+extern "C" rtError_t rtMalloc(void **out, uint64_t bytes, rtMemType_t, uint16_t) {
+    ++fake.alloc_calls;
+    if (fake.alloc_error != 0) return fake.alloc_error;
+    *out = std::malloc(bytes);
+    if (*out == nullptr) return kInjectedError;
+    fake.live.insert(*out);
+    return 0;
+}
+
+extern "C" rtError_t rtFree(void *ptr) {
+    ++fake.free_calls;
+    if (fake.free_error != 0) return fake.free_error;
+    EXPECT_EQ(fake.live.erase(ptr), 1U);
+    std::free(ptr);
+    return 0;
+}
+
+extern "C" rtError_t rtMemcpy(void *dst, uint64_t dst_bytes, const void *src, uint64_t bytes, rtMemcpyKind_t) {
+    ++fake.copy_calls;
+    if (fake.copy_calls == fake.copy_fail_on) return kInjectedError;
+    if (bytes > dst_bytes) return kInjectedError;
+    std::memcpy(dst, src, bytes);
+    return 0;
+}
+
+extern "C" rtError_t rtSetDevice(int32_t) { return fake.set_device_error; }
+
+extern "C" rtError_t rtDeviceReset(int32_t) {
+    ++fake.reset_calls;
+    return kInjectedError;
+}
+
+extern "C" aclError aclrtResetDevice(int32_t) {
+    ++fake.reset_calls;
+    return kInjectedError;
+}
+
+extern "C" aclError aclFinalize() {
+    ++fake.reset_calls;
+    return kInjectedError;
+}
+
+extern "C" aclError aclrtSynchronizeStreamWithTimeout(aclrtStream stream, int32_t) {
+    ++fake.sync_calls;
+    EXPECT_EQ(stream, fake.last_stream);
+    if (fake.sync_error != 0) return fake.sync_error;
+    if (fake.pending_result != nullptr) {
+        AicpuTopologyQueryResult result{};
+        result.occupy = 0x3c;
+        result.occupy_rc = 0;
+        std::memcpy(fake.pending_result, &result, sizeof(result));
+        fake.pending_result = nullptr;
+    }
+    return 0;
+}
+
+int DeviceRunnerBase::launch_aicpu_payload(
+    rtStream_t stream, void *args, size_t args_size, const char *kernel_name, int aicpu_num
+) {
+    ++fake.launch_calls;
+    EXPECT_STREQ(kernel_name, "simpler_aicpu_query_topology");
+    EXPECT_EQ(args_size, sizeof(AicpuTopologyQueryArgs));
+    EXPECT_EQ(aicpu_num, 1);
+    AicpuTopologyQueryArgs copied{};
+    std::memcpy(&copied, args, sizeof(copied));
+    fake.pending_result = reinterpret_cast<void *>(copied.result_addr);
+    fake.last_stream = stream;
+    return fake.launch_error;
+}
+
+namespace {
+
+TEST_F(KernelTopologyLifecycle, SuccessReleasesScratchAndReusesOccupancyCache) {
+    ASSERT_EQ(query(), 0);
+    EXPECT_EQ(output.occupy, 0x3cU);
+    EXPECT_EQ(runner.committed_device_memory(), 0U);
+    EXPECT_EQ(runner.kernel_topology_result_, nullptr);
+    ASSERT_EQ(query(), 0);
+    EXPECT_EQ(fake.alloc_calls, 1);
+    EXPECT_EQ(fake.launch_calls, 1);
+    EXPECT_EQ(fake.sync_calls, 1);
+    EXPECT_EQ(fake.free_calls, 1);
+}
+
+TEST_F(KernelTopologyLifecycle, AllocationFailureDoesNotPublishOrLaunch) {
+    fake.alloc_error = kInjectedError;
+    EXPECT_NE(query(), 0);
+    EXPECT_EQ(fake.launch_calls, 0);
+    EXPECT_EQ(fake.free_calls, 0);
+    EXPECT_FALSE(runner.aicpu_device_occupancy_cached_);
+    EXPECT_EQ(runner.committed_device_memory(), 0U);
+}
+
+TEST_F(KernelTopologyLifecycle, CopyFailureReleasesScratchWithoutLaunch) {
+    fake.copy_fail_on = 1;
+    EXPECT_EQ(query(), kInjectedError);
+    EXPECT_EQ(fake.launch_calls, 0);
+    EXPECT_EQ(fake.sync_calls, 0);
+    EXPECT_EQ(fake.free_calls, 1);
+    EXPECT_EQ(runner.committed_device_memory(), 0U);
+}
+
+TEST_F(KernelTopologyLifecycle, CopyRollbackFailureRetainsScratchUntilCloseRetry) {
+    fake.copy_fail_on = 1;
+    fake.free_error = kInjectedError;
+    EXPECT_EQ(query(), kInjectedError);
+    expect_retained(false);
+    EXPECT_EQ(runner.kernel_execution_state().phase(), KernelContextPhase::Poisoned);
+    EXPECT_EQ(runner.finalize(), kInjectedError);
+    expect_retained(false);
+    EXPECT_EQ(fake.sync_calls, 0);
+    fake.free_error = 0;
+    EXPECT_EQ(runner.finalize(), 0);
+    EXPECT_EQ(runner.committed_device_memory(), 0U);
+}
+
+TEST_F(KernelTopologyLifecycle, LaunchFailureRetainsPossiblyInFlightScratch) {
+    fake.launch_error = kInjectedError;
+    EXPECT_EQ(query(), kInjectedError);
+    expect_retained(true);
+    EXPECT_EQ(fake.free_calls, 0);
+    EXPECT_EQ(query(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(fake.launch_calls, 1);
+    EXPECT_EQ(runner.finalize(), 0);
+    EXPECT_EQ(fake.sync_calls, 1);
+    EXPECT_EQ(fake.free_calls, 1);
+}
+
+TEST_F(KernelTopologyLifecycle, SyncAndCloseFailuresKeepBufferUntilConfirmedCompletion) {
+    fake.sync_error = kInjectedError;
+    EXPECT_EQ(query(), kInjectedError);
+    expect_retained(true);
+    EXPECT_EQ(runner.finalize(), kInjectedError);
+    expect_retained(true);
+    EXPECT_EQ(fake.free_calls, 0);
+    fake.sync_error = 0;
+    fake.free_error = kInjectedError;
+    EXPECT_EQ(runner.finalize(), kInjectedError);
+    expect_retained(false);
+    const int completed_sync_calls = fake.sync_calls;
+    fake.free_error = 0;
+    EXPECT_EQ(runner.finalize(), 0);
+    EXPECT_EQ(fake.sync_calls, completed_sync_calls);
+    EXPECT_EQ(runner.committed_device_memory(), 0U);
+}
+
+TEST_F(KernelTopologyLifecycle, CloseDeviceSelectionFailurePreservesInFlightOwnership) {
+    fake.sync_error = kInjectedError;
+    EXPECT_EQ(query(), kInjectedError);
+    fake.set_device_error = kInjectedError;
+    EXPECT_EQ(runner.finalize(), kInjectedError);
+    expect_retained(true);
+    EXPECT_EQ(fake.sync_calls, 1);
+    EXPECT_EQ(fake.free_calls, 0);
+}
+
+TEST_F(KernelTopologyLifecycle, ResultCopyFailureDoesNotPublishCache) {
+    fake.copy_fail_on = 2;
+    EXPECT_EQ(query(), kInjectedError);
+    EXPECT_FALSE(runner.aicpu_device_occupancy_cached_);
+    EXPECT_EQ(fake.free_calls, 1);
+    EXPECT_EQ(runner.committed_device_memory(), 0U);
+}
+
+TEST_F(KernelTopologyLifecycle, SuccessfulQueryCleanupFailureDoesNotPublishCache) {
+    fake.free_error = kInjectedError;
+    EXPECT_EQ(query(), kInjectedError);
+    EXPECT_FALSE(runner.aicpu_device_occupancy_cached_);
+    EXPECT_EQ(output.occupy, 0U);
+    expect_retained(false);
+}
+
+}  // namespace

--- a/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
+++ b/tests/ut/cpp/hierarchical/test_pipeline_contract.cpp
@@ -221,6 +221,90 @@ TEST(PipelineContract, ShippedArenaTopologiesAreServiceable) {
     EXPECT_TRUE(has_serviceable_arena_topology(tmr));
 }
 
+PipelineContract kernel_contract() {
+    PipelineContract c{PTO_PIPELINE_CONTRACT_ABI_VERSION, 6, 1, {}};
+    for (uint32_t kind = PTO_PIPELINE_GM_HEAP; kind <= PTO_PIPELINE_RUNTIME_IMAGE; ++kind) {
+        c.resources[kind - 1] = {kind, PTO_PIPELINE_DEVICE_SCRATCH, 4096};
+    }
+    c.resources[3] = {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0};
+    c.resources[4] = {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0};
+    c.resources[5] = {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0};
+    return c;
+}
+
+TEST(PipelineContract, KernelByteRulesAreModeSpecific) {
+    auto c = kernel_contract();
+    EXPECT_TRUE(is_valid_pipeline_contract(&c, SIMPLER_MODE_KERNEL));
+    EXPECT_TRUE(is_valid_tmr_kernel_pipeline_contract(&c));
+    EXPECT_FALSE(is_valid_pipeline_contract(&c));
+    EXPECT_FALSE(is_valid_pipeline_contract(&c, 99u));
+    EXPECT_FALSE(is_valid_pipeline_contract(&c, UINT32_MAX));
+    EXPECT_FALSE(is_valid_pipeline_contract(nullptr, SIMPLER_MODE_KERNEL));
+    for (uint32_t i = 0; i < c.resource_count; ++i) {
+        auto invalid = c;
+        invalid.resources[i].bytes_per_copy = i < 3 ? 0 : 1;
+        EXPECT_FALSE(is_valid_pipeline_contract(&invalid, SIMPLER_MODE_KERNEL)) << i;
+    }
+}
+
+TEST(PipelineContract, KernelRequiresExactlyItsSupportedResourceShape) {
+    const auto c = kernel_contract();
+    for (uint32_t i = 0; i < c.resource_count; ++i) {
+        auto missing = c;
+        missing.resources[i] = missing.resources[--missing.resource_count];
+        EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&missing)) << i;
+        auto wrong_class = c;
+        wrong_class.resources[i].resource_class = (wrong_class.resources[i].resource_class + 1) % 3;
+        EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&wrong_class)) << i;
+        auto duplicate = c;
+        duplicate.resources[i] = duplicate.resources[(i + 1) % c.resource_count];
+        EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&duplicate)) << i;
+    }
+    auto invalid = c;
+    invalid.pipeline_depth = 2;
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&invalid));
+    invalid = c;
+    invalid.resource_count = PTO_PIPELINE_MAX_RESOURCES + 1;
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&invalid));
+    EXPECT_FALSE(has_serviceable_stream_topology(invalid));
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(nullptr));
+}
+
+TEST(PipelineContract, StreamServiceabilityDoesNotChangeStructuralRules) {
+    auto c = accepted_contract();
+    EXPECT_TRUE(has_serviceable_stream_topology(c));
+    c.pipeline_depth = 2;
+    EXPECT_TRUE(has_serviceable_stream_topology(c));
+    c.resources[3].kind = PTO_PIPELINE_AICPU_STREAM;
+    EXPECT_TRUE(is_valid_pipeline_contract(&c));
+    EXPECT_TRUE(has_serviceable_arena_topology(c));
+    EXPECT_FALSE(has_serviceable_stream_topology(c));
+    c = accepted_contract();
+    c.resources[2].resource_class = PTO_PIPELINE_HOST_PER_RUN;
+    EXPECT_FALSE(has_serviceable_stream_topology(c));
+    c.resource_count = 0;
+    EXPECT_TRUE(is_valid_pipeline_contract(&c));
+    EXPECT_FALSE(has_serviceable_stream_topology(c));
+}
+
+TEST(PipelineContract, CommonKernelAdmissionDoesNotRequireTmrResourceSet) {
+    const PipelineContract c{
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        4,
+        1,
+        {
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_HOST_PER_RUN, 4096},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_HOST_PER_RUN, 4096},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+    ASSERT_TRUE(is_valid_pipeline_contract(&c, SIMPLER_MODE_KERNEL));
+    EXPECT_TRUE(has_serviceable_arena_topology(c));
+    EXPECT_TRUE(has_serviceable_stream_topology(c));
+    EXPECT_FALSE(is_valid_tmr_kernel_pipeline_contract(&c));
+}
+
 TEST(PipelineSlotPool, DepthOneKeepsLegacySingleSlotBehavior) {
     PipelineSlotPool pool(1);
     auto first = pool.try_acquire();

--- a/tests/ut/cpp/hierarchical/test_pipeline_contract_loader.cpp
+++ b/tests/ut/cpp/hierarchical/test_pipeline_contract_loader.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include <dlfcn.h>
+#include <stdexcept>
+#include <string>
+#include <gtest/gtest.h>
+
+#include "chip_worker.h"
+#include "chip_run_lane.h"
+#include "pipeline_contract.h"
+
+namespace {
+
+template <typename T>
+T symbol(void *handle, const char *name) {
+    dlerror();
+    void *result = dlsym(handle, name);
+    const char *error = dlerror();
+    if (error != nullptr || result == nullptr) {
+        throw std::runtime_error(error != nullptr ? error : name);
+    }
+    return reinterpret_cast<T>(result);
+}
+
+class LoadedRuntime {
+public:
+    explicit LoadedRuntime(const char *path, int flags = RTLD_NOW | RTLD_LOCAL) {
+        handle = dlopen(path, flags);
+        if (!handle) throw std::runtime_error(dlerror());
+    }
+    ~LoadedRuntime() { dlclose(handle); }
+    LoadedRuntime(const LoadedRuntime &) = delete;
+    LoadedRuntime &operator=(const LoadedRuntime &) = delete;
+    void *handle;
+};
+
+PipelineContract program_contract() {
+    return {
+        PTO_PIPELINE_CONTRACT_ABI_VERSION,
+        6,
+        2,
+        {
+            {PTO_PIPELINE_GM_HEAP, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_GM_SM, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_RUNTIME_IMAGE, PTO_PIPELINE_DEVICE_SCRATCH, 0},
+            {PTO_PIPELINE_TASK_ARGS, PTO_PIPELINE_HOST_PER_RUN, 0},
+            {PTO_PIPELINE_AICPU_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+            {PTO_PIPELINE_AICORE_STREAM, PTO_PIPELINE_EXEC_HANDLE, 0},
+        }
+    };
+}
+
+void expect_factory_admission(const PipelineContract &contract, int expected_creates, const char *message) {
+    LoadedRuntime fixture(PIPELINE_FIXTURE_PATH);
+    auto set_contract = symbol<void (*)(const PipelineContract *)>(fixture.handle, "test_set_pipeline_contract");
+    auto create_count = symbol<int (*)()>(fixture.handle, "test_context_create_count");
+    set_contract(&contract);
+    {
+        ChipWorker worker;
+        try {
+            worker.init(PIPELINE_FIXTURE_PATH, "", "", "", 0);
+            FAIL() << "The fixture factory must fail after admission";
+        } catch (const std::runtime_error &error) {
+            EXPECT_STREQ(error.what(), message);
+        }
+    }
+    EXPECT_EQ(create_count(), expected_creates);
+}
+
+}  // namespace
+
+TEST(PipelineContractLoader, MissingOrMisclassifiedStreamsRejectBeforeCreatingContext) {
+    for (uint32_t index : {4u, 5u}) {
+        auto contract = program_contract();
+        contract.resources[index] = contract.resources[3];
+        ASSERT_TRUE(is_valid_pipeline_contract(&contract));
+        expect_factory_admission(contract, 0, "host runtime returned a PipelineContract this build cannot accept");
+        contract = program_contract();
+        contract.resources[index].resource_class = PTO_PIPELINE_HOST_PER_RUN;
+        expect_factory_admission(contract, 0, "host runtime returned a PipelineContract this build cannot accept");
+    }
+}
+
+TEST(PipelineContractLoader, LegalProgramDeclarationReachesRealFactoryCall) {
+    expect_factory_admission(program_contract(), 1, "create_device_context returned null");
+}
+
+TEST(KernelPipelineEntry, RealSimVariantsValidateWithoutClaimingOrCommitting) {
+    // Sim hooks must remain global for every host runtime loaded beneath them.
+    LoadedRuntime sim_context(SIM_CONTEXT_PATH, RTLD_NOW | RTLD_GLOBAL);
+    for (const char *arch : {"a2a3", "a5"}) {
+        for (const char *runtime : {"tensormap_and_ringbuffer", "host_build_graph"}) {
+            const std::string path =
+                std::string(RUNTIME_LIBRARY_ROOT) + "/" + arch + "/sim/" + runtime + "/libhost_runtime.so";
+            SCOPED_TRACE(path);
+            LoadedRuntime library(path.c_str());
+            auto create = symbol<decltype(&create_device_context)>(library.handle, "create_device_context");
+            auto destroy = symbol<decltype(&destroy_device_context)>(library.handle, "destroy_device_context");
+            auto init = symbol<decltype(&simpler_kernel_mode_init)>(library.handle, "simpler_kernel_mode_init");
+            auto supported =
+                symbol<decltype(&simpler_kernel_mode_supported)>(library.handle, "simpler_kernel_mode_supported");
+            auto launch = symbol<decltype(&simpler_kernel_mode_launch)>(library.handle, "simpler_kernel_mode_launch");
+            auto committed =
+                symbol<decltype(&committed_device_memory_ctx)>(library.handle, "committed_device_memory_ctx");
+            DeviceContextHandle ctx = create();
+            ASSERT_NE(ctx, nullptr);
+            CallConfig config;
+            auto invoke = [&](const CallConfig *input, uint64_t generation = 1) {
+                return init(ctx, 0, nullptr, 0, nullptr, 0, nullptr, 0, input, generation);
+            };
+            EXPECT_EQ(invoke(nullptr), PTO_RUNTIME_ERR_INTERNAL);
+            EXPECT_EQ(invoke(&config, 0), PTO_RUNTIME_ERR_INTERNAL);
+            const uint8_t binary = 0;
+            EXPECT_EQ(init(ctx, 0, &binary, 0, nullptr, 0, nullptr, 0, &config, 1), PTO_RUNTIME_ERR_INTERNAL);
+            EXPECT_EQ(init(ctx, 0, nullptr, 0, &binary, 0, nullptr, 0, &config, 1), PTO_RUNTIME_ERR_INTERNAL);
+            EXPECT_EQ(init(ctx, 0, nullptr, 0, nullptr, 0, &binary, 0, &config, 1), PTO_RUNTIME_ERR_INTERNAL);
+            config.runtime_env.ring_task_window[0] = 3;
+            EXPECT_EQ(
+                invoke(&config), std::string(runtime) == "tensormap_and_ringbuffer" ? PTO_RUNTIME_ERR_INTERNAL :
+                                                                                      PTO_RUNTIME_ERR_UNSUPPORTED
+            );
+            config.runtime_env.ring_task_window[0] = 0;
+            EXPECT_EQ(invoke(&config), PTO_RUNTIME_ERR_UNSUPPORTED);
+            EXPECT_EQ(supported(ctx), 0);
+            EXPECT_EQ(committed(ctx), 0u);
+            // A structurally valid launch still cannot run after unsupported init.
+            int caller_stream_token = 0;
+            EXPECT_EQ(launch(ctx, 0, &config, &caller_stream_token), PTO_RUNTIME_ERR_INVALID_STATE);
+            EXPECT_EQ(invoke(&config), PTO_RUNTIME_ERR_UNSUPPORTED);
+            EXPECT_EQ(committed(ctx), 0u);
+            destroy(ctx);
+        }
+    }
+}

--- a/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
+++ b/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#include "worker/runtime_c_api.h"
+#include "platform_comm/comm.h"
+#include "common/host_log_state.h"
+
+// Sequential loader fixture: only the declaration and factory counter are live.
+// Every loaded symbol uses its production signature; unexpected execution fails.
+namespace {
+PipelineContract contract{};
+int create_count = 0;
+}  // namespace
+extern "C" {
+void test_set_pipeline_contract(const PipelineContract *value) {
+    contract = *value;
+    create_count = 0;
+}
+int test_context_create_count() { return create_count; }
+int simpler_host_log_bind_state(SimplerHostLogState *) { return 0; }
+
+DeviceContextHandle create_device_context(void) {
+    ++create_count;
+    return nullptr;
+}
+
+void destroy_device_context(DeviceContextHandle ctx) {}
+
+void *device_malloc_ctx(DeviceContextHandle ctx, size_t size) { return nullptr; }
+
+void device_free_ctx(DeviceContextHandle ctx, void *dev_ptr) {}
+
+size_t committed_device_memory_ctx(DeviceContextHandle ctx) { return 0; }
+
+int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int copy_to_device_ctx(DeviceContextHandle ctx, void *dev_ptr, const void *host_ptr, size_t size) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *dev_ptr, size_t size) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+size_t get_runtime_size(void) { return 0; }
+
+size_t get_runtime_alignment(void) { return 0; }
+
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *prewarm_config, int enable_sdma, const void *sdma_warmup_binary, uint64_t sdma_warmup_size
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_run(
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_prepare_run(
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config,
+    const NativeRunDescriptor *descriptor
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_poll_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_wait_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int supports_concurrent_native_prepare_ctx(DeviceContextHandle ctx) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+uint64_t get_arena_bank_gm_heap_base_ctx(DeviceContextHandle ctx, uint32_t bank_id) { return 0; }
+
+uint64_t get_retained_temp_addr_ctx(DeviceContextHandle ctx, uint32_t slot_id) { return 0; }
+
+const PipelineContract *get_pipeline_contract(void) { return &contract; }
+
+int simpler_unregister_callable(DeviceContextHandle ctx, int32_t callable_id) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+size_t get_aicpu_dlopen_count(DeviceContextHandle ctx) { return 0; }
+
+size_t get_host_dlopen_count(DeviceContextHandle ctx) { return 0; }
+
+size_t get_run_stream_set_create_count(DeviceContextHandle ctx) { return 0; }
+
+int finalize_device(DeviceContextHandle ctx) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int ensure_acl_ready_ctx(void *, int) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+void *create_comm_stream_ctx(void *) { return nullptr; }
+
+int destroy_comm_stream_ctx(void *, void *) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+CommHandle comm_init(int rank, int nranks, void *stream, const char *rootinfo_path) { return nullptr; }
+
+int comm_alloc_windows(CommHandle h, size_t win_size, uint64_t *device_ctx_out) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_get_local_window_base(CommHandle h, uint64_t *base_out) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_get_window_size(CommHandle h, size_t *size_out) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_derive_context(
+    CommHandle h, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank, size_t window_offset,
+    size_t window_size, uint64_t *device_ctx_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_alloc_domain_windows(
+    CommHandle h, uint64_t allocation_id, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank,
+    size_t window_size, uint64_t *device_ctx_out, uint64_t *local_window_base_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_release_domain_windows(CommHandle h, uint64_t allocation_id, size_t rank_count, uint32_t domain_rank) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_global_domain_prepare(
+    uint64_t domain_id, uint32_t domain_rank, uint32_t rank_count, size_t window_size, uint32_t profile,
+    CommGlobalDomainDescriptor *descriptor_out, uint64_t *local_window_base_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_global_domain_import(
+    uint64_t domain_id, const CommGlobalDomainDescriptor *descriptors, size_t descriptor_count, uint64_t *device_ctx_out
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int comm_global_domain_release(uint64_t domain_id) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_barrier(CommHandle h) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int comm_destroy(CommHandle h) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_kernel_mode_supported(DeviceContextHandle ctx) { return PTO_RUNTIME_ERR_INTERNAL; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    return PTO_RUNTIME_ERR_INTERNAL;
+}
+
+}  // extern "C"

--- a/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
+++ b/tests/ut/cpp/stubs/pipeline_contract_runtime.cpp
@@ -167,7 +167,7 @@ int simpler_kernel_mode_init(
 }
 
 int simpler_kernel_mode_prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size
 ) {
     return PTO_RUNTIME_ERR_INTERNAL;
 }

--- a/tests/ut/cpp/types/test_callable_scalar_count.cpp
+++ b/tests/ut/cpp/types/test_callable_scalar_count.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// ChipCallable::scalar_count_ contract: the field is a cached derivation of
+// the signature's SCALAR entries (0 also meaning "not recorded"), the factory
+// validates range and signature agreement, the field occupies former header
+// padding only, and a blob written by a producer that predates the field
+// (whose padding make_callable zero-initialized) reads back as
+// scalar_count == 0.
+
+#include <cstddef>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "callable.h"
+
+namespace {
+
+// Builds a chip callable whose signature carries `scalar_entries` trailing
+// SCALAR entries after one IN and one OUT tensor, declaring `declared_count`
+// as its scalar count.
+std::vector<uint8_t> build_chip_callable(int32_t declared_count, int32_t scalar_entries) {
+    std::vector<ArgDirection> sig{ArgDirection::IN, ArgDirection::OUT};
+    for (int32_t i = 0; i < scalar_entries; ++i)
+        sig.push_back(ArgDirection::SCALAR);
+
+    ArgDirection core_sig[1] = {ArgDirection::IN};
+    const uint8_t kernel[] = {0x01, 0x02, 0x03, 0x04};
+    auto core = make_callable<CORE_MAX_TENSOR_ARGS>(core_sig, 1, kernel, sizeof(kernel));
+
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F'};
+    int32_t child_ids[1] = {3};
+    std::vector<uint8_t> children[1] = {std::move(core)};
+
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        sig.data(), static_cast<int32_t>(sig.size()), declared_count, "orch_fn", fake_orch_so, sizeof(fake_orch_so),
+        child_ids, children, 1, "cfg_name"
+    );
+}
+
+// scalar_count() reads 0 both for a scalar-free orchestration and for an
+// artifact built before the field existed, so the wire contract has a consumer
+// derive the effective count from the signature when the field is 0 rather
+// than subtracting it. This pins the answer the naive formula gets wrong, so a
+// consumer that reintroduces it fails here rather than on device.
+TEST(CallableScalarCount, SubtractingAnUnrecordedCountMiscountsScalarsAsTensors) {
+    auto buf = build_chip_callable(0, 9);
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    ASSERT_EQ(callable->sig_count(), 11);
+    ASSERT_EQ(callable->scalar_count(), 0);
+
+    int32_t signature_scalars = 0;
+    for (int32_t i = 0; i < callable->sig_count(); ++i) {
+        if (callable->sig(i) == ArgDirection::SCALAR) ++signature_scalars;
+    }
+    ASSERT_EQ(signature_scalars, 9);
+
+    const int32_t effective_scalars = callable->scalar_count() != 0 ? callable->scalar_count() : signature_scalars;
+    EXPECT_EQ(callable->sig_count() - effective_scalars, 2);
+    EXPECT_EQ(callable->sig_count() - callable->scalar_count(), 11);
+}
+
+}  // namespace
+
+TEST(CallableScalarCount, RoundTripsThroughFactory) {
+    for (int32_t count : {0, 1, 7, CHIP_MAX_SCALAR_ARGS}) {
+        auto buf = build_chip_callable(count, count);
+        const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+        EXPECT_EQ(callable->scalar_count(), count);
+        EXPECT_EQ(callable->sig_count(), 2 + count);
+    }
+}
+
+TEST(CallableScalarCount, RejectsOutOfRangeWithValueAndLimit) {
+    for (int32_t count : {-1, CHIP_MAX_SCALAR_ARGS + 1}) {
+        try {
+            (void)build_chip_callable(count, count > 0 ? count : 0);
+            FAIL() << "expected scalar count validation to fail for " << count;
+        } catch (const std::invalid_argument &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(std::to_string(count)), std::string::npos) << message;
+            EXPECT_NE(message.find(std::to_string(CHIP_MAX_SCALAR_ARGS)), std::string::npos) << message;
+        }
+    }
+}
+
+// A nonzero count is a cached derivation of the signature, so a value that
+// disagrees with the signature's SCALAR entries is rejected naming both
+// numbers. Zero stays valid with any signature (legacy "not recorded").
+TEST(CallableScalarCount, RejectsCountDisagreeingWithSignature) {
+    struct Case {
+        int32_t declared;
+        int32_t entries;
+    };
+    for (const Case &c : {Case{5, 0}, Case{3, 9}}) {
+        try {
+            (void)build_chip_callable(c.declared, c.entries);
+            FAIL() << "expected consistency validation to fail for declared=" << c.declared << " entries=" << c.entries;
+        } catch (const std::invalid_argument &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(std::to_string(c.declared)), std::string::npos) << message;
+            EXPECT_NE(message.find(std::to_string(c.entries)), std::string::npos) << message;
+        }
+    }
+    auto unrecorded = build_chip_callable(0, 9);
+    EXPECT_EQ(reinterpret_cast<const ChipCallable *>(unrecorded.data())->scalar_count(), 0);
+}
+
+// A legacy blob is byte-identical to a current one built with the same inputs
+// except that the four bytes now holding scalar_count_ were zero-initialized
+// padding. Zeroing them reproduces such a blob exactly.
+TEST(CallableScalarCount, LegacyBlobReadsZero) {
+    auto buf = build_chip_callable(9, 9);
+    std::memset(buf.data() + offsetof(ChipCallable, scalar_count_), 0, sizeof(int32_t));
+
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    EXPECT_EQ(callable->scalar_count(), 0);
+    EXPECT_EQ(callable->sig_count(), 11);
+    EXPECT_EQ(std::string(callable->func_name(), callable->func_name_len()), "orch_fn");
+    EXPECT_EQ(std::string(callable->config_name(), callable->config_name_len()), "cfg_name");
+    ASSERT_EQ(callable->child_count(), 1);
+    EXPECT_EQ(callable->child_func_id(0), 3);
+    EXPECT_EQ(callable->child(0).binary_size(), 4u);
+}
+
+// Two builds with the same signature that differ only in the declared count
+// (0 = "not recorded" vs the real derivation) must differ only in that
+// field's four bytes — every other header byte, the orchestration binary,
+// and the child payload keep their positions and values.
+TEST(CallableScalarCount, OnlyTheFieldBytesVary) {
+    auto unrecorded = build_chip_callable(0, 9);
+    auto nine = build_chip_callable(9, 9);
+    ASSERT_EQ(unrecorded.size(), nine.size());
+
+    constexpr size_t field_begin = offsetof(ChipCallable, scalar_count_);
+    constexpr size_t field_end = field_begin + sizeof(int32_t);
+    for (size_t i = 0; i < unrecorded.size(); ++i) {
+        if (i >= field_begin && i < field_end) continue;
+        ASSERT_EQ(unrecorded[i], nine[i]) << "byte " << i << " must not depend on scalar_count";
+    }
+    EXPECT_NE(std::memcmp(unrecorded.data() + field_begin, nine.data() + field_begin, sizeof(int32_t)), 0);
+}

--- a/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
+++ b/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
@@ -60,7 +60,7 @@ std::vector<uint8_t> build_test_chip_callable() {
     std::vector<uint8_t> children[2] = {std::move(core0), std::move(core1)};
 
     return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-        nullptr, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
+        nullptr, 0, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
     );
 }
 

--- a/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
+++ b/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
@@ -50,7 +50,7 @@ TEST(ChipMaxTensorArgs, ChipStorageHoldsCapacity) {
 TEST(ChipMaxTensorArgs, ChipCallableAcceptsCapacity) {
     std::vector<ArgDirection> signature(256, ArgDirection::IN);
     auto buffer = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-        signature.data(), static_cast<int32_t>(signature.size()), "composed", nullptr, 0, nullptr, nullptr, 0, ""
+        signature.data(), static_cast<int32_t>(signature.size()), 0, "composed", nullptr, 0, nullptr, nullptr, 0, ""
     );
 
     const auto &callable = *reinterpret_cast<const ChipCallable *>(buffer.data());
@@ -63,7 +63,7 @@ TEST(ChipMaxTensorArgs, ChipCallableOverflowReportsRequestedAndSupportedCounts) 
 
     try {
         (void)make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-            signature.data(), requested, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
+            signature.data(), requested, 0, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
         );
         FAIL() << "expected signature capacity validation to fail";
     } catch (const std::invalid_argument &error) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -11,7 +11,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cstddef>
 #include <cstring>
 
 #include "kernel_invocation_header.h"
@@ -21,18 +20,6 @@ namespace {
 TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
     EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
     EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
-}
-
-TEST(KernelInvocationHeaderWire, LayoutMatchesHostDeviceEnvelope) {
-    EXPECT_EQ(sizeof(SimplerKernelInvocationHeader), 40u);
-    EXPECT_EQ(alignof(SimplerKernelInvocationHeader), 8u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, mode), 0u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, callable_id), 4u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, generation), 8u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, payload_bytes), 16u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, tensor_count), 24u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, scalar_count), 28u);
-    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, host_copy_tensor_count), 32u);
 }
 
 TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -11,6 +11,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <cstring>
 
 #include "kernel_invocation_header.h"
@@ -20,6 +21,18 @@ namespace {
 TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
     EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
     EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
+}
+
+TEST(KernelInvocationHeaderWire, LayoutMatchesHostDeviceEnvelope) {
+    EXPECT_EQ(sizeof(SimplerKernelInvocationHeader), 40u);
+    EXPECT_EQ(alignof(SimplerKernelInvocationHeader), 8u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, mode), 0u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, callable_id), 4u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, generation), 8u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, payload_bytes), 16u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, tensor_count), 24u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, scalar_count), 28u);
+    EXPECT_EQ(offsetof(SimplerKernelInvocationHeader, host_copy_tensor_count), 32u);
 }
 
 TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "kernel_invocation_header.h"
+
+namespace {
+
+TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
+    EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
+    EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
+}
+
+TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = 17;
+    header.generation = 0x1122334455667788ull;
+    header.payload_bytes = 4096;
+    header.tensor_count = 12;
+    header.scalar_count = 5;
+
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)];
+    std::memcpy(wire, &header, sizeof(header));
+    SimplerKernelInvocationHeader restored{};
+    std::memcpy(&restored, wire, sizeof(restored));
+
+    EXPECT_EQ(restored.mode, static_cast<uint32_t>(SIMPLER_MODE_KERNEL));
+    EXPECT_EQ(restored.callable_id, 17);
+    EXPECT_EQ(restored.generation, 0x1122334455667788ull);
+    EXPECT_EQ(restored.payload_bytes, 4096u);
+    EXPECT_EQ(restored.tensor_count, 12);
+    EXPECT_EQ(restored.scalar_count, 5);
+    EXPECT_EQ(restored.host_copy_tensor_count, 0);
+}
+
+TEST(KernelInvocationHeaderWire, ZeroInitializedBlobReadsAsEmpty) {
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)] = {};
+    SimplerKernelInvocationHeader header;
+    std::memcpy(&header, wire, sizeof(header));
+    EXPECT_EQ(header.mode, static_cast<uint32_t>(SIMPLER_MODE_PROGRAM));
+    EXPECT_EQ(header.payload_bytes, 0u);
+    EXPECT_EQ(header.tensor_count, 0);
+    EXPECT_EQ(header.scalar_count, 0);
+    EXPECT_EQ(header.host_copy_tensor_count, 0);
+}
+
+}  // namespace

--- a/tests/ut/cpp/types/test_kernel_invocation_validation.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_validation.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <limits>
+#include <vector>
+
+#include "kernel_invocation_validation.h"
+
+namespace {
+using namespace simpler::kernel;
+
+TEST(KernelInvocationValidation, EffectiveScalarCompatibilityAndFailureTransaction) {
+    const ArgDirection signature[] = {ArgDirection::IN, ArgDirection::OUT, ArgDirection::SCALAR};
+    int32_t tensors = -1, scalars = -1;
+    EXPECT_EQ(derive_invocation_counts(signature, 3, 0, &tensors, &scalars), InvocationStatus::Ok);
+    EXPECT_EQ(tensors, 2);
+    EXPECT_EQ(scalars, 1);
+    EXPECT_EQ(derive_invocation_counts(signature, 3, 1, &tensors, &scalars), InvocationStatus::Ok);
+    EXPECT_EQ(derive_invocation_counts(signature, 3, 2, &tensors, &scalars), InvocationStatus::InvalidSignature);
+    EXPECT_EQ(tensors, 2);
+    EXPECT_EQ(scalars, 1);
+    const ArgDirection interleaved[] = {ArgDirection::SCALAR, ArgDirection::IN};
+    EXPECT_EQ(derive_invocation_counts(interleaved, 2, 0, &tensors, &scalars), InvocationStatus::InvalidSignature);
+    const ArgDirection unknown[] = {static_cast<ArgDirection>(42)};
+    EXPECT_EQ(derive_invocation_counts(unknown, 1, 0, &tensors, &scalars), InvocationStatus::InvalidSignature);
+    EXPECT_EQ(derive_invocation_counts(nullptr, 0, 0, &tensors, &scalars), InvocationStatus::Ok);
+    EXPECT_EQ(tensors, 0);
+    EXPECT_EQ(scalars, 0);
+    EXPECT_EQ(derive_invocation_counts(signature, -1, 0, &tensors, &scalars), InvocationStatus::InvalidCounts);
+    EXPECT_EQ(derive_invocation_counts(signature, 257, 0, &tensors, &scalars), InvocationStatus::InvalidCounts);
+    EXPECT_EQ(derive_invocation_counts(signature, 3, -1, &tensors, &scalars), InvocationStatus::InvalidCounts);
+    EXPECT_EQ(derive_invocation_counts(nullptr, 1, 0, &tensors, &scalars), InvocationStatus::InvalidArgument);
+}
+
+TEST(KernelInvocationValidation, FramingRejectsBeforePayloadReadsAndPreservesOutput) {
+    const PreparedInvocationView prepared{2, 1, 1, 7};
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = prepared.callable_id;
+    header.generation = prepared.slot_generation;
+    header.tensor_count = 1;
+    header.scalar_count = 1;
+    std::vector<uint8_t> bytes(sizeof(header) + 1);
+    auto check = [&](InvocationStatus expected, size_t size = sizeof(SimplerKernelInvocationHeader)) {
+        std::memcpy(bytes.data() + 1, &header, sizeof(header));
+        SimplerKernelInvocationHeader out{};
+        out.callable_id = 31;
+        EXPECT_EQ(validate_invocation_header({bytes.data() + 1, size}, prepared, &out), expected);
+        if (expected != InvocationStatus::Ok) EXPECT_EQ(out.callable_id, 31);
+    };
+    check(InvocationStatus::Ok);
+    check(InvocationStatus::InvalidSize, sizeof(header) - 1);
+    header.payload_bytes = std::numeric_limits<uint64_t>::max();
+    check(InvocationStatus::InvalidSize);
+    header.payload_bytes = 0;
+    header.mode = SIMPLER_MODE_PROGRAM;
+    check(InvocationStatus::InvalidHeader);
+    header.mode = 99;
+    check(InvocationStatus::InvalidHeader);
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.tensor_count = -1;
+    check(InvocationStatus::InvalidCounts);
+    header.tensor_count = 256;
+    check(InvocationStatus::InvalidCounts);
+    header.tensor_count = 1;
+    header.scalar_count = -1;
+    check(InvocationStatus::InvalidCounts);
+    header.scalar_count = 129;
+    check(InvocationStatus::InvalidCounts);
+    header.scalar_count = 0;
+    check(InvocationStatus::InvalidCounts);
+    header.scalar_count = 1;
+    header.host_copy_tensor_count = 1;
+    check(InvocationStatus::InvalidCounts);
+    header.host_copy_tensor_count = -1;
+    check(InvocationStatus::InvalidCounts);
+    header.host_copy_tensor_count = 0;
+    header.generation = 8;
+    check(InvocationStatus::StaleCallable);
+    header.generation = 0;
+    check(InvocationStatus::InvalidHeader);
+    header.generation = 7;
+    header.callable_id = 64;
+    check(InvocationStatus::InvalidHeader);
+    header.callable_id = 3;
+    check(InvocationStatus::StaleCallable);
+}
+TEST(KernelInvocationValidation, RuntimePayloadIsOpaqueAndTrustedCountsAreRequired) {
+    const PreparedInvocationView prepared{5, 2, 1, 9};
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = prepared.callable_id;
+    header.generation = prepared.slot_generation;
+    header.tensor_count = prepared.tensor_count;
+    header.scalar_count = prepared.scalar_count;
+    header.payload_bytes = 13;
+    std::vector<uint8_t> packet(sizeof(header) + header.payload_bytes, 0xa5);
+    std::memcpy(packet.data(), &header, sizeof(header));
+    SimplerKernelInvocationHeader out{};
+    ASSERT_EQ(validate_invocation_header({packet.data(), packet.size()}, prepared, &out), InvocationStatus::Ok);
+    EXPECT_EQ(out.payload_bytes, 13u);
+
+    auto different = prepared;
+    different.tensor_count = 1;
+    EXPECT_EQ(
+        validate_invocation_header({packet.data(), packet.size()}, different, &out), InvocationStatus::InvalidCounts
+    );
+    EXPECT_EQ(out.tensor_count, prepared.tensor_count);
+    different = prepared;
+    different.slot_generation = 0;
+    EXPECT_EQ(
+        validate_invocation_header({packet.data(), packet.size()}, different, &out), InvocationStatus::InvalidArgument
+    );
+    EXPECT_EQ(out.generation, prepared.slot_generation);
+}
+}  // namespace

--- a/tests/ut/py/kernel_close_faults.cpp
+++ b/tests/ut/py/kernel_close_faults.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <array>
+#include <cstdio>
+#include <dlfcn.h>
+#include <unistd.h>
+
+#include "common/host_log_state.h"
+
+namespace {
+int failure_kind = 0;
+int attempts = 0;
+bool pending = false;
+SimplerHostLogState test_log_state{};
+bool guard_acl = false;
+std::array<int, 6> forbidden_calls{};
+bool fake_device_drain = false;
+int device_drain_calls = 0;
+
+int forbidden(size_t index) {
+    ++forbidden_calls[index];
+    return -4322;
+}
+
+int destroy(const char *symbol, void *handle, int kind) {
+    if (failure_kind == kind) {
+        ++attempts;
+        if (pending) {
+            pending = false;
+            return -4321;
+        }
+    }
+    auto real_destroy = reinterpret_cast<int (*)(void *)>(dlsym(RTLD_NEXT, symbol));
+    return real_destroy(handle);
+}
+}  // namespace
+
+extern "C" void arm_destroy_failure(int kind) {
+    failure_kind = kind;
+    attempts = 0;
+    pending = true;
+}
+
+extern "C" int destroy_attempts() { return attempts; }
+
+extern "C" void arm_acl_guard() {
+    forbidden_calls.fill(0);
+    guard_acl = true;
+}
+extern "C" int acl_call_count(int index) { return forbidden_calls.at(index); }
+extern "C" void arm_fatal_drain() {
+    fake_device_drain = true;
+    device_drain_calls = 0;
+}
+extern "C" int fatal_drain_count() { return device_drain_calls; }
+
+extern "C" int aclInit(const char *config) {
+    if (guard_acl) return forbidden(0);
+    return reinterpret_cast<int (*)(const char *)>(dlsym(RTLD_NEXT, "aclInit"))(config);
+}
+extern "C" int aclrtSetDevice(int device) {
+    if (guard_acl) return forbidden(1);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "aclrtSetDevice"))(device);
+}
+extern "C" int aclrtResetDevice(int device) {
+    if (guard_acl) return forbidden(2);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "aclrtResetDevice"))(device);
+}
+extern "C" int aclrtResetDeviceForce(int device) {
+    if (guard_acl) return forbidden(3);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "aclrtResetDeviceForce"))(device);
+}
+extern "C" int aclFinalize() {
+    if (guard_acl) return forbidden(4);
+    return reinterpret_cast<int (*)()>(dlsym(RTLD_NEXT, "aclFinalize"))();
+}
+extern "C" int rtDeviceReset(int device) {
+    if (guard_acl) return forbidden(5);
+    return reinterpret_cast<int (*)(int)>(dlsym(RTLD_NEXT, "rtDeviceReset"))(device);
+}
+extern "C" int aclrtSynchronizeDeviceWithTimeout(int32_t timeout) {
+    if (fake_device_drain) {
+        ++device_drain_calls;
+        return 0;
+    }
+    return reinterpret_cast<int (*)(int32_t)>(dlsym(RTLD_NEXT, "aclrtSynchronizeDeviceWithTimeout"))(timeout);
+}
+
+// The ctypes loader has no ChipWorker to bind a process-owned logger sink.
+extern "C" int bind_test_log(void *runtime) {
+    test_log_state.threshold = 40;
+    test_log_state.sink_owner_pid = getpid();
+    test_log_state.sink_process_pid = getpid();
+    test_log_state.sink_context = &test_log_state;
+    test_log_state.sink_enqueue = [](void *, SimplerHostLogState *, const char *record, uint32_t size, int32_t) {
+        return std::fwrite(record, 1, size, stderr) == size ? 1 : 0;
+    };
+    auto bind = reinterpret_cast<SimplerHostLogBindStateFn>(dlsym(runtime, "simpler_host_log_bind_state"));
+    return bind == nullptr ? -1 : bind(&test_log_state);
+}
+
+extern "C" int rtStreamDestroy(void *stream) { return destroy("rtStreamDestroy", stream, 1); }
+extern "C" int aclrtDestroyEvent(void *event) { return destroy("aclrtDestroyEvent", event, 2); }
+
+extern "C" int aclrtCreateEventExWithFlag(void **event, uint32_t flag) {
+    if (failure_kind == 3 && pending) {
+        pending = false;
+        return -4321;
+    }
+    auto create = reinterpret_cast<int (*)(void **, uint32_t)>(dlsym(RTLD_NEXT, "aclrtCreateEventExWithFlag"));
+    return create(event, flag);
+}

--- a/tests/ut/py/kernel_prepare_orchestration.cpp
+++ b/tests/ut/py/kernel_prepare_orchestration.cpp
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Registration resolves this symbol but never invokes the orchestration.
+extern "C" void kernel_prepare_orchestration() {}

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -380,6 +380,33 @@ class TestChipWorkerPython:
         )
         assert expected_warning in capsys.readouterr().err
 
+    def test_public_wrapper_keeps_registries_when_native_finalize_fails(self):
+        from _task_interface import ChipCallable  # noqa: PLC0415
+        from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
+
+        class FakeImpl:
+            initialized = True
+            device_id = 0
+
+            def finalize(self):
+                raise RuntimeError("injected device teardown failure")
+
+        worker = ChipWorker()
+        worker._impl = FakeImpl()
+        worker._callable_registry[0] = ChipCallable.build(signature=[], func_name="test", binary=b"\x00", children=[])
+        worker._identity_registry[b"digest"] = object()
+        worker._live_handles[1] = b"digest"
+
+        with pytest.raises(RuntimeError, match="injected device teardown failure"):
+            worker.finalize()
+
+        # The registries name what the native side still holds. A teardown that
+        # did not complete leaves those resources alive, so dropping the
+        # registries would hide them from a retry and from the caller.
+        assert list(worker._callable_registry) == [0]
+        assert list(worker._identity_registry) == [b"digest"]
+        assert worker._live_handles == {1: b"digest"}
+
     def test_public_wrapper_flush_timeout_is_reported_with_loss_counters(self, monkeypatch, capsys):
         import simpler.task_interface as task_interface_mod  # noqa: PLC0415
         from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -23,6 +23,15 @@ _NEWLY_REQUIRED_PIPELINE_SYMBOLS = {
     "get_retained_temp_addr_ctx",
     "supports_concurrent_native_prepare_ctx",
 }
+# Kernel-mode lifecycle surface: every host-runtime component exports all of
+# these; components without kernel-mode support export validating stubs that
+# report unsupported rather than omitting the symbols.
+_KERNEL_MODE_SYMBOLS = {
+    "simpler_kernel_mode_init",
+    "simpler_kernel_mode_launch",
+    "simpler_kernel_mode_prepare_callable",
+    "simpler_kernel_mode_supported",
+}
 _REMOVED_AMBIENT_SELECTION_SYMBOLS = {
     "select_arena_bank_ctx",
     "select_pipeline_slot_ctx",
@@ -73,4 +82,5 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     symbols = _defined_external_symbols(runtime_path)
 
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
+    assert _KERNEL_MODE_SYMBOLS <= symbols, sorted(_KERNEL_MODE_SYMBOLS - symbols)
     assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -123,7 +123,7 @@ def test_execution_mode_headers_are_self_contained(language: str, standard: str,
     assert result.returncode == 0, result.stderr
 
 
-def test_pipeline_contract_has_no_invocation_header_dependency():
+def test_pipeline_contract_has_no_kernel_lifecycle_or_invocation_dependency():
     compiler = shutil.which("c++")
     assert compiler is not None, "Header dependency test requires c++"
     command = [compiler, "-x", "c++", "-std=c++17"]
@@ -135,4 +135,5 @@ def test_pipeline_contract_has_no_invocation_header_dependency():
     dependencies = subprocess.run(command + ["-M", "-"], input=source, capture_output=True, text=True, check=False)
     assert dependencies.returncode == 0, dependencies.stderr
     assert "execution_mode.h" in dependencies.stdout
-    assert "kernel_invocation_header.h" not in dependencies.stdout
+    for header in ("kernel_invocation_header.h", "kernel_execution_state.h", "execution_mode_latch.h"):
+        assert header not in dependencies.stdout

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -84,3 +85,54 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
     assert _KERNEL_MODE_SYMBOLS <= symbols, sorted(_KERNEL_MODE_SYMBOLS - symbols)
     assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)
+
+
+@pytest.mark.parametrize(("language", "standard", "compiler_name"), [("c", "c11", "cc"), ("c++", "c++17", "c++")])
+@pytest.mark.parametrize(
+    "headers",
+    [
+        ("execution_mode.h",),
+        ("kernel_invocation_header.h",),
+        ("execution_mode.h", "kernel_invocation_header.h"),
+        ("kernel_invocation_header.h", "execution_mode.h"),
+    ],
+)
+def test_execution_mode_headers_are_self_contained(language: str, standard: str, compiler_name: str, headers: tuple):
+    compiler = shutil.which(compiler_name)
+    assert compiler is not None, f"Header ABI tests require {compiler_name}"
+    includes = "\n".join(f'#include "{header}"' for header in headers)
+    source = includes + "\nSimplerExecutionMode mode = SIMPLER_MODE_KERNEL;\n"
+    assertion = "_Static_assert" if language == "c" else "static_assert"
+    source += f'{assertion}(SIMPLER_MODE_PROGRAM == 0 && SIMPLER_MODE_KERNEL == 1, "mode values");\n'
+    result = subprocess.run(
+        [
+            compiler,
+            "-x",
+            language,
+            f"-std={standard}",
+            "-I",
+            str(_PROJECT_ROOT / "src/common/task_interface"),
+            "-fsyntax-only",
+            "-",
+        ],
+        input=source,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_pipeline_contract_has_no_invocation_header_dependency():
+    compiler = shutil.which("c++")
+    assert compiler is not None, "Header dependency test requires c++"
+    command = [compiler, "-x", "c++", "-std=c++17"]
+    for directory in ("src/common", "src/common/task_interface", "src/common/platform/include"):
+        command.extend(["-I", str(_PROJECT_ROOT / directory)])
+    source = '#include "worker/pipeline_contract.h"\n'
+    result = subprocess.run(command + ["-fsyntax-only", "-"], input=source, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+    dependencies = subprocess.run(command + ["-M", "-"], input=source, capture_output=True, text=True, check=False)
+    assert dependencies.returncode == 0, dependencies.stderr
+    assert "execution_mode.h" in dependencies.stdout
+    assert "kernel_invocation_header.h" not in dependencies.stdout

--- a/tests/ut/py/test_kernel_mode_c_api.py
+++ b/tests/ut/py/test_kernel_mode_c_api.py
@@ -1,0 +1,475 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Kernel-mode C ABI driven through a real loaded host runtime.
+
+The class-level tests cover the state machines in isolation; these cover the
+glue no other test reaches — argument validation as the loaded component
+actually performs it, and, on hardware, the bring-up and teardown of a real
+kernel context.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+
+PTO_RUNTIME_ERR_INTERNAL = -1000
+PTO_RUNTIME_ERR_UNSUPPORTED = -1001
+PTO_RUNTIME_ERR_INVALID_STATE = -1003
+
+_ARCHES = ("a2a3", "a5")
+_RUNTIMES = ("host_build_graph", "tensormap_and_ringbuffer")
+_SIM_CASES = [pytest.param(arch, runtime, id=f"{arch}-sim-{runtime}") for arch in _ARCHES for runtime in _RUNTIMES]
+_ONBOARD_CASES = [
+    pytest.param(
+        arch,
+        runtime,
+        id=f"{arch}-onboard-{runtime}",
+        marks=[pytest.mark.requires_hardware, pytest.mark.platforms([arch])],
+    )
+    for arch in _ARCHES
+    for runtime in _RUNTIMES
+]
+
+
+@pytest.fixture(scope="module")
+def kernel_close_faults(tmp_path_factory):
+    output = tmp_path_factory.mktemp("kernel-close-faults") / "faults.so"
+    subprocess.run(
+        [
+            "c++",
+            "-shared",
+            "-fPIC",
+            "-I" + str(_PROJECT_ROOT / "src/common/log/include"),
+            str(Path(__file__).with_name("kernel_close_faults.cpp")),
+            "-ldl",
+            "-o",
+            str(output),
+        ],
+        check=True,
+    )
+    return output
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _ONBOARD_CASES)
+@pytest.mark.parametrize(
+    "scenario",
+    ["repeat_init", "init_failure", "stream_close", "event_close", "destroy_unclosed", "prepare", "fatal_device"],
+)
+def test_kernel_lifecycle_retry(arch, runtime, scenario, kernel_close_faults, request):
+    _binaries(arch, runtime)
+    device = str(request.config.getoption("--device")).split("-")[0].split(",")[0]
+    env = dict(os.environ)
+    env["LD_PRELOAD"] = str(kernel_close_faults) + (":" + env["LD_PRELOAD"] if env.get("LD_PRELOAD") else "")
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve()), arch, runtime, device, scenario],
+        check=False,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    if scenario == "destroy_unclosed":
+        assert "refusing to destroy an unclosed kernel context" in result.stdout + result.stderr
+
+
+# RUNTIME_ENV_FIELD_GROUPS(3) * RUNTIME_ENV_RING_COUNT(4); the size assertion
+# below is what catches a layout change rather than this constant.
+_RUNTIME_ENV_UINT64_FIELDS = 12
+_OUTPUT_PREFIX_BYTES = 1024
+
+
+class CallConfig(ctypes.Structure):
+    """Mirror of the packed CallConfig the C ABI takes by pointer."""
+
+    _pack_ = 1
+    _fields_ = [
+        ("aicpu_thread_num", ctypes.c_int32),
+        ("enable_chip_swimlane", ctypes.c_int32),
+        ("enable_dump_args", ctypes.c_int32),
+        ("enable_pmu", ctypes.c_int32),
+        ("enable_dep_gen", ctypes.c_int32),
+        ("enable_scope_stats", ctypes.c_int32),
+        ("capture_clock_anchors", ctypes.c_int32),
+        ("runtime_env", ctypes.c_uint64 * _RUNTIME_ENV_UINT64_FIELDS),
+        ("output_prefix", ctypes.c_char * _OUTPUT_PREFIX_BYTES),
+    ]
+
+
+def _load(arch: str, variant: str, runtime: str) -> ctypes.CDLL:
+    path = _PROJECT_ROOT / "build" / "lib" / arch / variant / runtime / "libhost_runtime.so"
+    if not path.exists():
+        pytest.skip(f"{path} not built")
+    if variant == "sim":
+        # A simulated host runtime resolves its device entries against the
+        # simulator context, which the worker normally loads for it.
+        sim_context = _PROJECT_ROOT / "build" / "lib" / "libcpu_sim_context.so"
+        if not sim_context.exists():
+            pytest.skip(f"{sim_context} not built")
+        ctypes.CDLL(str(sim_context), mode=ctypes.RTLD_GLOBAL)  # its hooks resolve by dlsym(RTLD_DEFAULT)
+    # RTLD_LOCAL, as the worker loads it: two runtimes export the same entry
+    # names, so a globally-scoped load makes the second one's calls land in
+    # the first.
+    lib = ctypes.CDLL(str(path), mode=ctypes.RTLD_LOCAL)
+    lib.create_device_context.restype = ctypes.c_void_p
+    lib.create_device_context.argtypes = []
+    lib.destroy_device_context.argtypes = [ctypes.c_void_p]
+    lib.finalize_device.argtypes = [ctypes.c_void_p]
+    lib.finalize_device.restype = ctypes.c_int
+    lib.committed_device_memory_ctx.argtypes = [ctypes.c_void_p]
+    lib.committed_device_memory_ctx.restype = ctypes.c_size_t
+    lib.simpler_kernel_mode_supported.argtypes = [ctypes.c_void_p]
+    lib.simpler_kernel_mode_supported.restype = ctypes.c_int
+    lib.simpler_kernel_mode_init.argtypes = [
+        ctypes.c_void_p, ctypes.c_int,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.POINTER(CallConfig), ctypes.c_uint64,
+    ]  # fmt: skip
+    lib.simpler_kernel_mode_init.restype = ctypes.c_int
+    lib.simpler_kernel_mode_prepare_callable.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int32,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+    ]
+    lib.simpler_kernel_mode_prepare_callable.restype = ctypes.c_int
+    lib.simpler_kernel_mode_launch.argtypes = [ctypes.c_void_p, ctypes.c_int32, ctypes.c_void_p, ctypes.c_void_p]
+    lib.simpler_kernel_mode_launch.restype = ctypes.c_int
+    lib.simpler_init.argtypes = [
+        ctypes.c_void_p, ctypes.c_int,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.c_char_p, ctypes.c_size_t,
+        ctypes.POINTER(CallConfig), ctypes.c_int, ctypes.c_void_p, ctypes.c_uint64,
+    ]  # fmt: skip
+    lib.simpler_init.restype = ctypes.c_int
+    return lib
+
+
+def _minimal_callable_image() -> bytes:
+    """A structurally valid ChipCallable image — the smallest input that gets
+    past argument validation and reaches the ordering verdict."""
+    import ctypes as _ctypes  # noqa: PLC0415
+
+    from simpler.task_interface import ArgDirection, ChipCallable  # noqa: PLC0415
+
+    chip = ChipCallable.build(signature=[ArgDirection.IN], func_name="f", binary=b"\x00", children=[])
+    return _ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+
+
+def _binaries(arch: str, runtime: str) -> tuple[bytes, bytes, bytes]:
+    base = _PROJECT_ROOT / "build" / "lib" / arch / "onboard" / runtime
+    dispatcher = _PROJECT_ROOT / "build" / "lib" / arch / "dispatcher" / "libsimpler_aicpu_dispatcher.so"
+    files = (base / "libaicpu_kernel.so", base / "aicore_kernel.o", dispatcher)
+    for path in files:
+        if not path.exists():
+            pytest.skip(f"{path} not built")
+    return tuple(path.read_bytes() for path in files)  # type: ignore[return-value]
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_kernel_init_rejects_malformed_arguments(arch: str, runtime: str):
+    """Every component runs the same structural validation before its verdict.
+
+    The checks live in one shared header precisely so a stub and a real
+    implementation accept and reject the same arguments; that parity is only
+    provable against the loaded component.
+    """
+    lib = _load(arch, "sim", runtime)
+    config = CallConfig()
+    payload = b"\x00\x01\x02\x03"
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        # A binary and its size describe one object, so a pointer without a
+        # size — or a size without a pointer — is structurally invalid.
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, None, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+            )
+            == PTO_RUNTIME_ERR_INTERNAL
+        )
+        # A negative device and a zero generation are both out of contract.
+        for device_id, generation in ((-1, 1), (0, 0)):
+            assert (
+                lib.simpler_kernel_mode_init(
+                    ctx,
+                    device_id,
+                    payload,
+                    len(payload),
+                    payload,
+                    len(payload),
+                    payload,
+                    len(payload),
+                    ctypes.byref(config),
+                    generation,
+                )  # fmt: skip
+                == PTO_RUNTIME_ERR_INTERNAL
+            )
+        # A null config is rejected before anything else is read.
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), None, 1
+            )
+            == PTO_RUNTIME_ERR_INTERNAL
+        )
+    finally:
+        lib.destroy_device_context(ctx)
+
+
+def _run_lifecycle_retry(arch, runtime, device, scenario):
+    lib = _load(arch, "onboard", runtime)
+    # Caller-owned binding precedes kernel init and the forbidden-call window.
+    lib.rtSetDevice.argtypes = [ctypes.c_int]
+    lib.rtSetDevice.restype = ctypes.c_int
+    assert lib.rtSetDevice(device) == 0
+    aicpu, aicore, dispatcher = _binaries(arch, runtime)
+    config = CallConfig()
+    ctx = lib.create_device_context()
+    init_args = (
+        ctx,
+        device,
+        aicpu,
+        len(aicpu),
+        aicore,
+        len(aicore),
+        dispatcher,
+        len(dispatcher),
+        ctypes.byref(config),
+        1,
+    )
+    faults = ctypes.CDLL(None)
+    faults.bind_test_log.argtypes = [ctypes.c_void_p]
+    faults.bind_test_log.restype = ctypes.c_int
+    assert faults.bind_test_log(lib._handle) == 0
+    faults.arm_destroy_failure.argtypes = [ctypes.c_int]
+    faults.destroy_attempts.restype = ctypes.c_int
+    lib.ensure_acl_ready_ctx.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    lib.ensure_acl_ready_ctx.restype = ctypes.c_int
+    faults.acl_call_count.argtypes = [ctypes.c_int]
+    faults.acl_call_count.restype = ctypes.c_int
+    faults.arm_acl_guard()
+    # Prove each interceptor counts and refuses calls before trusting zeros.
+    forbidden_args = (
+        ("aclInit", ctypes.c_char_p, None),
+        ("aclrtSetDevice", ctypes.c_int, device),
+        ("aclrtResetDevice", ctypes.c_int, device),
+        ("aclrtResetDeviceForce", ctypes.c_int, device),
+        ("aclFinalize", None, None),
+        ("rtDeviceReset", ctypes.c_int, device),
+    )
+    for i, (symbol, argtype, value) in enumerate(forbidden_args):
+        fn = getattr(faults, symbol)
+        fn.argtypes = [] if argtype is None else [argtype]
+        fn.restype = ctypes.c_int
+        assert (fn() if argtype is None else fn(value)) == -4322
+        assert faults.acl_call_count(i) == 1
+    faults.arm_acl_guard()
+    if scenario == "init_failure":
+        faults.arm_destroy_failure(3)
+    assert lib.simpler_kernel_mode_init(*init_args) == (-4321 if scenario == "init_failure" else 0)
+    try:
+        # These exported C++ methods use the Linux Itanium ABI. Resolve the
+        # actual runtime's methods rather than adding production test hooks.
+        force_reset = getattr(lib, "_ZN12DeviceRunner18force_reset_deviceEv")
+        force_reset.argtypes = [ctypes.c_void_p]
+        force_reset.restype = ctypes.c_int
+        assert force_reset(ctx) == PTO_RUNTIME_ERR_UNSUPPORTED
+        assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
+        if scenario == "fatal_device":
+            recover = getattr(lib, "_ZN12DeviceRunner31recover_device_or_mark_unusableEi")
+            recover.argtypes = [ctypes.c_void_p, ctypes.c_int]
+            recover.restype = None
+            accepts = getattr(lib, "_ZNK12DeviceRunner14can_accept_runEv")
+            accepts.argtypes = [ctypes.c_void_p]
+            accepts.restype = ctypes.c_bool
+            assert accepts(ctx)
+            # Inject the drain result, not a real device fault or device reset.
+            # The real recovery method sets device_unusable_ and real finalize
+            # must then take the fatal-device branch.
+            faults.arm_fatal_drain()
+            recover(ctx, 507018)
+            assert faults.fatal_drain_count() == 1
+            assert not accepts(ctx)
+            assert force_reset(ctx) == PTO_RUNTIME_ERR_UNSUPPORTED
+            assert lib.finalize_device(ctx) == 0
+        elif scenario == "destroy_unclosed":
+            lib.destroy_device_context(ctx)
+            assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
+            assert lib.finalize_device(ctx) == 0
+        elif scenario == "prepare":
+            _check_prepare_reuse(lib, ctx, arch, runtime)
+        elif scenario in ("repeat_init", "init_failure"):
+            assert lib.simpler_kernel_mode_init(*init_args) == PTO_RUNTIME_ERR_INVALID_STATE
+            assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
+        else:
+            faults.arm_destroy_failure(1 if scenario == "stream_close" else 2)
+            assert lib.finalize_device(ctx) == -4321
+            first_attempts = faults.destroy_attempts()
+            assert first_attempts > 0
+            assert lib.finalize_device(ctx) == 0
+            assert faults.destroy_attempts() == first_attempts + 1
+    finally:
+        lib.finalize_device(ctx)
+        lib.destroy_device_context(ctx)
+        names = (
+            "aclInit",
+            "aclrtSetDevice",
+            "aclrtResetDevice",
+            "aclrtResetDeviceForce",
+            "aclFinalize",
+            "rtDeviceReset",
+        )
+        assert {name: faults.acl_call_count(i) for i, name in enumerate(names)} == dict.fromkeys(names, 0)
+
+
+def _check_prepare_reuse(lib, ctx, arch, runtime):
+    import tempfile  # noqa: PLC0415
+
+    from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+    from simpler_setup.kernel_compiler import KernelCompiler  # noqa: PLC0415
+
+    with tempfile.TemporaryDirectory(prefix="kernel-prepare-") as build_dir:
+        binary = KernelCompiler(arch).compile_orchestration(
+            runtime, str(Path(__file__).with_name("kernel_prepare_orchestration.cpp")), build_dir=build_dir
+        )
+    chip = ChipCallable.build(signature=[], func_name="kernel_prepare_orchestration", binary=binary, children=[])
+    image = ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+    before = lib.committed_device_memory_ctx(ctx)
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == 0
+    prepared = lib.committed_device_memory_ctx(ctx)
+    assert prepared > before
+    # Duplicate registration is rejected; it must not disturb the first ID.
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) != 0
+    assert lib.committed_device_memory_ctx(ctx) == prepared
+    # Identical bytes deduplicate the callable upload. The second ID also
+    # reuses the context's persistent argument blocks, so neither adds GM.
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 1, image, len(image)) == 0
+    assert lib.committed_device_memory_ctx(ctx) == prepared
+    assert lib.finalize_device(ctx) == 0
+    assert lib.committed_device_memory_ctx(ctx) == 0
+    assert lib.simpler_kernel_mode_prepare_callable(ctx, 2, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_kernel_entries_reject_a_context_with_no_kernel_claim(arch: str, runtime: str):
+    """Structurally valid calls on a context that never claimed kernel mode
+    are an ordering error, not an argument error."""
+    lib = _load(arch, "sim", runtime)
+    image = _minimal_callable_image()
+    stream = ctypes.byref((ctypes.c_uint8 * 8)())
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        assert lib.simpler_kernel_mode_supported(ctx) == 0
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+        assert lib.simpler_kernel_mode_launch(ctx, 0, image, stream) == PTO_RUNTIME_ERR_INVALID_STATE
+        # An out-of-range callable id and a truncated image are argument
+        # errors, so the structural checks run before the ordering one.
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, -1, image, len(image)) == PTO_RUNTIME_ERR_INTERNAL
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, 1) == PTO_RUNTIME_ERR_INTERNAL
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image) - 1) == PTO_RUNTIME_ERR_INTERNAL
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+        assert lib.simpler_kernel_mode_launch(ctx, 0, image, None) == PTO_RUNTIME_ERR_INTERNAL
+    finally:
+        lib.destroy_device_context(ctx)
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_simulated_components_report_kernel_mode_unsupported(arch: str, runtime: str):
+    """A component without kernel-mode execution still validates first, then
+    reports unsupported — it never claims a mode it cannot honor."""
+    lib = _load(arch, "sim", runtime)
+    config = CallConfig()
+    payload = b"\x00"
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+            )
+            == PTO_RUNTIME_ERR_UNSUPPORTED
+        )
+        # The refused init took no claim, so the context is still free.
+        image = _minimal_callable_image()
+        assert lib.simpler_kernel_mode_prepare_callable(ctx, 0, image, len(image)) == PTO_RUNTIME_ERR_INVALID_STATE
+    finally:
+        lib.destroy_device_context(ctx)
+
+
+@pytest.mark.parametrize(("arch", "runtime"), _ONBOARD_CASES)
+def test_kernel_context_brings_up_and_closes_on_a_borrowed_device(arch: str, runtime: str, request):
+    """A kernel context comes up on a device the caller owns, refuses the
+    program-mode entry for the rest of its life, and releases everything it
+    created on close."""
+    lib = _load(arch, "onboard", runtime)
+    aicpu, aicore, dispatcher = _binaries(arch, runtime)
+    config = CallConfig()
+    device_id = int(str(request.config.getoption("--device")).split("-")[0].split(",")[0])
+    lib.rtSetDevice.argtypes = [ctypes.c_int]
+    lib.rtSetDevice.restype = ctypes.c_int
+    assert lib.rtSetDevice(device_id) == 0
+
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx,
+                device_id,
+                aicpu,
+                len(aicpu),
+                aicore,
+                len(aicore),
+                dispatcher,
+                len(dispatcher),
+                ctypes.byref(config),
+                1,
+            )  # fmt: skip
+            == 0
+        )
+        # The claim is exclusive for the context's whole life.
+        assert (
+            lib.simpler_init(
+                ctx,
+                device_id,
+                aicpu,
+                len(aicpu),
+                aicore,
+                len(aicore),
+                dispatcher,
+                len(dispatcher),
+                ctypes.byref(config),
+                0,
+                None,
+                0,
+            )  # fmt: skip
+            == PTO_RUNTIME_ERR_INVALID_STATE
+        )
+        assert lib.finalize_device(ctx) == 0
+    finally:
+        # Destroying after a clean close is allowed; an unclosed kernel
+        # context would be refused and leaked instead.
+        lib.destroy_device_context(ctx)
+
+
+if __name__ == "__main__":
+    _run_lifecycle_retry(sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4])

--- a/tests/ut/py/test_kernel_mode_c_api.py
+++ b/tests/ut/py/test_kernel_mode_c_api.py
@@ -233,6 +233,43 @@ def test_kernel_init_rejects_malformed_arguments(arch: str, runtime: str):
         lib.destroy_device_context(ctx)
 
 
+@pytest.mark.parametrize(("arch", "runtime"), _SIM_CASES)
+def test_kernel_init_rejects_invalid_static_config_without_claim(arch: str, runtime: str):
+    lib = _load(arch, "sim", runtime)
+    config = CallConfig()
+    payload = b"\x00\x01\x02\x03"
+    ctx = lib.create_device_context()
+    assert ctx
+    try:
+        for threads in (-1, 1, 6):
+            config.aicpu_thread_num = threads
+            assert (
+                lib.simpler_kernel_mode_init(
+                    ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+                )
+                == PTO_RUNTIME_ERR_INTERNAL
+            )
+        config.aicpu_thread_num = 0
+        config.enable_dump_args = 1
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+            )
+            == PTO_RUNTIME_ERR_UNSUPPORTED
+        )
+        config.enable_dump_args = 0
+        assert (
+            lib.simpler_kernel_mode_init(
+                ctx, 0, payload, len(payload), payload, len(payload), payload, len(payload), ctypes.byref(config), 1
+            )
+            == PTO_RUNTIME_ERR_UNSUPPORTED
+        )
+        assert lib.committed_device_memory_ctx(ctx) == 0
+        assert lib.simpler_kernel_mode_supported(ctx) == 0
+    finally:
+        lib.destroy_device_context(ctx)
+
+
 def _run_lifecycle_retry(arch, runtime, device, scenario):
     lib = _load(arch, "onboard", runtime)
     # Caller-owned binding precedes kernel init and the forbidden-call window.
@@ -314,6 +351,10 @@ def _run_lifecycle_retry(arch, runtime, device, scenario):
             assert lib.ensure_acl_ready_ctx(ctx, device) == PTO_RUNTIME_ERR_UNSUPPORTED
             assert lib.finalize_device(ctx) == 0
         elif scenario == "prepare":
+            # The caller's packed buffer stops being configuration authority
+            # when init returns; prepare uses its owned, validated snapshot.
+            config.aicpu_thread_num = -1
+            config.enable_dump_args = 1
             _check_prepare_reuse(lib, ctx, arch, runtime)
         elif scenario in ("repeat_init", "init_failure"):
             assert lib.simpler_kernel_mode_init(*init_args) == PTO_RUNTIME_ERR_INVALID_STATE

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -1406,6 +1406,67 @@ class TestChipCallable:
         assert "sig_count=2" in r
         assert "child_count=1" in r
 
+    def test_scalar_count_defaults_to_zero(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN],
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert chip.scalar_count == 0
+
+    def test_scalar_count_keyword_round_trip(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN, ArgDirection.OUT] + [ArgDirection.SCALAR] * 5,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+            scalar_count=5,
+        )
+        assert chip.scalar_count == 5
+
+    def test_scalar_count_survives_from_bytes(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 7,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+            scalar_count=7,
+        )
+        raw = ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+        clone = ChipCallable.from_bytes(raw)
+        assert clone.scalar_count == 7
+
+    def test_scalar_count_out_of_range_reports_value_and_limit(self):
+        for bad in (-1, 129):
+            with pytest.raises(ValueError, match=rf"{bad}.*128"):
+                ChipCallable.build(
+                    signature=[],
+                    func_name="test_func",
+                    binary=b"\x00",
+                    children=[],
+                    scalar_count=bad,
+                )
+
+    def test_scalar_count_disagreeing_with_signature_rejected(self):
+        """A nonzero count is a cached derivation of the signature; zero also
+        means "not recorded" and stays valid with any signature."""
+        with pytest.raises(ValueError, match=r"5.*0.*SCALAR"):
+            ChipCallable.build(
+                signature=[ArgDirection.IN, ArgDirection.OUT],
+                func_name="test_func",
+                binary=b"\x00",
+                children=[],
+                scalar_count=5,
+            )
+        unrecorded = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 3,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert unrecorded.scalar_count == 0
+
 
 # ============================================================================
 # ChipTensor.child_memory

--- a/tools/cann-examples/tmr-invocation-snapshot/device/CMakeLists.txt
+++ b/tools/cann-examples/tmr-invocation-snapshot/device/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+
+cmake_minimum_required(VERSION 3.16)
+project(snapshot_probe_device LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+add_library(snapshot_probe_device SHARED snapshot.cpp)
+target_include_directories(snapshot_probe_device PRIVATE
+    "${ROOT}/src/common" "${ROOT}/src/common/task_interface"
+)
+target_compile_options(snapshot_probe_device PRIVATE -Wall -Wextra -O2 -fPIC)
+target_link_options(snapshot_probe_device PRIVATE -Wl,--build-id)

--- a/tools/cann-examples/tmr-invocation-snapshot/device/snapshot.cpp
+++ b/tools/cann-examples/tmr-invocation-snapshot/device/snapshot.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstring>
+#include <ctime>
+#include "../protocol.h"
+#include "tensormap_and_ringbuffer/kernel_invocation_args.h"
+
+namespace {
+SnapshotProbeInit fixture{};
+uint32_t next_result = 0;
+}  // namespace
+
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_init(void *args) {
+    if (args == nullptr) return 1;
+    std::memcpy(&fixture, args, sizeof(fixture));
+    next_result = 0;
+    return 0;
+}
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *) { return 1; }
+
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_kernel_exec(void *args) {
+    using namespace simpler::tmr;
+    if (args == nullptr || fixture.results_addr == 0 || next_result >= fixture.capacity) return 1;
+    if (fixture.gate_addr == 0) return 1;
+    timespec started{};
+    if (clock_gettime(CLOCK_MONOTONIC, &started) != 0) return 1;
+    // The host releases this test-only gate after destroying every packet.
+    // No invocation bytes are read while the gate is closed.
+    while (*reinterpret_cast<volatile uint32_t *>(fixture.gate_addr) == 0) {
+        timespec now{};
+        if (clock_gettime(CLOCK_MONOTONIC, &now) != 0 || now.tv_sec - started.tv_sec > 30) return 1;
+    }
+    SimplerKernelInvocationHeader header{};
+    std::memcpy(&header, args, sizeof(header));
+    const auto callable = snapshot_probe_callable(header.callable_id);
+    size_t bytes = 0;
+    auto status = tmr_invocation_size(callable, &bytes);
+    TmrInvocationView view;
+    const TmrExecutionBindingView binding{fixture.results_addr, fixture.context_generation};
+    // The formal host adapter submits exactly the independently derived size.
+    // This CPU entry has no API for observing CANN's actual readable byte count.
+    if (status == InvocationStatus::Ok)
+        status = decode_tmr_invocation({static_cast<const uint8_t *>(args), bytes}, callable, binding, &view);
+    uint64_t sum = 0;
+    if (status == InvocationStatus::Ok) {
+        EntryArgsStorage storage{};
+        status = materialize_tmr_entry_args(view, &storage);
+        for (int i = 0; i < storage.tensor_count(); ++i)
+            sum += storage.tensor(i).buffer.addr + storage.tensor(i).numel();
+        for (int i = 0; i < storage.scalar_count(); ++i)
+            sum += storage.scalar(i);
+    }
+    auto *results = reinterpret_cast<volatile SnapshotProbeResult *>(fixture.results_addr);
+    const auto index = next_result++;
+    results[index].sum = sum;
+    results[index].callable_id = header.callable_id;
+    results[index].status = static_cast<int32_t>(status);
+    return status == InvocationStatus::Ok ? 0 : 1;
+}

--- a/tools/cann-examples/tmr-invocation-snapshot/host/CMakeLists.txt
+++ b/tools/cann-examples/tmr-invocation-snapshot/host/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+
+cmake_minimum_required(VERSION 3.16)
+project(snapshot_probe LANGUAGES CXX)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+get_filename_component(ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." ABSOLUTE)
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+if(NOT ASCEND_HOME_PATH)
+    message(FATAL_ERROR "ASCEND_HOME_PATH must be set")
+endif()
+include("${ROOT}/cmake/host_log_sources.cmake")
+add_executable(snapshot_probe probe.cpp
+    "${ROOT}/src/common/aicpu_loader/host/load_aicpu_op.cpp"
+    "${ROOT}/src/common/task_interface/assert_compat.cpp"
+    ${SIMPLER_HOST_LOG_SOURCES}
+)
+target_include_directories(snapshot_probe PRIVATE
+    "${ROOT}/src/common" "${ROOT}/src/common/task_interface"
+    "${ROOT}/src/common/worker" "${ROOT}/src/common/platform/include"
+    "${ROOT}/src/common/log/include" "${ROOT}/src/a2a3/platform/include"
+    "${ASCEND_HOME_PATH}/include" "${ASCEND_HOME_PATH}/pkg_inc"
+    "${ASCEND_HOME_PATH}/pkg_inc/runtime" "${ASCEND_HOME_PATH}/pkg_inc/runtime/runtime"
+    "${ASCEND_HOME_PATH}/pkg_inc/profiling"
+)
+target_link_directories(snapshot_probe PRIVATE "${ASCEND_HOME_PATH}/lib64")
+target_link_libraries(snapshot_probe PRIVATE ascendcl runtime pthread dl)
+target_compile_options(snapshot_probe PRIVATE -Wall -Wextra)

--- a/tools/cann-examples/tmr-invocation-snapshot/host/probe.cpp
+++ b/tools/cann-examples/tmr-invocation-snapshot/host/probe.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <acl/acl.h>
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "../protocol.h"
+#include "platform/onboard/host/tmr_kernel_invocation.h"
+
+namespace {
+void check(int code, const char *operation) {
+    if (code != 0) throw std::runtime_error(std::string(operation) + ": " + std::to_string(code));
+}
+std::vector<uint8_t> read_binary(const char *path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) throw std::runtime_error(std::string("cannot open ") + path);
+    return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+}  // namespace
+
+// Standalone process: owns its ACL setup and result buffer. No TMR execution
+// resources or production registry are created by this transport-only probe.
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        std::fprintf(stderr, "usage: snapshot_probe DEVICE DISPATCHER_SO PROBE_SO\n");
+        return 2;
+    }
+    try {
+        const int device = std::stoi(argv[1]);
+        const auto dispatcher = read_binary(argv[2]);
+        const auto binary = read_binary(argv[3]);
+        check(aclInit(nullptr), "aclInit");
+        check(aclrtSetDevice(device), "aclrtSetDevice");
+        aclrtStream stream = nullptr;
+        check(aclrtCreateStream(&stream), "create stream");
+        aclrtStream release_stream = nullptr;
+        check(aclrtCreateStream(&release_stream), "create release stream");
+        constexpr uint32_t count = 24;
+        void *results = nullptr;
+        check(aclrtMalloc(&results, count * sizeof(SnapshotProbeResult), ACL_MEM_MALLOC_HUGE_FIRST), "alloc results");
+        check(
+            aclrtMemset(results, count * sizeof(SnapshotProbeResult), 0xff, count * sizeof(SnapshotProbeResult)),
+            "initialize result sentinels"
+        );
+        void *gate = nullptr;
+        check(aclrtMalloc(&gate, sizeof(uint32_t), ACL_MEM_MALLOC_HUGE_FIRST), "alloc test gate");
+        check(aclrtMemset(gate, sizeof(uint32_t), 0, sizeof(uint32_t)), "close test gate");
+        {
+            host::LoadAicpuOp loader;
+            check(
+                loader.BootstrapDispatcher(
+                    dispatcher.data(), dispatcher.size(), binary.data(), binary.size(), stream, device
+                ),
+                "bootstrap"
+            );
+            check(loader.Init({simpler::tmr::TmrKernelInvocationName}), "register entries");
+            SnapshotProbeInit init{reinterpret_cast<uint64_t>(results), 13, reinterpret_cast<uint64_t>(gate), count};
+            check(loader.LaunchBuiltInOp(stream, &init, sizeof(init), 1, "simpler_aicpu_init"), "init fixture");
+            check(aclrtSynchronizeStream(stream), "sync prepare");
+
+            std::vector<SnapshotProbeResult> expected;
+            simpler::tmr::TmrEncodingCache caches[3];
+            const simpler::tmr::TmrExecutionBindingView binding{init.results_addr, init.context_generation};
+            for (uint32_t i = 0; i < count; ++i) {
+                const auto callable = snapshot_probe_callable(static_cast<int32_t>(i % 3));
+                ChipStorageTaskArgs args{};
+                uint64_t sum = 0;
+                for (int t = 0; t < callable.tensor_count; ++t) {
+                    const uint32_t shape[] = {1};
+                    const uint64_t addr = init.results_addr + (i % count) * sizeof(SnapshotProbeResult);
+                    args.add_tensor(make_tensor_external(
+                        reinterpret_cast<void *>(addr), shape, 1, DataType::FLOAT32, AddressSpace::DEVICE
+                    ));
+                    sum += addr + 1;
+                }
+                if (callable.scalar_count != 0) {
+                    args.add_scalar(i * 17 + 5);
+                    sum += i * 17 + 5;
+                }
+                simpler::tmr::TmrEncodingCandidate candidate;
+                auto status = simpler::tmr::encode_tmr_invocation(args, callable, binding, caches[i % 3], &candidate);
+                if (status != simpler::kernel::InvocationStatus::Ok) throw std::runtime_error("encode failed");
+                check(
+                    simpler::tmr::enqueue_tmr_invocation_aicpu(loader, stream, 1, candidate, callable, binding),
+                    "enqueue snapshot"
+                );
+                caches[i % 3].commit(std::move(candidate));
+                const auto packet = candidate.packet();
+                std::memset(const_cast<uint8_t *>(packet.data), 0xa5, packet.size);
+                args = {};
+                expected.push_back({sum, callable.callable_id, 0});
+            }
+            check(aclrtMemsetAsync(gate, sizeof(uint32_t), 1, sizeof(uint32_t), release_stream), "release test gate");
+            check(aclrtSynchronizeStream(stream), "sync invocations");
+            check(aclrtSynchronizeStream(release_stream), "sync release");
+            std::vector<SnapshotProbeResult> actual(count);
+            check(
+                aclrtMemcpy(
+                    actual.data(), actual.size() * sizeof(actual[0]), results, actual.size() * sizeof(actual[0]),
+                    ACL_MEMCPY_DEVICE_TO_HOST
+                ),
+                "read results"
+            );
+            for (uint32_t i = 0; i < count; ++i) {
+                if (actual[i].sum != expected[i].sum || actual[i].callable_id != expected[i].callable_id ||
+                    actual[i].status != 0)
+                    throw std::runtime_error("snapshot mismatch at " + std::to_string(i));
+            }
+            std::printf(
+                "PASS: %u gated asynchronous snapshots, minimum/maximum packets, host overwrite+release\n", count
+            );
+        }
+        check(aclrtFree(results), "free results");
+        check(aclrtFree(gate), "free test gate");
+        check(aclrtDestroyStream(release_stream), "destroy release stream");
+        check(aclrtDestroyStream(stream), "destroy stream");
+        check(aclrtResetDevice(device), "reset device");
+        check(aclFinalize(), "aclFinalize");
+        return 0;
+    } catch (const std::exception &error) {
+        std::fprintf(stderr, "FAIL: %s\n", error.what());
+        return 1;
+    }
+}

--- a/tools/cann-examples/tmr-invocation-snapshot/protocol.h
+++ b/tools/cann-examples/tmr-invocation-snapshot/protocol.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+#include <cstdint>
+#include <type_traits>
+#include "task_interface/kernel_invocation_validation.h"
+
+// Test fixtures, published by a separate init task before any invocation.
+struct SnapshotProbeInit {
+    uint64_t results_addr;
+    uint64_t context_generation;
+    uint64_t gate_addr;
+    uint32_t capacity;
+};
+struct SnapshotProbeResult {
+    uint64_t sum;
+    int32_t callable_id;
+    int32_t status;
+};
+static_assert(std::is_trivially_copyable_v<SnapshotProbeInit> && std::is_standard_layout_v<SnapshotProbeInit>);
+static_assert(std::is_trivially_copyable_v<SnapshotProbeResult> && std::is_standard_layout_v<SnapshotProbeResult>);
+
+inline simpler::kernel::PreparedInvocationView snapshot_probe_callable(int32_t id) {
+    switch (id) {
+    case 0:
+        return {0, 0, 0, 1};
+    case 1:
+        return {1, 1, 1, 2};
+    case 2:
+        return {2, CHIP_MAX_TENSOR_ARGS, 0, 3};
+    default:
+        return {-1, 0, 0, 0};
+    }
+}


### PR DESCRIPTION

> Stacked on [#2180](https://github.com/hw-native-sys/simpler/pull/2180) at `b0943525dd8eaeb486bca92bbf5480a37eb61fcb`. The inherited stack contains K1 (#2064), TMR resource contracts (#2177), and the K2 integration from #2176. Review the K5 delta against this fixed K4 baseline; changes inherited from those prerequisites are not K5 additions. The HBG/2b implementation is outside this stack.
>
> This branch labels prerequisite commit subjects by component without changing their trees. Its equivalent K4 parent is `c73001d69b78b84a238b2e78be1102f984f6c0e9`; the K5 commit is [b6435e48](https://github.com/Leaf-Salix/simpler/commit/b6435e4858b1e0443966d664cca478276baefa55). [K5-only diff](https://github.com/Leaf-Salix/simpler/compare/c73001d69b78b84a238b2e78be1102f984f6c0e9...b6435e4858b1e0443966d664cca478276baefa55).
>
> Draft scope: resident-argument preparation and independently testable TMR execution-input consumption. Public kernel execution and graph replay still require the resource providers and execution binder. Reconcile prerequisite changes and rerun the affected validation before merge.

## Motivation

K4 supplies an invocation snapshot, but the TMR executor also needs context-stable configuration and persistent AICore entry arguments. Passing each invocation by rewriting a shared Runtime would mix these lifetimes and undermine asynchronous graph execution.

This PR separates their sources while retaining the existing KernelArgs/Runtime layouts and reusing the executor, scheduler, and K2 resource owner:

```text
init configuration copy
  → prepare-time topology resolution
  → persistent Runtime prefix, register table, and KernelArgs

K4 packet + trusted callable/binding views
  → admission into executor-owned argument storage
  → config and orchestration consume the same invocation
  → scheduler resolves functions through this callable's bounded table
  → existing child task payloads
  → release references after all consumers have finished
```

The two lifetimes remain separate: invocation processing does not update the resident callable ID, function table, or entry-argument fields. Workers and teardown gates remain mutable execution state; this PR does not claim the entire Runtime is immutable.

## Resident contract and execution adaptation

### Context configuration and persistent arguments

`src/common/platform/include/host/kernel_static_config.h` introduces `KernelStaticConfig`, a Host-owned copy of the context request and its generation. Packed input is read through `memcpy`; the caller's configuration pointer is not retained. Invalid thread counts are rejected. Kernel mode snapshots the existing `SIMPLER_TMR_SERIAL_ORCH_SCHED_ENABLE` setting at init; program mode retains its existing configuration behavior.

The first prepare resolves worker/thread counts and architecture-specific affinity before publishing persistent arguments. Later prepares reuse the fixed configuration and resident allocations. Kernel diagnostics requests remain explicitly unsupported, with resident DFX fields zeroed. The a2a3 FFTS fields and a5 SIMT anchor are preserved.

`DeviceRunnerBase::prepare_kernel_callable()` performs topology resolution and runtime-specific static configuration before calling the existing `PersistentKernelArgs::prepare_once()`. Configuration is fixed at the context level, not selected by the first or last registered callable. The prepare ABI does not accept replacement configuration, and invocation consumption does not update it.

The resident TMR upload remains the `DeviceRuntimeLaunchDesc` prefix of Runtime, not its Host-only members. The physical layout is unchanged: callable ID, function table, orchestration arguments, and execution-memory placeholders retain their empty/sentinel values. Their presence in the layout does not make them kernel invocation inputs.

### Persistent ownership and failure recovery

`src/common/platform/onboard/host/kernel_persistent_args.{h,cpp}` retains the existing `PersistentKernelArgs` owner for the Runtime image, register-address table, and device KernelArgs. Its failure handling is tightened:

- Record ownership as allocations succeed, including partial architecture initialization.
- Expose ready arguments only after preparation succeeds completely.
- Revoke readiness on finalize; retain pointers whose release failed for a later close retry.
- Prevent another prepare or allocator-wide cleanup from discarding partially retained ownership.
- Keep abandonment restricted to the existing device-resource invalidation contract.

The a5 kernel topology query also retains its temporary allocation and pending stream after submission/synchronization failure. Cleanup must establish completion before freeing that buffer. A failed free on the successful query path must not publish cached topology or report success. This handling does not reset a caller-owned device.

### TMR-specific invocation views and consumers

`src/common/tensormap_and_ringbuffer/kernel_execution_inputs.h` defines internal borrowed views, not another wire format or resource registry:

| Input | Responsibility |
| --- | --- |
| `KernelBindingView` | Trusted binding identity, resident Runtime, SM/arena regions, and RuntimeContext offset |
| `KernelCallableView` | Trusted callable identity/counts/generation and a bounded CoreCallable address table |
| `ExecutionInputs` | Current callable ID, materialized arguments, function table, and explicit execution-memory sources |

Admission checks region bounds/alignment, size arithmetic, RuntimeContext placement, and function-table bounds before consuming the K4 packet. K4 validates the packet against the independent trusted identities. The provider must already supply a valid initialized image and keep all borrowed resources alive; matching generations alone do not establish lifetime safety. `device_binding_addr` remains opaque.

Each existing AicpuExecutor owns one `KernelInvocationState` with its argument storage. The internal phases are `admit_kernel_execution`, `init_kernel_execution`, `run_kernel_execution`, `kernel_execution_status`, and `release_kernel_execution`. An active invocation rejects replacement; this guard is not a concurrency lock.

```cpp
InvocationStatus admit_kernel_execution(
    ByteSpan packet,
    const KernelCallableView& callable,
    const KernelBindingView& binding) noexcept;
int32_t init_kernel_execution();
int32_t run_kernel_execution();
int32_t kernel_execution_status();
void release_kernel_execution();
```

`KernelInvocationState::admit()` invokes K4's `consume_tmr_invocation()` once and materializes descriptors/scalars into executor-owned `EntryArgsStorage`. It does not copy Tensor data, replace K4 decoding, allocate a per-invocation device buffer, or create a large temporary Runtime on the stack. Failed admission publishes no execution inputs.

The implementations in both `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp` feed these inputs into the existing execution body. HBG does not consume this TMR view or acquire a TMR payload requirement.

Both architectures consume the explicit inputs throughout:

- Config and orchestration use the same callable ID and argument storage.
- Both scheduler handshake initialization stages retain the invocation's function table.
- Initial task counts and execution status use the bound SM, not resident placeholders.
- Ordinary, early, and gated dispatch reject invalid function mappings before publishing work.
- Final orchestration unbinding uses the current callable ID. Release clears scheduler/argument references before clearing invocation storage.

No new public C API, K9/K4 packet layout, device argument pool, or callable manager is introduced.

## Lifecycle and program-path impact

**Execution transaction:** The caller owns the publication and completion protocol around the internal consumer phases:

```text
acquire exclusive use of the executor/workspace
  → obtain independently trusted, live callable and binding views
  → admit and materialize this invocation
  → publish inputs to the execution threads
  → initialize and run the existing TMR consumers
  → complete or cancel execution; join all consumers
  → release borrowed references, then clear invocation storage
allow the next invocation to reuse the executor/workspace
```

**Ownership:** Config and orchestration borrow the same executor-owned argument storage through `orch_args_cached_`. On normal completion, the final execution thread unbinds the current callable's orchestration Runtime. Release resets scheduler references and cached arguments before clearing storage. The provider keeps the resident Runtime, arenas, SM, function table, and callable images alive through their last device use; a generation match is not a retain operation.

**Serialization:** Admission and release require one owner. The runtime DSO's executor is a shared static instance: protection must cover every user of that instance, including mixed program/kernel use, rather than only one context's lock. No additional mutex, registry, or implicit launch synchronization is introduced. A successful native enqueue is not evidence that storage can be reused.

**Program compatibility:** Program entry wrappers continue to obtain their inputs from the original Runtime. Program bind/staging and per-run resource preparation are not redirected through the kernel path. Shared executor/scheduler code is modified, so this is not a claim of zero program-source impact; valid program behavior is covered by regression testing. The a2a3 program cleanup retains its Runtime cache invalidation, while kernel cleanup does not assume that the next invocation will refresh the resident Runtime from Host memory.

**Dependencies:** K2 supplies the resident owner and context facilities; K4 supplies the packet and argument conversion. K3/K10 retain responsibility for execution-resource and callable publication/lifetime. K7/binder supplies platform entry setup, execution ordering, cancellation, completion, and reuse protection. This PR exposes callable consumption phases but does not register an incomplete public device entry. `simpler_kernel_mode_supported()` remains `0`; public launch still rejects execution. Sim kernel init retains its validated unsupported endpoint, and HBG kernel init is not enabled by this TMR change.

## Tests

Results describe the source snapshot published as `b6435e48`. Commit-subject relabeling preserved every source tree; it did not constitute a new test run. These results are not a completed GitHub CI run.

### Coverage added in this PR

- `tests/ut/cpp/common/test_kernel_persistent_args.cpp`: Allocation/copy/partial-architecture failures, retained ownership after failed rollback, readiness revocation, retrying only remaining allocations, and abandonment. Shared owner tests cover TMR/HBG on both architectures.
- `tests/ut/cpp/common/test_kernel_execution_inputs.cpp`: Packed configuration ownership, replacement rejection, binding bounds/alignment, stale identity rejection, unchanged published inputs on failure, program storage borrowing, and empty-Tensor conversion compatibility.
- `tests/ut/cpp/common/test_tmr_scheduler_execution_inputs.cpp`: **6 cases per architecture**, covering both handshake binding sites, A/B/A function selection, ordinary/early/gated payload publication, invalid mappings, and program wrappers.
- `tests/ut/cpp/common/test_tmr_executor_execution_inputs.cpp`: **4 cases per architecture**, covering actual config/orchestration consumption, serial/nonserial A/B/A reuse, failed admission, early init rejection, and config failure followed by release and successful execution of another invocation.
- `tests/ut/cpp/hardware/test_a5_kernel_topology_lifecycle.cpp`: **9 cases** using the real onboard Host implementation with injected runtime operations. They check allocation/copy/launch/sync/free failures, retained ownership, close retries, and the absence of device reset or ACL finalization.
- `tests/ut/py/test_kernel_mode_c_api.py`: Real sim entry checks for invalid and unsupported kernel configuration without enabling execution.

### Validation results

| Validation | Result and scope |
| --- | --- |
| C++ regression matrix | 18 CTest targets passed, covering inherited contracts, four TMR/HBG resident-owner variants, both TMR makers, scheduler/executor consumers, and a5 topology lifecycle |
| Sanitizers | 10 targets passed ASan/UBSan in the closure run |
| Executor failure-reuse supplement | Both architecture targets, now four GTests each, passed normally and under ASan/UBSan; normal execution repeated three times successfully |
| C ABI | 29 passed, 36 deselected; deselected cases are not passes |
| Runtime build and symbols | Eight architecture/platform/runtime components rebuilt and kernel lifecycle symbols checked |
| Program simulation regression | Both architecture sweeps completed successfully; L2 a2a3 HBG: 12 passed/7 skipped, TMR: 30 passed/1 skipped; a5 HBG: 13 passed, TMR: 29 passed |
| Incremental lint | Applicable pre-commit checks passed for the full K5 set and subsequently for the two supplementary test files |

The executor tests compile the real executor, scheduler, runtime, and SO loader. They exercise K4 admission followed by actual config/orchestration calls, serial/nonserial A/B/A reuse, transport-buffer overwrite, and resident-field preservation. The orchestration fixture submits a dependency-only task; actual AICore execution is not claimed. Child function-table selection is covered separately through the real scheduler's ordinary/early/gated paths.

The supplementary tests cover early init configuration rejection and config expected-count mismatch. Both threads return, release runs, and a new invocation succeeds with its own arguments. They do not establish recovery from every partial handshake or asynchronous device cancellation.

Topology fault injection exercises the actual a5 onboard Host implementation without NPU execution. Isolated builds use explicit ccache and four-way parallelism; existing Torch dependencies are not installed or replaced.

### Reproduction

After the repository's isolated build setup, the focused executor tests can be rebuilt and run with:

```bash
export CCACHE_DIR="$PWD/.ccache"
export CMAKE_BUILD_PARALLEL_LEVEL=4
ccache -s
cmake -S tests/ut/cpp -B tests/ut/cpp/build \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
cmake --build tests/ut/cpp/build --parallel 4 \
  --target test_a2a3_tmr_executor_execution_inputs \
           test_a5_tmr_executor_execution_inputs
ctest --test-dir tests/ut/cpp/build --output-on-failure --timeout 60 \
  -R '^test_(a2a3|a5)_tmr_executor_execution_inputs$'
ctest --test-dir tests/ut/cpp/build --output-on-failure --timeout 60 \
  --repeat until-fail:3 \
  -R '^test_(a2a3|a5)_tmr_executor_execution_inputs$'
```

Use a separate build directory with `-fsanitize=address,undefined -fno-omit-frame-pointer` for the sanitizer run. The a5 topology target additionally requires the existing hardware-test CMake option, CANN development dependencies, and the built a5 onboard Host library; its injected Host test does not execute an NPU kernel.

### Remaining acceptance

- A5 silicon execution.
- Public kernel launch with real resource and residency providers.
- ACLGraph capture/replay, cross-stream exclusion, and graph-visible resource release.
- Full-pipeline steady-state HBM behavior and launch-time allocation/copy measurements.

These remain integration acceptance items. Host fixtures, owner counters, and program simulation do not substitute for them. The earlier K4 CPU transport probe is not counted as K5 executor or graph-execution evidence.

## Commits

The K5 implementation is [b6435e48](https://github.com/Leaf-Salix/simpler/commit/b6435e4858b1e0443966d664cca478276baefa55) — `Add: isolate TMR resident and invocation state（K5）`: persistent ownership fixes, immutable context configuration, explicit invocation consumption in both executors/schedulers, and associated tests.

Earlier commits are prerequisite code, with component labels added to their subjects. Their source trees are unchanged:

| Component | Commit in this branch | Original commit |
| --- | --- | --- |
| K1 | `66156ed3` | `dc1268cd` |
| 2a resource requirements | `9e5492b1` | `48e37b3b` |
| 2a interface alignment | `db2553e7` | `2153406a` |
| K4 snapshot foundation | `b5529c89` | `3e822453` |
| K2/K4 integration | `c73001d6` | `b0943525` |

The dependency chain is K1 → {2a, K2} → K4 → this K5 PR. K2's implementation is already included in the K4 integration snapshot; this branch does not introduce a separate K2 merge commit. For a focused review, compare `c73001d6...b6435e48` rather than attributing the entire branch-to-main diff to K5.

## 中文总结

- **合并依赖：** 基于 #2180 的 `b0943525`，包含 K1、2a 和 K2/K4 组合实现。当前 K5 提交为 `b6435e48`；前序提交仅整理标题，代码树不变。等待前置合入后对齐复验，保持 Draft。
- **交付内容：** init 复制 context 配置，prepare 解析硬件拓扑并固定常驻参数；K4 快照转换进入真实 executor，config/orchestration 使用同一份本轮参数，scheduler 两处绑定均使用当前 callable 的函数表。
- **ABI 与解耦：** 保留现有公开 kernel ABI、K9/K4 wire 和 program KernelArgs/Runtime 布局；复用 K2 owner 和原 executor/scheduler，不另建参数池、allocator 或资源管理表。program 保留原数据来源，不能将共享源码改动表述为“完全没有影响面”。
- **生命周期：** 常驻参数准备失败或 free 失败不丢账，撤销可借用状态并支持 close 重试；本轮 storage 在所有消费者结束后才释放引用和复用。generation 检查不代替资源保活，跨 context/跨模式共享 executor 的串行保护由 K7/binder 负责。
- **验证结果：** 收尾矩阵 18 个 C++ target、29 个 ABI 用例、两架构 program sim 回归通过；10 个 target 的 ASan/UBSan 通过。补测后的真实 executor 两架构各 4 个用例，普通、三次重复及 sanitizer 均通过，新增覆盖 init/config 失败后 release 与成功复用。发布前全部修改文件的适用 pre-commit 检查通过，未安装 Torch。
- **未完成范围：** A5 真机、真实 provider 与 K7/binder 接通后的公开 launch、ACLGraph capture/replay、并发取消及 graph 生命周期仍需组合验收。本 PR 提供独立可评审的常驻准备和消费实现，不宣称整条 kernel pipeline 已完成。
