### PR TITLE
Fix: kernel-mode capacity refusals no longer free what they protect (⑤K3)

### DIFF
--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -304,7 +304,9 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
            simpler_unregister_callable, get_pipeline_contract,
            supports_concurrent_native_prepare_ctx,
            get_arena_bank_gm_heap_base_ctx, get_retained_temp_addr_ctx,
-           finalize_device
+           finalize_device, simpler_kernel_mode_supported,
+           simpler_kernel_mode_init, simpler_kernel_mode_prepare_callable,
+           simpler_kernel_mode_launch
     create_device_context() → DeviceContextHandle
     allocate zeroed, aligned, stable native-run storage per pipeline slot
     simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size, ...)

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -445,7 +445,9 @@ non-child tensors, growing it (free old + malloc new) only when a run needs
 more than is currently retained, and bump-slices each tensor from it. The
 buffer lives on the `DeviceRunner` across runs (freed once at finalize); the
 platform only stores its `{addr, size}` slot. If a grow allocation fails the
-run fails before device argument staging. See the runtime's `RUNTIME_LOGIC.md`
+run fails before device argument staging; under a kernel-mode context a run
+that would grow an already-allocated buffer fails there too, since that
+buffer's address is one a captured graph may replay. See the runtime's `RUNTIME_LOGIC.md`
 §2.4 for the grow/reuse mechanics.
 
 ### SUB-type child loop (Python callable leaf)

--- a/docs/user/reference/python-api.md
+++ b/docs/user/reference/python-api.md
@@ -107,12 +107,17 @@ ChipCallable.build(
     func_name="my_orchestration",     # the exported orchestration symbol
     binary=orch_bytes,
     children=[(func_id, core_callable), ...],
+    scalar_count=0,                   # scalar arguments the orchestration expects
 )
 ```
 
 `ArgDirection` is `SCALAR`, `IN`, `OUT`, or `INOUT`. The signature list is
 positional and defines the task-arg order. `func_id` must match the id the
-orchestration submits. `ChipCallable` exposes `binary_size`.
+orchestration submits. `ChipCallable` exposes `binary_size` and
+`scalar_count`. `scalar_count` is a cached derivation of the signature: a
+nonzero value must equal the signature's `SCALAR` entry count or `build`
+raises, while 0 also means "not recorded" — an artifact built before the
+count existed or an orchestration that takes no scalars.
 
 Public `Worker` calls use `TaskArgs` containing address-free `Tensor` views at
 every level. The L2 leaf resolves those views into the internal

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -2690,7 +2690,8 @@ NB_MODULE(_task_interface, m) {
         .def_static(
             "build",
             [](std::vector<ArgDirection> signature, std::string func_name, nb::bytes binary,
-               std::vector<std::tuple<int32_t, PyCoreCallable>> children, std::string config_name) -> PyChipCallable {
+               std::vector<std::tuple<int32_t, PyCoreCallable>> children, std::string config_name,
+               int32_t scalar_count) -> PyChipCallable {
                 auto bin_ptr = reinterpret_cast<const void *>(binary.c_str());
                 auto bin_size = static_cast<uint32_t>(binary.size());
                 auto child_count = static_cast<int32_t>(children.size());
@@ -2703,14 +2704,16 @@ NB_MODULE(_task_interface, m) {
                 }
 
                 auto buf = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-                    signature.data(), static_cast<int32_t>(signature.size()), func_name.c_str(), bin_ptr, bin_size,
-                    func_ids.data(), child_bufs.data(), child_count, config_name.c_str()
+                    signature.data(), static_cast<int32_t>(signature.size()), scalar_count, func_name.c_str(), bin_ptr,
+                    bin_size, func_ids.data(), child_bufs.data(), child_count, config_name.c_str()
                 );
                 return PyChipCallable{std::move(buf)};
             },
             nb::arg("signature"), nb::arg("func_name"), nb::arg("binary"), nb::arg("children"),
-            nb::arg("config_name") = "",
-            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children."
+            nb::arg("config_name") = "", nb::arg("scalar_count") = 0,
+            "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children. "
+            "scalar_count caches the signature's SCALAR entry count; a nonzero value that disagrees with the "
+            "signature raises, and 0 also means the count is not recorded."
         )
 
         .def_static(
@@ -2776,6 +2779,15 @@ NB_MODULE(_task_interface, m) {
                 return std::string(c.config_name(), c.config_name_len());
             },
             "The optional orchestration config function name."
+        )
+
+        .def_prop_ro(
+            "scalar_count",
+            [](const PyChipCallable &self) -> int32_t {
+                return self.get().scalar_count();
+            },
+            "Number of scalar arguments the orchestration expects. 0 also for "
+            "legacy artifacts built before the count was recorded."
         )
 
         .def_prop_ro(

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -64,6 +64,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -148,6 +148,20 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // A kernel-mode context borrows the caller's device and ACL context, so
+    // the ACL lifecycle (aclInit / aclrtSetDevice / aclrtResetDevice[Force] /
+    // aclFinalize) belongs to the caller. Every call site of those APIs falls
+    // into one of three classes: (a) the aclInit / aclrtSetDevice below this
+    // guard, (b) calls inside force_reset_device(), behind its own
+    // kernel-mode guard, or (c) calls gated on acl_ready_, which only the
+    // path below this guard sets. finalize()'s rt-layer device reset on the
+    // acl_ready_ == false path is intercepted by the kernel-mode branch
+    // inside finalize(). Together these keep the caller's device and ACL
+    // state unreachable in kernel mode.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("ensure_acl_ready: refused — a kernel-mode context does not own the caller's ACL lifecycle");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
 
     // aclInit is process-wide; CANN returns ACL_ERROR_REPEAT_INITIALIZE if it
     // has already been initialized (possibly by another owner), which we
@@ -857,6 +871,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -1071,10 +1093,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup performance profiling (including a2a3's dep_gen). Normally
@@ -1121,6 +1148,10 @@ int DeviceRunner::finalize() {
                 if (rc == 0) rc = finalize_rc;
             }
             acl_ready_ = false;
+        } else if (execution_mode_latch().is_kernel()) {
+            // A kernel-mode context borrows the caller's device; the device
+            // reset belongs to the caller, so the healthy close path releases
+            // only context-owned resources.
         } else {
             int reset_rc = rtDeviceReset(device_id_);
             if (reset_rc != 0) {

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/args_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -120,7 +120,11 @@ On each trb bind, `RetainedTempBump`:
   retained size it `device_free`s the old buffer, `device_malloc`s a new one,
   and writes it back via `set_retained_temp_buffer` (no data preserved across
   this grow — the buffer is per-run scratch). Smaller later runs keep the
-  larger buffer; the slot only grows;
+  larger buffer; the slot only grows. Under a kernel-mode context the slot is
+  context-static: the first allocation is taken normally, but a later run
+  needing more than the retained size is refused with
+  `PTO_RUNTIME_ERR_INTERNAL` instead of re-based, because a captured graph
+  replays the slices the buffer already handed out;
 - bump-slices each tensor from the retained base at the next 1024-aligned
   offset. Slices always fit because the buffer was sized from the same
   tensors; a miss is a caller bug (reported, bind fails). The runtime never

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -261,8 +261,9 @@ public:
 
     // Pack the run's non-child, non-empty tensors to compute the required
     // aligned size, then grow the retained slot if it is too small (free old +
-    // malloc new + write back). Returns false only if the (grow) device_malloc
-    // fails. A run needing 0 bytes leaves the slot untouched.
+    // malloc new + write back). Returns false when that device_malloc fails,
+    // and when a kernel-mode context would have to grow a slot that already
+    // holds a buffer. A run needing 0 bytes leaves the slot untouched.
     bool begin(const HostApi *api, const ChipStorageTaskArgs *orch_args) {
         api_ = api;
         offset_ = 0;
@@ -277,6 +278,21 @@ public:
         void *addr = nullptr;
         size_t size = 0;
         api->get_retained_temp_buffer(&addr, &size);
+        if (required > size && addr != nullptr && api->is_kernel_mode()) {
+            // A kernel-mode context's retained buffer keeps its address for the
+            // context's life, and a captured graph replays the slices it handed
+            // out. Growing is free + malloc, which re-bases every one of them,
+            // so the run is refused ahead of the free and the slot stays
+            // exactly as the previous run left it. An empty slot holds no
+            // address to preserve, so the context's first allocation is not a
+            // re-base and is taken normally.
+            LOG_ERROR(
+                "Retained temp buffer is context-static in kernel mode: this run needs %zu bytes, the retained "
+                "buffer holds %zu",
+                required, size
+            );
+            return false;
+        }
         if (required > size) {
             if (addr != nullptr) {
                 api->device_free(addr);

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -69,6 +69,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -107,6 +107,20 @@ int DeviceRunner::ensure_acl_ready(int device_id) {
         LOG_ERROR("ensure_acl_ready: invalid device_id %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // A kernel-mode context borrows the caller's device and ACL context, so
+    // the ACL lifecycle (aclInit / aclrtSetDevice / aclrtResetDevice[Force] /
+    // aclFinalize) belongs to the caller. Every call site of those APIs falls
+    // into one of three classes: (a) the aclInit / aclrtSetDevice below this
+    // guard, (b) calls inside force_reset_device(), behind its own
+    // kernel-mode guard, or (c) calls gated on acl_ready_, which only the
+    // path below this guard sets. finalize()'s rt-layer device reset on the
+    // acl_ready_ == false path is intercepted by the kernel-mode branch
+    // inside finalize(). Together these keep the caller's device and ACL
+    // state unreachable in kernel mode.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("ensure_acl_ready: refused — a kernel-mode context does not own the caller's ACL lifecycle");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
 
     // aclInit is process-wide; CANN returns 100002 if it has already been
     // initialized (possibly by another owner), which we treat as success.
@@ -816,6 +830,14 @@ int DeviceRunner::force_reset_device() {
     if (device_id_ < 0) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+    // aclrtResetDeviceForce would reset the caller's device and ACL context;
+    // a kernel-mode context owns neither (see ensure_acl_ready()), so error
+    // recovery on that path never resets the device out from under the host
+    // process.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("force_reset_device: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
     // aclrtResetDeviceForce is an ACL API; bring ACL up for the whole sequence,
     // released on scope exit so a repeated poison-then-reset cycle in a
     // long-lived process leaks no ACL state.
@@ -956,10 +978,15 @@ int DeviceRunner::finalize() {
         return abandon_rc != 0 ? abandon_rc : reset_rc;
     }
 
-    int rc = attach_current_thread(device_id_);
-    if (rc != 0) {
-        LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
-        return rc;
+    // A kernel-mode context runs on the caller's already-current device, so
+    // this thread needs no bind and the context owns no device state to adopt.
+    int rc = 0;
+    if (!execution_mode_latch().is_kernel()) {
+        rc = attach_current_thread(device_id_);
+        if (rc != 0) {
+            LOG_ERROR("Failed to attach finalize thread to device %d: %d", device_id_, rc);
+            return rc;
+        }
     }
 
     // Cleanup all profiling subsystems (free shm + per-buffer dev/host
@@ -990,6 +1017,10 @@ int DeviceRunner::finalize() {
             if (rc == 0) rc = finalize_rc;
         }
         acl_ready_ = false;
+    } else if (execution_mode_latch().is_kernel()) {
+        // A kernel-mode context borrows the caller's device; the device
+        // reset belongs to the caller, so the healthy close path releases
+        // only context-owned resources.
     } else {
         int reset_rc = rtDeviceReset(device_id_);
         if (reset_rc != 0) {

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/chip_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/host_phase_records.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/kernel_execution_state.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/clock_correlation.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/dep_gen_collector.cpp"

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -121,7 +121,11 @@ On each trb bind, `RetainedTempBump`:
   retained size it `device_free`s the old buffer, `device_malloc`s a new one,
   and writes it back via `set_retained_temp_buffer` (no data preserved across
   this grow — the buffer is per-run scratch). Smaller later runs keep the
-  larger buffer; the slot only grows;
+  larger buffer; the slot only grows. Under a kernel-mode context the slot is
+  context-static: the first allocation is taken normally, but a later run
+  needing more than the retained size is refused with
+  `PTO_RUNTIME_ERR_INTERNAL` instead of re-based, because a captured graph
+  replays the slices the buffer already handed out;
 - bump-slices each tensor from the retained base at the next 1024-aligned
   offset. Slices always fit because the buffer was sized from the same
   tensors; a miss is a caller bug (reported, bind fails). The runtime never

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -261,8 +261,9 @@ public:
 
     // Pack the run's non-child, non-empty tensors to compute the required
     // aligned size, then grow the retained slot if it is too small (free old +
-    // malloc new + write back). Returns false only if the (grow) device_malloc
-    // fails. A run needing 0 bytes leaves the slot untouched.
+    // malloc new + write back). Returns false when that device_malloc fails,
+    // and when a kernel-mode context would have to grow a slot that already
+    // holds a buffer. A run needing 0 bytes leaves the slot untouched.
     bool begin(const HostApi *api, const ChipStorageTaskArgs *orch_args) {
         api_ = api;
         offset_ = 0;
@@ -277,6 +278,21 @@ public:
         void *addr = nullptr;
         size_t size = 0;
         api->get_retained_temp_buffer(&addr, &size);
+        if (required > size && addr != nullptr && api->is_kernel_mode()) {
+            // A kernel-mode context's retained buffer keeps its address for the
+            // context's life, and a captured graph replays the slices it handed
+            // out. Growing is free + malloc, which re-bases every one of them,
+            // so the run is refused ahead of the free and the slot stays
+            // exactly as the previous run left it. An empty slot holds no
+            // address to preserve, so the context's first allocation is not a
+            // re-base and is taken normally.
+            LOG_ERROR(
+                "Retained temp buffer is context-static in kernel mode: this run needs %zu bytes, the retained "
+                "buffer holds %zu",
+                required, size
+            );
+            return false;
+        }
         if (required > size) {
             if (addr != nullptr) {
                 api->device_free(addr);

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -46,11 +46,13 @@ struct HostApiOps {
     // across runs on the DeviceRunner. trb bind reads the slot, and if the
     // retained buffer is too small for this run's packed temporary size it
     // device_free's the old one, device_malloc's a bigger one, and writes the
-    // new {addr, size} back. The grow/pack/slice logic lives in trb bind
-    // (runtime_maker); the platform only remembers the slot so it can be reused
-    // by later runs and freed at finalize. The slot is per pipeline slot, so
-    // two runs in different slots never share a staging buffer. `get` returns
-    // {nullptr, 0} when nothing is retained yet.
+    // new {addr, size} back — except under a kernel-mode context, which refuses
+    // the run instead and leaves the slot untouched, since its buffers keep
+    // their addresses for the life of the context. The grow/pack/slice logic
+    // lives in trb bind (runtime_maker); the platform only remembers the slot
+    // so it can be reused by later runs and freed at finalize. The slot is per
+    // pipeline slot, so two runs in different slots never share a staging
+    // buffer. `get` returns {nullptr, 0} when nothing is retained yet.
     void (*get_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void **addr, size_t *size);
     void (*set_retained_temp_buffer)(void *runner_ctx, uint32_t pipeline_slot, void *addr, size_t size);
     // Runner-owned Graph Definition storage: one device block per pipeline slot
@@ -93,8 +95,15 @@ struct HostApiOps {
     // Commit the three pooled regions (GM heap, runtime shared memory, and
     // prebuilt runtime arena) of the arena bank selected by this run, as three
     // independent device allocations. `runtime_arena_size == 0` skips the
-    // third region. Idempotent on identical sizes; returns 0 on success, -1 on
-    // allocation failure.
+    // third region. Idempotent on identical sizes; returns 0 on success and
+    // PTO_RUNTIME_ERR_INTERNAL on failure.
+    //
+    // The two failures leave the bank in different states. An allocation
+    // failure releases every region and zeroes every size the bank remembers,
+    // so a caller retries from the post-construction state rather than a
+    // partial layout. A kernel-mode context's refusal to re-base or release a
+    // committed region leaves every region exactly as it was, since rolling
+    // that back would free the addresses the refusal exists to hold still.
     int (*setup_static_arena)(
         void *runner_ctx, uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size
     );
@@ -150,6 +159,15 @@ struct HostApiOps {
     bool (*publish_chip_swimlane_extension)(
         void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
     );
+    // This context's execution identity. A captured graph replays the
+    // addresses of the run it captured, so a kernel-mode context's buffers must
+    // not move: the pooled arena regions and the retained temporary buffer are
+    // each sized once and keep their address for the context's life, and the
+    // two sizing paths that would otherwise re-base them read this and refuse
+    // instead. The other device buffers reached through this table do not
+    // consult it — acquire_graph_definition_block still grows by replacement. A
+    // table that does not supply this entry reports program mode.
+    bool (*is_kernel_mode)(void *runner_ctx);
 };
 
 /**
@@ -269,6 +287,14 @@ public:
         } catch (...) {
             return false;
         }
+    }
+    /**
+     * True when this run belongs to a kernel-mode context, whose pooled arena
+     * regions and retained temporary buffer hold their addresses for the life
+     * of the context.
+     */
+    bool is_kernel_mode() const noexcept {
+        return ops_->is_kernel_mode != nullptr && ops_->is_kernel_mode(runner_ctx_);
     }
 
 private:

--- a/src/common/platform/include/host/execution_mode_latch.h
+++ b/src/common/platform/include/host/execution_mode_latch.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <mutex>
+
+#include "execution_mode.h"
+#include "runtime_c_api.h"
+
+/**
+ * Write-once execution identity of one device context.
+ *
+ * A context's mode is a property of its construction, not a state that
+ * evolves: the C ABI creates contexts mode-less (`create_device_context`
+ * takes no parameters), so the first init entry to run completes the
+ * construction by latching the mode, and the latch never changes afterwards
+ * — not on finalize, not on error. `simpler_init` latches PROGRAM before
+ * touching any runner state, so a live program context is never unlatched
+ * and the program/kernel mutual exclusion is enforced on every init, not by
+ * anyone remembering a separate claim step. Re-initializing a finalized
+ * context under the same mode stays possible (latching the held mode is
+ * idempotent); changing a context's identity is not. That permission is real
+ * for PROGRAM, whose finalize resets device_id_ to -1; for KERNEL the latch
+ * would allow the re-latch but KernelExecutionState's phase machine refuses
+ * the re-init, since close() leaves the phase Closed and initialize() accepts
+ * only New.
+ *
+ * There is no unlatch and no rollback: an init that fails after latching
+ * leaves the context on that identity permanently, so a handle from a failed
+ * kernel init can never be recycled into a program context. Latching is
+ * therefore the step an init takes once it has decided which identity it is
+ * constructing, and an init that adopts device state must roll that state
+ * back itself.
+ *
+ * Every kernel-mode guard keys on is_kernel(), which is false until an init
+ * latches KERNEL — so the guards arm exactly when a kernel context comes
+ * into existence.
+ */
+class ExecutionModeLatch {
+public:
+    /** Latch the identity. Idempotent for the held mode; a different mode
+        returns PTO_RUNTIME_ERR_INVALID_STATE. */
+    int latch(SimplerExecutionMode mode) {
+        std::scoped_lock lock(mutex_);
+        if (latched_ && mode_ != mode) return PTO_RUNTIME_ERR_INVALID_STATE;
+        mode_ = mode;
+        latched_ = true;
+        return 0;
+    }
+
+    bool is_kernel() const {
+        std::scoped_lock lock(mutex_);
+        return latched_ && mode_ == SIMPLER_MODE_KERNEL;
+    }
+
+    bool is_latched() const {
+        std::scoped_lock lock(mutex_);
+        return latched_;
+    }
+
+    /** The held mode; meaningful only once is_latched(). */
+    SimplerExecutionMode latched_mode() const {
+        std::scoped_lock lock(mutex_);
+        return mode_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    bool latched_{false};
+    SimplerExecutionMode mode_{SIMPLER_MODE_PROGRAM};
+};

--- a/src/common/platform/include/host/kernel_entry_validation.h
+++ b/src/common/platform/include/host/kernel_entry_validation.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "callable.h"
+#include "callable_protocol.h"
+#include "runtime_c_api.h"
+
+/**
+ * Structural argument validation shared by every host-runtime component's
+ * kernel-mode entries. Both platform c_api implementations (onboard and sim)
+ * route through these checks, so a stub and a real implementation accept and
+ * reject exactly the same arguments — the same parity rule the shared phase
+ * machine follows. Each function returns 0 or PTO_RUNTIME_ERR_INTERNAL and
+ * mutates nothing; logging stays with the callers.
+ */
+
+/* A binary buffer and its size describe one object, so they are valid only
+   present-together or absent-together. */
+inline bool kernel_binary_span_is_consistent(const void *binary, size_t size) {
+    return (binary == nullptr) == (size == 0);
+}
+
+inline int validate_kernel_init_args(
+    const void *ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
+    size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size, const void *config,
+    uint64_t context_generation
+) {
+    if (ctx == nullptr || config == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (device_id < 0 || context_generation == 0) return PTO_RUNTIME_ERR_INTERNAL;
+    if (!kernel_binary_span_is_consistent(aicpu_binary, aicpu_size) ||
+        !kernel_binary_span_is_consistent(aicore_binary, aicore_size) ||
+        !kernel_binary_span_is_consistent(dispatcher_binary, dispatcher_size)) {
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    return 0;
+}
+
+inline int validate_kernel_prepare_callable_args(
+    const void *ctx, int32_t callable_id, const void *callable, size_t callable_size, const void *caller_stream
+) {
+    if (ctx == nullptr || callable == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_size < sizeof(ChipCallable)) return PTO_RUNTIME_ERR_INTERNAL;
+    /* ChipCallable's storage_ is CALLABLE_CHILD_ALIGN-aligned relative to the
+       header, so a misaligned image puts every child at a misaligned address. */
+    if (reinterpret_cast<uintptr_t>(callable) % alignof(ChipCallable) != 0) return PTO_RUNTIME_ERR_INTERNAL;
+    return 0;
+}
+
+inline int
+validate_kernel_launch_args(const void *ctx, int32_t callable_id, const void *args, const void *caller_stream) {
+    if (ctx == nullptr || args == nullptr || caller_stream == nullptr) return PTO_RUNTIME_ERR_INTERNAL;
+    if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) return PTO_RUNTIME_ERR_INTERNAL;
+    return 0;
+}

--- a/src/common/platform/include/host/kernel_execution_state.h
+++ b/src/common/platform/include/host/kernel_execution_state.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+
+#include "runtime_c_api.h"
+
+/**
+ * Runtime operations owned by the kernel-context lifecycle — the complete
+ * vocabulary available to context init and close.
+ *
+ * Deliberately absent from this table: device/stream synchronization, device
+ * reset, ACL finalization, capture queries, model handles, and
+ * stream-to-model attachment. Keeping those operations unrepresentable makes
+ * the host-only lifecycle tests an architectural guard instead of a mock
+ * that can silently exercise forbidden behavior.
+ */
+struct KernelContextOps {
+    void *context{nullptr};
+    int (*get_current_device)(void *context, int *device_id){nullptr};
+    int (*create_hidden_stream)(void *context, void **stream){nullptr};
+    int (*destroy_hidden_stream)(void *context, void *stream){nullptr};
+    int (*create_event)(void *context, void **event){nullptr};
+    int (*destroy_event)(void *context, void *event){nullptr};
+
+    bool valid() const {
+        return get_current_device != nullptr && create_hidden_stream != nullptr && destroy_hidden_stream != nullptr &&
+               create_event != nullptr && destroy_event != nullptr;
+    }
+};
+
+/**
+ * Allocation-free operation table for one borrowed-stream kernel-mode
+ * enqueue — the complete vocabulary available to a launch. Synchronization,
+ * allocation, stream/event creation, capture inspection, and model
+ * attachment cannot be expressed. The opaque context normally points to a
+ * stack snapshot owned by the caller.
+ *
+ * The unrepresentability guarantee binds only launch code that routes every
+ * runtime call through this table; routing through it is the launch
+ * implementation's obligation, and its call-sequence tests are what hold the
+ * obligation.
+ */
+struct KernelLaunchOps {
+    void *context{nullptr};
+    int (*wait_event)(void *context, void *stream, void *event) noexcept {nullptr};
+    int (*memset_handshake)(void *context, void *stream) noexcept {nullptr};
+    int (*record_event)(void *context, void *event, void *stream) noexcept {nullptr};
+    int (*launch_aicpu)(void *context, void *stream) noexcept {nullptr};
+    int (*launch_aicore)(void *context, void *stream) noexcept {nullptr};
+    int (*cancel_waiting_aicore)(void *context, void *stream) noexcept {nullptr};
+
+    bool valid() const {
+        return wait_event != nullptr && memset_handshake != nullptr && record_event != nullptr &&
+               launch_aicpu != nullptr && launch_aicore != nullptr && cancel_waiting_aicore != nullptr;
+    }
+};
+
+enum class KernelContextPhase : uint8_t {
+    New = 0,
+    Initializing,
+    Collecting,
+    ReadyEnqueued,
+    Poisoned,
+    Closing,
+    Closed,
+};
+
+enum class KernelStreamKind : size_t {
+    Aicpu = 0,
+    Aicore,
+    Count,
+};
+
+enum class KernelEventKind : size_t {
+    PrepareTail = 0,
+    Start,
+    AicoreDone,
+    SerialTail,
+    Count,
+};
+
+/**
+ * Context-lifetime state for the borrowed kernel execution mode.
+ *
+ * This object owns the persistent hidden stream pair and event set; every
+ * graph-visible persistent execution resource belongs here rather than in a
+ * per-invocation object. The caller stream is never stored or destroyed —
+ * each launch receives it as a borrowed argument.
+ *
+ * Phase machine:
+ *   New → (initialize) → Collecting ⇄ ReadyEnqueued
+ *   Collecting/ReadyEnqueued → (poison, on partial-enqueue failure) → Poisoned
+ *   Collecting/ReadyEnqueued/Poisoned → (close) → Closing → Closed
+ * Initializing is held only inside initialize()'s critical section and the
+ * lock is released with the phase already past it, so no caller observes it;
+ * close()'s rejection of it is defensive. The stream and event sets are the
+ * launch protocol's shared vocabulary, common to both runtimes, so
+ * initialize() creates all of them unconditionally.
+ *
+ * A pre-enqueue validation failure leaves the phase unchanged. Poisoned
+ * rejects dispatch but still accepts close. Closing is sticky: entered
+ * before the first destructive teardown step, it rejects all dispatch, and a
+ * cleanup failure stays in Closing for explicit close() retry — successfully
+ * destroyed handles are nulled, so a retry redoes only the remainder.
+ *
+ * Error reporting keeps two slots so a controlled runtime error can never
+ * mask a real teardown failure: last_runtime_error() latches the first
+ * poison cause, unexpected_teardown_error() latches the first real cleanup
+ * failure. A caller deciding an overall verdict consults them in that order
+ * before reporting controlled success.
+ *
+ * The destructor performs no runtime calls. If a caller skips explicit close
+ * while an ACLGraph can still reference these handles, freeing them would be
+ * a use-after-free, so the handles leak instead. Refusing to destroy an
+ * unclosed kernel runner is the public C API's half of that contract;
+ * destroy_device_context refuses only on an outstanding native run, so that
+ * refusal does not yet cover an unclosed kernel runner.
+ */
+class KernelExecutionState {
+public:
+    KernelExecutionState() = default;
+    ~KernelExecutionState() = default;
+    KernelExecutionState(const KernelExecutionState &) = delete;
+    KernelExecutionState &operator=(const KernelExecutionState &) = delete;
+
+    int initialize(int requested_device_id, const KernelContextOps &ops);
+    int mark_ready_enqueued();
+    void poison(int runtime_error);
+    int close();
+
+    KernelContextPhase phase() const;
+    bool accepts_dispatch() const;
+    int device_id() const;
+    int last_runtime_error() const;
+    int unexpected_teardown_error() const;
+    bool has_live_resources() const;
+    void *hidden_stream(KernelStreamKind kind) const;
+    void *event(KernelEventKind kind) const;
+
+private:
+    int cleanup_owned_resources_locked();
+    bool has_live_resources_locked() const;
+
+    mutable std::mutex mutex_;
+    KernelContextPhase phase_{KernelContextPhase::New};
+    int device_id_{-1};
+    int last_runtime_error_{0};
+    int unexpected_teardown_error_{0};
+    KernelContextOps ops_{};
+    std::array<void *, static_cast<size_t>(KernelStreamKind::Count)> hidden_streams_{};
+    std::array<void *, static_cast<size_t>(KernelEventKind::Count)> events_{};
+};

--- a/src/common/platform/include/host/static_arena_bank.h
+++ b/src/common/platform/include/host/static_arena_bank.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+
+#include "common/unified_log.h"
+#include "utils/device_arena.h"
+#include "../../../worker/runtime_c_api.h"
+
+/**
+ * The capacity rule for one arena bank's three pooled regions, shared by the
+ * onboard and simulation runners so both hold the same rule rather than two
+ * copies of it.
+ */
+
+/**
+ * One region of a bank: the arena backing it, the size the bank remembers for
+ * it, and the size this call asks for. `cached_size` is updated in place to
+ * whatever the region holds when the call returns.
+ */
+struct StaticArenaRegionRequest {
+    DeviceArena *arena;
+    size_t *cached_size;
+    size_t requested_size;
+};
+
+/** The three regions a bank commits together. */
+struct StaticArenaBankRequest {
+    StaticArenaRegionRequest gm_heap;
+    StaticArenaRegionRequest gm_sm;
+    StaticArenaRegionRequest runtime_pool;
+};
+
+/**
+ * `rc` is 0 or PTO_RUNTIME_ERR_INTERNAL. `bases_changed` is true when any
+ * region was released or (re)committed, so the pooled base addresses handed
+ * out earlier are no longer current and any image keyed on them is stale.
+ */
+struct StaticArenaBankOutcome {
+    int rc{0};
+    bool bases_changed{false};
+};
+
+/**
+ * Commit the bank: grow a region whose request exceeds the remembered size,
+ * release one whose request is zero, and leave one whose request already fits
+ * untouched — so a steady-state caller mutates nothing.
+ *
+ * `kernel_mode` selects the context-static capacity rule. A kernel-mode
+ * context's config never changes, so each region is committed at most once and
+ * is neither grown nor released afterwards: a captured graph replays the base
+ * address the region held when it was captured. A request that would re-base
+ * or release a committed region is therefore an internal invariant break, not
+ * caller-configurable behavior, and is refused with PTO_RUNTIME_ERR_INTERNAL.
+ *
+ * The refusal is the one failure that leaves the bank exactly as it was. Every
+ * other failure rolls the whole bank back — releasing each region and zeroing
+ * its cached size, peers from earlier successful calls included, so a caller
+ * that retries starts from the post-construction state rather than a partial
+ * layout. Rolling a refusal back would free the very base addresses the rule
+ * exists to hold still, so the two failures cannot share one exit.
+ */
+inline StaticArenaBankOutcome commit_static_arena_bank(const StaticArenaBankRequest &request, bool kernel_mode) {
+    const StaticArenaRegionRequest regions[] = {request.gm_heap, request.gm_sm, request.runtime_pool};
+    StaticArenaBankOutcome outcome;
+    bool capacity_refused = false;
+
+    for (const StaticArenaRegionRequest &region : regions) {
+        DeviceArena &arena = *region.arena;
+        size_t &cached_size = *region.cached_size;
+        const size_t requested_size = region.requested_size;
+
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            capacity_refused = true;
+            outcome.rc = PTO_RUNTIME_ERR_INTERNAL;
+            break;
+        }
+        if (requested_size == 0) {
+            // hbg's runtime_arena path: caller passed 0 and never reserved a
+            // region. Leave the arena uncommitted; acquire_pooled_* will
+            // return nullptr.
+            if (arena.is_committed() && cached_size != 0) {
+                arena.release();
+                cached_size = 0;
+                outcome.bases_changed = true;
+            }
+            continue;
+        }
+        if (arena.is_committed() && requested_size <= cached_size) {
+            continue;
+        }
+        arena.release();
+        cached_size = 0;
+        outcome.bases_changed = true;
+        arena.reserve(requested_size, DeviceArena::kDefaultBaseAlign);
+        if (arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
+            // release() is idempotent on an arena whose commit() failed — it
+            // zeroes cursor_ and frees nothing — so the rollback below releases
+            // every region unconditionally rather than testing each one.
+            arena.release();
+            outcome.rc = PTO_RUNTIME_ERR_INTERNAL;
+            break;
+        }
+        cached_size = requested_size;
+    }
+
+    if (outcome.rc != 0 && !capacity_refused) {
+        for (const StaticArenaRegionRequest &region : regions) {
+            region.arena->release();
+            *region.cached_size = 0;
+        }
+        outcome.bases_changed = true;
+    }
+    return outcome;
+}

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -25,9 +25,11 @@
  */
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "runtime_c_api.h"
 #include "task_args_wire.h"
@@ -437,6 +439,17 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
 
     // CANN dlog must be levelled BEFORE the device context is opened
     // (rtSetDevice inside attach_current_thread): CANN snapshots the
@@ -1199,6 +1212,49 @@ int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     } catch (...) {
         return PTO_RUNTIME_ERR_INTERNAL;
     }
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * This backend reports kernel mode unsupported: supported() is 0 and init
+ * refuses after the shared structural validation, so no context here ever
+ * latches kernel mode and prepare/launch reject with INVALID_STATE.
+ * Argument validation is shared with every other component through
+ * kernel_entry_validation.h, so an argument this stub accepts is one a real
+ * implementation accepts.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by this host runtime");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -241,6 +241,10 @@ static uint32_t get_chip_swimlane_level(void *runner_ctx) {
     return static_cast<DeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
 }
 
+static bool is_kernel_mode(void *runner_ctx) {
+    return runner_ctx != nullptr && static_cast<DeviceRunnerBase *>(runner_ctx)->execution_mode_latch().is_kernel();
+}
+
 static bool publish_chip_swimlane_extension(
     void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
 ) {
@@ -360,6 +364,7 @@ static const HostApiOps g_host_api_ops = {
     .host_phase_pool_arm = host_phase_pool_arm,
     .host_phase_pool_finish = host_phase_pool_finish,
     .publish_chip_swimlane_extension = publish_chip_swimlane_extension,
+    .is_kernel_mode = is_kernel_mode,
 };
 
 /* ===========================================================================

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -373,7 +373,26 @@ int DeviceRunnerBase::setup_static_arena(
     ArenaBank &bank = this->arena_bank(arena_bank);
 
     bool arena_changed = false;
-    auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+    // A kernel-mode context's config is context-static, so each region is
+    // committed at most once and never grown or released afterwards; captured
+    // graphs may hold the committed base address. A request that would
+    // re-base or release a committed region under kernel mode is therefore an
+    // internal invariant break, not caller-configurable behavior. The refusal
+    // is not self-contained: the caller collapses a nonzero return to
+    // `ok = false` and then releases all three regions unconditionally, and
+    // DeviceArena::release() frees the backing buffer — so a fired guard drops
+    // the very base addresses it names.
+    const bool kernel_mode = execution_mode_latch().is_kernel();
+    auto commit_region = [&arena_changed,
+                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (requested_size == 0) {
             // hbg's runtime_arena path: caller passed 0 and never reserved
             // a region. Leave the arena uncommitted; acquire_pooled_* will
@@ -441,6 +460,10 @@ int DeviceRunnerBase::setup_static_arena(
 }
 
 std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
+    // A freshly spawned thread carries no CANN device context of its own, so
+    // this bind creates one rather than taking anything from the caller — it
+    // is the one rtSetDevice a borrowed-device context still owns, and it is
+    // scoped to a thread this runner created.
     int dev_id = device_id_;
     return std::thread([dev_id, fn = std::move(fn)]() {
         rtSetDevice(dev_id);
@@ -448,7 +471,7 @@ std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {
     });
 }
 
-int DeviceRunnerBase::attach_current_thread(int device_id) {
+int DeviceRunnerBase::bind_current_thread(int device_id) {
     if (device_id < 0) {
         LOG_ERROR("Invalid device_id: %d", device_id);
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -468,13 +491,57 @@ int DeviceRunnerBase::attach_current_thread(int device_id) {
         ACL_LOG_ERROR_DETAIL(rc);
         return rc;
     }
+    return 0;
+}
 
-    // simpler_init performs the only lifetime write. Prepared-run admission
-    // and execution subsequently attach different host threads, so repeated
-    // same-value writes here would still be a C++ data race.
+int DeviceRunnerBase::attach_current_thread(int device_id) {
+    // rtSetDevice and the op-execute watchdog below are acts of device
+    // ownership, so this entry belongs to a program context. A kernel context
+    // reaches its device through adopt_borrowed_device instead; the one caller
+    // here that runs under both identities is DeviceRunner::finalize(), which
+    // skips this call on a kernel latch.
+    if (execution_mode_latch().is_kernel()) {
+        LOG_ERROR("attach_current_thread: refused — a kernel-mode context does not own the caller's device");
+        return PTO_RUNTIME_ERR_UNSUPPORTED;
+    }
+
+    int rc = bind_current_thread(device_id);
+    if (rc != 0) return rc;
+
+    // Both writers of device_id_ — this one and adopt_borrowed_device — guard
+    // on the still-unset value, and both run before any prepare, execution or
+    // collector thread attaches. Prepared-run admission and execution
+    // subsequently attach different host threads, so repeated same-value
+    // writes here would still be a C++ data race.
     if (device_id_ == -1) {
         timeout_config_ = resolve_onboard_timeout_config();
         configure_aicore_op_timeout();
+        device_id_ = device_id;
+    }
+    return 0;
+}
+
+int DeviceRunnerBase::adopt_borrowed_device(int device_id) {
+    // The caller already holds this device current on its own threads, so the
+    // only thing a kernel context takes from it is the identity: no
+    // rtSetDevice, and no configure_aicore_op_timeout, which would rewrite the
+    // op-execute watchdog for every other user of that card. Resolving the
+    // timeout config is pure environment parsing and stays, because the stream
+    // and scheduler timeouts derived from it are read on both identities.
+    if (!execution_mode_latch().is_kernel()) {
+        LOG_ERROR("adopt_borrowed_device: refused — the context has not latched kernel mode");
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    if (device_id < 0) {
+        LOG_ERROR("Invalid device_id: %d", device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ != -1 && device_id_ != device_id) {
+        LOG_ERROR("DeviceRunner already on device %d; close before adopting device %d", device_id_, device_id);
+        return PTO_RUNTIME_ERR_INTERNAL;
+    }
+    if (device_id_ == -1) {
+        timeout_config_ = resolve_onboard_timeout_config();
         device_id_ = device_id;
     }
     return 0;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -47,6 +47,7 @@
 #include "host/acl_error_log.h"
 #include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
+#include "host/static_arena_bank.h"
 #include "host_log.h"
 #include "platform_comm/comm.h"
 #include "runtime_c_api.h"
@@ -365,90 +366,18 @@ int DeviceRunnerBase::setup_static_arena(
     // combined size can exceed the device allocator's largest contiguous
     // block. Each arena commits exactly one region, so its base() is the
     // pooled pointer the caller wants.
-    //
-    // Idempotent for the production case (sizes do not change across a
-    // worker's lifetime). If a caller asks for a larger layout on any
-    // region, redo just that region — already-committed peers stay alive
-    // so their callers don't have to re-acquire.
     ArenaBank &bank = this->arena_bank(arena_bank);
 
-    bool arena_changed = false;
-    // A kernel-mode context's config is context-static, so each region is
-    // committed at most once and never grown or released afterwards; captured
-    // graphs may hold the committed base address. A request that would
-    // re-base or release a committed region under kernel mode is therefore an
-    // internal invariant break, not caller-configurable behavior. The refusal
-    // is not self-contained: the caller collapses a nonzero return to
-    // `ok = false` and then releases all three regions unconditionally, and
-    // DeviceArena::release() frees the backing buffer — so a fired guard drops
-    // the very base addresses it names.
-    const bool kernel_mode = execution_mode_latch().is_kernel();
-    auto commit_region = [&arena_changed,
-                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
-        if (kernel_mode && arena.is_committed() &&
-            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
-            LOG_ERROR(
-                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
-                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
-            );
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        if (requested_size == 0) {
-            // hbg's runtime_arena path: caller passed 0 and never reserved
-            // a region. Leave the arena uncommitted; acquire_pooled_* will
-            // return nullptr.
-            if (arena.is_committed() && cached_size != 0) {
-                arena.release();
-                cached_size = 0;
-                arena_changed = true;
-            }
-            return 0;
-        }
-        if (arena.is_committed() && requested_size <= cached_size) {
-            return 0;
-        }
-        arena.release();
-        cached_size = 0;
-        arena_changed = true;
-        arena.reserve(requested_size, DeviceArena::kDefaultBaseAlign);
-        if (arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
-            // commit() failure leaves committed_=false, so the next entry's
-            // is_committed() guard skips the release branch. release() is
-            // idempotent on a never-committed arena (zeroes cursor_).
-            arena.release();
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        cached_size = requested_size;
-        return 0;
+    const StaticArenaBankRequest request{
+        {&bank.gm_heap, &bank.cached_gm_heap_size, gm_heap_size},
+        {&bank.gm_sm, &bank.cached_gm_sm_size, gm_sm_size},
+        {&bank.runtime_pool, &bank.cached_runtime_arena_size, runtime_arena_size},
     };
-    // Try to commit all three regions; on any failure, fully roll back —
-    // including any earlier-committed peers from a PRIOR successful call.
-    // The simpler "only roll back peers from this call" pattern would
-    // leave stale committed regions when a re-init (e.g., later worker
-    // asking for a larger layout) fails midway, defeating the
-    // "failure means failure" guarantee. Reset everything to the
-    // post-construction state so the caller can retry with a new layout.
-    bool ok = commit_region(bank.gm_heap, bank.cached_gm_heap_size, gm_heap_size) == 0;
-    ok = ok && commit_region(bank.gm_sm, bank.cached_gm_sm_size, gm_sm_size) == 0;
-    ok = ok && commit_region(bank.runtime_pool, bank.cached_runtime_arena_size, runtime_arena_size) == 0;
-    if (!ok) {
-        bank.gm_heap.release();
-        bank.gm_sm.release();
-        bank.runtime_pool.release();
-        bank.cached_gm_heap_size = 0;
-        bank.cached_gm_sm_size = 0;
-        bank.cached_runtime_arena_size = 0;
-        if (arena_bank == 0) {
-            prebuilt_runtime_arena_cache_valid_ = false;
-            prebuilt_runtime_arena_cache_key_.clear();
-            prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;
-            prebuilt_runtime_arena_cache_sm_base_ = nullptr;
-            prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
-            prebuilt_runtime_arena_cache_image_.clear();
-        }
-        return PTO_RUNTIME_ERR_INTERNAL;
-    }
-    if (arena_changed && arena_bank == 0) {
+    const StaticArenaBankOutcome outcome = commit_static_arena_bank(request, execution_mode_latch().is_kernel());
+    // The cache keys an assembled image to the bases it was built for, so it
+    // outlives exactly those calls that moved nothing. Only bank 0 has bases
+    // in it.
+    if (outcome.bases_changed && arena_bank == 0) {
         prebuilt_runtime_arena_cache_valid_ = false;
         prebuilt_runtime_arena_cache_key_.clear();
         prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;
@@ -456,7 +385,7 @@ int DeviceRunnerBase::setup_static_arena(
         prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
         prebuilt_runtime_arena_cache_image_.clear();
     }
-    return 0;
+    return outcome.rc;
 }
 
 std::thread DeviceRunnerBase::create_thread(std::function<void()> fn) {

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -19,8 +19,9 @@
  *   - The trivial tensor-memory wrappers (`allocate_tensor`,
  *     `free_tensor`, `copy_*_device`).
  *   - The arena-pool accessors (`acquire_pooled_gm_heap`, etc.).
- *   - Device lifecycle: `attach_current_thread`,
- *     `configure_aicore_op_timeout`, `ensure_device_initialized`,
+ *   - Device lifecycle: `bind_current_thread`, `attach_current_thread`,
+ *     `adopt_borrowed_device`, `configure_aicore_op_timeout`,
+ *     `ensure_device_initialized`,
  *     `ensure_binaries_loaded`, persistent AICPU/AICore streams,
  *     dispatcher/executor bytes, `LoadAicpuOp`, `KernelArgsHelper`.
  *   - block_dim resolution: `query_max_block_dim`, `resolve_block_dim`.
@@ -65,6 +66,7 @@
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -133,6 +135,15 @@ public:
      * distinct buffers; tests read this to prove the split is real.
      */
     uint64_t retained_temp_addr(uint32_t slot_id) const;
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. Every kernel-mode guard on the ACL-lifecycle and arena
+     * paths keys on is_kernel(); `attach_current_thread` refuses outright on a
+     * kernel latch, which is what keeps the program-mode entries and the
+     * per-thread device bind off a borrowed device.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
 
     /** Allocate / free / copy on the per-Worker `MemoryAllocator` + CANN runtime. */
     void *allocate_tensor(std::size_t bytes);
@@ -215,17 +226,37 @@ public:
     std::thread create_thread(std::function<void()> fn);
 
     /**
-     * Attach the current host thread to the target device.
+     * Bind the calling thread to a device, taking nothing else from it.
      *
-     * Required before host-side runtime initialization may allocate or
-     * free device memory on the current thread. Idempotent for the same
-     * id; errors if called with a different id after a prior attach.
-     * No streams are created here.
+     * Idempotent for the same id; errors if called with a different id after
+     * a prior adopt. Creates no streams and records no identity.
+     *
+     * @param device_id  Device ID (0-15)
+     * @return 0 on success, error code on failure.
+     */
+    int bind_current_thread(int device_id);
+
+    /**
+     * Bind the current host thread and adopt the device for a program
+     * context: on the first call it also resolves the timeout config, writes
+     * the card's op-execute watchdog, and records device_id_.
+     *
+     * Required before host-side runtime initialization may allocate or free
+     * device memory on the current thread. Refuses with
+     * PTO_RUNTIME_ERR_UNSUPPORTED on a context latched to kernel mode, which
+     * owns neither the bind nor the watchdog.
      *
      * @param device_id  Device ID (0-15)
      * @return 0 on success, error code on failure.
      */
     int attach_current_thread(int device_id);
+    /**
+     * Record which device a kernel-mode context runs on. Takes no device side
+     * effect: the caller already holds the device current, so this neither
+     * binds the thread nor touches the card's op-execute watchdog. Requires
+     * the execution-mode latch to already read kernel.
+     */
+    int adopt_borrowed_device(int device_id);
 
     /**
      * One-shot device initialization. Performs, in order:
@@ -303,7 +334,7 @@ public:
         sdma_warmup_binary_ = std::move(sdma_warmup_binary);
     }
 
-    /** The device id captured by simpler_init's `attach_current_thread` call. */
+    /** Which device this context is on; -1 until an init entry adopts one. */
     int device_id() const { return device_id_; }
 
     /**
@@ -1176,9 +1207,16 @@ protected:
 
     // ---- State shared by both a2a3 and a5 ---------------------------------
     //
-    // `device_id_` is written once by simpler_init and is immutable while
-    // native prepare, execution, and collector threads attach to the runner.
+    // Which device this context is on — not a claim of ownership, which the
+    // execution-mode latch carries instead. Written once before any prepare,
+    // execution or collector thread attaches: `attach_current_thread` writes
+    // it for a program context and `adopt_borrowed_device` for a kernel one, both
+    // guarded on the still-unset value, so repeated same-value writes from
+    // later-attaching threads cannot race.
     int device_id_{-1};
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -138,10 +138,12 @@ public:
 
     /**
      * This context's execution identity, latched once by whichever init entry
-     * constructs it. Every kernel-mode guard on the ACL-lifecycle and arena
-     * paths keys on is_kernel(); `attach_current_thread` refuses outright on a
-     * kernel latch, which is what keeps the program-mode entries and the
-     * per-thread device bind off a borrowed device.
+     * constructs it. Every kernel-mode guard on the ACL-lifecycle and capacity
+     * paths keys on is_kernel() — the pooled arena regions here, and the trb
+     * retained temporary buffer through HostApiOps::is_kernel_mode, which
+     * carries this same latch into runtime code. `attach_current_thread`
+     * refuses outright on a kernel latch, which is what keeps the program-mode
+     * entries and the per-thread device bind off a borrowed device.
      */
     ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
 
@@ -187,15 +189,19 @@ public:
      * is 0 for the hbg path (no prebuilt runtime arena) — the
      * corresponding arena stays uncommitted.
      *
-     * On failure to commit a later region, earlier committed regions are
-     * rolled back (a5's prior semantics). This is the safer default: a
+     * An allocation failure on any region rolls the whole bank back,
+     * earlier committed peers included. This is the safer default: a
      * partial commit otherwise leaves the caller with pooled pointers
      * that survive a "failure" return, masking the real error and risking
-     * later mismatched-arena bugs. (The a2a3 implementation that
-     * previously kept earlier committed peers alive on failure is
-     * normalized away.)
+     * later mismatched-arena bugs.
      *
-     * @return 0 on success, -1 on failure.
+     * A kernel-mode context's refusal to re-base or release a committed
+     * region is the one failure that does not roll back — every region
+     * stays committed and every cached size stays intact, because the
+     * rollback would free the addresses the refusal exists to hold still.
+     * A caller distinguishes the two by mode, not by the return code.
+     *
+     * @return 0 on success, PTO_RUNTIME_ERR_INTERNAL on failure.
      */
     int setup_static_arena(uint32_t arena_bank, size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
 

--- a/src/common/platform/shared/host/kernel_execution_state.cpp
+++ b/src/common/platform/shared/host/kernel_execution_state.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/kernel_execution_state.h"
+
+int KernelExecutionState::initialize(int requested_device_id, const KernelContextOps &ops) {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::New) return PTO_RUNTIME_ERR_INVALID_STATE;
+    if (requested_device_id < 0 || !ops.valid()) return PTO_RUNTIME_ERR_INTERNAL;
+
+    int current_device = -1;
+    int rc = ops.get_current_device(ops.context, &current_device);
+    if (rc != 0) return rc;
+    if (current_device != requested_device_id) return PTO_RUNTIME_ERR_INVALID_STATE;
+
+    phase_ = KernelContextPhase::Initializing;
+    ops_ = ops;
+    device_id_ = requested_device_id;
+
+    for (auto &stream : hidden_streams_) {
+        rc = ops_.create_hidden_stream(ops_.context, &stream);
+        if (rc != 0) break;
+    }
+    if (rc == 0) {
+        for (auto &event : events_) {
+            rc = ops_.create_event(ops_.context, &event);
+            if (rc != 0) break;
+        }
+    }
+    if (rc != 0) {
+        const int cleanup_rc = cleanup_owned_resources_locked();
+        if (cleanup_rc != 0) {
+            if (unexpected_teardown_error_ == 0) unexpected_teardown_error_ = cleanup_rc;
+            phase_ = KernelContextPhase::Closing;
+        } else {
+            phase_ = KernelContextPhase::New;
+            device_id_ = -1;
+            ops_ = {};
+        }
+        return rc;
+    }
+
+    phase_ = KernelContextPhase::Collecting;
+    return 0;
+}
+
+int KernelExecutionState::mark_ready_enqueued() {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::Collecting && phase_ != KernelContextPhase::ReadyEnqueued) {
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    }
+    phase_ = KernelContextPhase::ReadyEnqueued;
+    return 0;
+}
+
+void KernelExecutionState::poison(int runtime_error) {
+    std::scoped_lock lock(mutex_);
+    if (phase_ != KernelContextPhase::Collecting && phase_ != KernelContextPhase::ReadyEnqueued) return;
+    phase_ = KernelContextPhase::Poisoned;
+    if (last_runtime_error_ == 0) last_runtime_error_ = runtime_error;
+}
+
+int KernelExecutionState::close() {
+    std::scoped_lock lock(mutex_);
+    switch (phase_) {
+    case KernelContextPhase::New:
+        phase_ = KernelContextPhase::Closed;
+        return 0;
+    case KernelContextPhase::Closed:
+        return 0;
+    case KernelContextPhase::Initializing:
+        return PTO_RUNTIME_ERR_INVALID_STATE;
+    case KernelContextPhase::Collecting:
+    case KernelContextPhase::ReadyEnqueued:
+    case KernelContextPhase::Poisoned:
+    case KernelContextPhase::Closing:
+        break;
+    }
+    phase_ = KernelContextPhase::Closing;
+    const int rc = cleanup_owned_resources_locked();
+    if (rc != 0) {
+        if (unexpected_teardown_error_ == 0) unexpected_teardown_error_ = rc;
+        return rc;
+    }
+    phase_ = KernelContextPhase::Closed;
+    return 0;
+}
+
+int KernelExecutionState::cleanup_owned_resources_locked() {
+    int first_error = 0;
+    for (size_t i = events_.size(); i > 0; --i) {
+        void *&event = events_[i - 1];
+        if (event == nullptr) continue;
+        const int rc = ops_.destroy_event(ops_.context, event);
+        if (rc != 0) {
+            if (first_error == 0) first_error = rc;
+            continue;
+        }
+        event = nullptr;
+    }
+    for (size_t i = hidden_streams_.size(); i > 0; --i) {
+        void *&stream = hidden_streams_[i - 1];
+        if (stream == nullptr) continue;
+        const int rc = ops_.destroy_hidden_stream(ops_.context, stream);
+        if (rc != 0) {
+            if (first_error == 0) first_error = rc;
+            continue;
+        }
+        stream = nullptr;
+    }
+    return first_error;
+}
+
+KernelContextPhase KernelExecutionState::phase() const {
+    std::scoped_lock lock(mutex_);
+    return phase_;
+}
+
+bool KernelExecutionState::accepts_dispatch() const {
+    std::scoped_lock lock(mutex_);
+    return phase_ == KernelContextPhase::Collecting || phase_ == KernelContextPhase::ReadyEnqueued;
+}
+
+int KernelExecutionState::device_id() const {
+    std::scoped_lock lock(mutex_);
+    return device_id_;
+}
+
+int KernelExecutionState::last_runtime_error() const {
+    std::scoped_lock lock(mutex_);
+    return last_runtime_error_;
+}
+
+int KernelExecutionState::unexpected_teardown_error() const {
+    std::scoped_lock lock(mutex_);
+    return unexpected_teardown_error_;
+}
+
+bool KernelExecutionState::has_live_resources() const {
+    std::scoped_lock lock(mutex_);
+    return has_live_resources_locked();
+}
+
+bool KernelExecutionState::has_live_resources_locked() const {
+    for (void *stream : hidden_streams_) {
+        if (stream != nullptr) return true;
+    }
+    for (void *event : events_) {
+        if (event != nullptr) return true;
+    }
+    return false;
+}
+
+void *KernelExecutionState::hidden_stream(KernelStreamKind kind) const {
+    std::scoped_lock lock(mutex_);
+    return hidden_streams_[static_cast<size_t>(kind)];
+}
+
+void *KernelExecutionState::event(KernelEventKind kind) const {
+    std::scoped_lock lock(mutex_);
+    return events_[static_cast<size_t>(kind)];
+}

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -224,6 +224,10 @@ static uint32_t get_chip_swimlane_level(void *runner_ctx) {
     return static_cast<SimDeviceRunnerBase *>(runner_ctx)->chip_swimlane_level();
 }
 
+static bool is_kernel_mode(void *runner_ctx) {
+    return runner_ctx != nullptr && static_cast<SimDeviceRunnerBase *>(runner_ctx)->execution_mode_latch().is_kernel();
+}
+
 static bool publish_chip_swimlane_extension(
     void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
 ) {
@@ -344,6 +348,7 @@ static const HostApiOps g_host_api_ops = {
     .host_phase_pool_arm = host_phase_pool_arm,
     .host_phase_pool_finish = host_phase_pool_finish,
     .publish_chip_swimlane_extension = publish_chip_swimlane_extension,
+    .is_kernel_mode = is_kernel_mode,
 };
 
 /* ===========================================================================

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -24,9 +24,11 @@
 #include "runtime_c_api.h"
 
 #include "callable.h"
+#include "callable_protocol.h"
 #include "call_config.h"
 #include "device_runner_base.h"
 #include "host/dep_gen_collector.h"  // make_deps_json_path
+#include "host/kernel_entry_validation.h"
 #include "prepare_callable_common.h"
 #include "task_args_wire.h"
 #include "native_run_context.h"
@@ -433,6 +435,18 @@ int simpler_init(
     if (ctx == NULL) return PTO_RUNTIME_ERR_INTERNAL;
 
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
+
+    // Latching the identity is the first thing this entry does, so a context
+    // that already belongs to kernel mode is refused before any process- or
+    // runner-state mutation below. Latching PROGRAM is idempotent, which is
+    // what lets an init -> finalize -> init sequence on the same device run
+    // again.
+    const int latch_rc = runner->execution_mode_latch().latch(SIMPLER_MODE_PROGRAM);
+    if (latch_rc != 0) {
+        LOG_ERROR("simpler_init: refused — this context already belongs to kernel mode");
+        return latch_rc;
+    }
+
     runner->set_dma_workspace_request(enable_sdma != 0);
 
     int rc;
@@ -1010,6 +1024,49 @@ size_t committed_device_memory_ctx(DeviceContextHandle ctx) {
 int device_memory_info_ctx(DeviceContextHandle ctx, DeviceMemoryInfo *info) {
     if (ctx == NULL || info == NULL) return PTO_RUNTIME_ERR_INTERNAL;
     return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+/* ===========================================================================
+ * Kernel-mode lifecycle
+ *
+ * Simulation never supports kernel mode: it has no real streams for a caller
+ * to lend. supported() is 0 and init refuses after the shared structural
+ * validation, so no context here ever latches kernel mode and
+ * prepare/launch reject with INVALID_STATE. Argument validation is shared
+ * with every other component through kernel_entry_validation.h, so an
+ * argument this stub accepts is one the onboard path accepts too.
+ * =========================================================================== */
+
+int simpler_kernel_mode_supported(DeviceContextHandle) { return 0; }
+
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+) {
+    const int rc = validate_kernel_init_args(
+        ctx, device_id, aicpu_binary, aicpu_size, aicore_binary, aicore_size, dispatcher_binary, dispatcher_size,
+        config, context_generation
+    );
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_init: kernel mode is not supported by the simulator");
+    return PTO_RUNTIME_ERR_UNSUPPORTED;
+}
+
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+) {
+    const int rc = validate_kernel_prepare_callable_args(ctx, callable_id, callable, callable_size, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_prepare_callable: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
+}
+
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream) {
+    const int rc = validate_kernel_launch_args(ctx, callable_id, args, caller_stream);
+    if (rc != 0) return rc;
+    LOG_ERROR("simpler_kernel_mode_launch: no live kernel context on this device context");
+    return PTO_RUNTIME_ERR_INVALID_STATE;
 }
 
 }  // extern "C"

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -31,6 +31,7 @@
 #include "cpu_sim_context.h"
 #include "host/host_phase_records_artifact.h"
 #include "host/raii_scope_guard.h"
+#include "host/static_arena_bank.h"
 #include "task_args_wire.h"
 #include "utils/elf_build_id.h"
 
@@ -136,76 +137,15 @@ int SimDeviceRunnerBase::setup_static_arena(
     // combined size can exceed the device allocator's largest contiguous
     // block. Each arena commits exactly one region, so its base() is the
     // pooled pointer the caller wants.
-    //
-    // Idempotent for the production case (sizes do not change across a
-    // worker's lifetime). If a caller asks for a larger layout on any
-    // region, redo just that region.
-    bool arena_changed = false;
-    // A kernel-mode context's config is context-static, so each region is
-    // committed at most once and never grown or released afterwards; captured
-    // graphs may hold the committed base address. A request that would
-    // re-base or release a committed region under kernel mode is therefore an
-    // internal invariant break, not caller-configurable behavior. The refusal
-    // is not self-contained: the caller collapses a nonzero return to
-    // `ok = false` and then releases all three regions unconditionally, and
-    // DeviceArena::release() frees the backing buffer — so a fired guard drops
-    // the very base addresses it names.
-    const bool kernel_mode = execution_mode_latch().is_kernel();
-    auto commit_region = [&arena_changed,
-                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
-        if (kernel_mode && arena.is_committed() &&
-            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
-            LOG_ERROR(
-                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
-                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
-            );
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        if (requested_size == 0) {
-            if (arena.is_committed() && cached_size != 0) {
-                arena.release();
-                cached_size = 0;
-                arena_changed = true;
-            }
-            return 0;
-        }
-        if (arena.is_committed() && requested_size <= cached_size) {
-            return 0;
-        }
-        arena.release();
-        cached_size = 0;
-        arena_changed = true;
-        arena.reserve(requested_size, DeviceArena::kDefaultBaseAlign);
-        if (arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
-            arena.release();
-            return PTO_RUNTIME_ERR_INTERNAL;
-        }
-        cached_size = requested_size;
-        return 0;
+    const StaticArenaBankRequest request{
+        {&bank.gm_heap, &bank.cached_gm_heap_size, gm_heap_size},
+        {&bank.gm_sm, &bank.cached_gm_sm_size, gm_sm_size},
+        {&bank.runtime_pool, &bank.cached_runtime_arena_size, runtime_arena_size},
     };
-    // Failure of any region releases all peers — mirrors the onboard "rollback
-    // all on any failure" semantic (PR #922). Pooled pointers from a prior
-    // successful call stay valid; a failed resize attempt does not leave a
-    // partial layout behind.
-    bool ok = commit_region(bank.gm_heap, bank.cached_gm_heap_size, gm_heap_size) == 0;
-    ok = ok && commit_region(bank.gm_sm, bank.cached_gm_sm_size, gm_sm_size) == 0;
-    ok = ok && commit_region(bank.runtime_pool, bank.cached_runtime_arena_size, runtime_arena_size) == 0;
-    if (!ok) {
-        bank.gm_heap.release();
-        bank.gm_sm.release();
-        bank.runtime_pool.release();
-        bank.cached_gm_heap_size = 0;
-        bank.cached_gm_sm_size = 0;
-        bank.cached_runtime_arena_size = 0;
-        prebuilt_runtime_arena_cache_valid_ = false;
-        prebuilt_runtime_arena_cache_key_.clear();
-        prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;
-        prebuilt_runtime_arena_cache_sm_base_ = nullptr;
-        prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
-        prebuilt_runtime_arena_cache_image_.clear();
-        return PTO_RUNTIME_ERR_INTERNAL;
-    }
-    if (arena_changed) {
+    const StaticArenaBankOutcome outcome = commit_static_arena_bank(request, execution_mode_latch().is_kernel());
+    // The cache keys an assembled image to the bases it was built for, so it
+    // outlives exactly those calls that moved nothing.
+    if (outcome.bases_changed) {
         prebuilt_runtime_arena_cache_valid_ = false;
         prebuilt_runtime_arena_cache_key_.clear();
         prebuilt_runtime_arena_cache_gm_heap_base_ = nullptr;
@@ -213,7 +153,7 @@ int SimDeviceRunnerBase::setup_static_arena(
         prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
         prebuilt_runtime_arena_cache_image_.clear();
     }
-    return 0;
+    return outcome.rc;
 }
 
 bool SimDeviceRunnerBase::lookup_prebuilt_runtime_arena_cache(

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -141,7 +141,26 @@ int SimDeviceRunnerBase::setup_static_arena(
     // worker's lifetime). If a caller asks for a larger layout on any
     // region, redo just that region.
     bool arena_changed = false;
-    auto commit_region = [&arena_changed](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+    // A kernel-mode context's config is context-static, so each region is
+    // committed at most once and never grown or released afterwards; captured
+    // graphs may hold the committed base address. A request that would
+    // re-base or release a committed region under kernel mode is therefore an
+    // internal invariant break, not caller-configurable behavior. The refusal
+    // is not self-contained: the caller collapses a nonzero return to
+    // `ok = false` and then releases all three regions unconditionally, and
+    // DeviceArena::release() frees the backing buffer — so a fired guard drops
+    // the very base addresses it names.
+    const bool kernel_mode = execution_mode_latch().is_kernel();
+    auto commit_region = [&arena_changed,
+                          kernel_mode](DeviceArena &arena, size_t &cached_size, size_t requested_size) -> int {
+        if (kernel_mode && arena.is_committed() &&
+            (requested_size == 0 ? cached_size != 0 : requested_size > cached_size)) {
+            LOG_ERROR(
+                "setup_static_arena: kernel mode forbids %s a committed region (cached %zu, requested %zu)",
+                requested_size == 0 ? "releasing" : "growing", cached_size, requested_size
+            );
+            return PTO_RUNTIME_ERR_INTERNAL;
+        }
         if (requested_size == 0) {
             if (arena.is_committed() && cached_size != 0) {
                 arena.release();

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -264,9 +264,10 @@ public:
 
     /**
      * This context's execution identity, latched once by whichever init entry
-     * constructs it. The arena guard keys on is_kernel(). Simulation never
-     * supports kernel mode — it has no real streams for a caller to lend — so
-     * on this backend the latch only ever holds PROGRAM.
+     * constructs it. The arena guard keys on is_kernel(), as does the trb
+     * retained temporary buffer through HostApiOps::is_kernel_mode. Simulation
+     * never supports kernel mode — it has no real streams for a caller to lend
+     * — so on this backend the latch only ever holds PROGRAM.
      */
     ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
 

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -55,6 +55,7 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "platform_comm/comm.h"
+#include "host/execution_mode_latch.h"
 #include "host/memory_allocator.h"
 #include "host/chip_swimlane_collector.h"
 #include "host/host_phase_records.h"
@@ -260,6 +261,15 @@ public:
     void set_dma_workspace_request(bool enable_sdma) { sdma_requested_ = enable_sdma; }
     int ensure_dma_workspace_provisioned();
     int device_id() const { return device_id_; }
+
+    /**
+     * This context's execution identity, latched once by whichever init entry
+     * constructs it. The arena guard keys on is_kernel(). Simulation never
+     * supports kernel mode — it has no real streams for a caller to lend — so
+     * on this backend the latch only ever holds PROGRAM.
+     */
+    ExecutionModeLatch &execution_mode_latch() { return execution_mode_latch_; }
+
     uint64_t last_device_wall_ns() const { return device_wall_ns_; }
     // Per-phase AICPU wall (ns) from the most recent run; RunWall aliases
     // last_device_wall_ns(). 0 for a phase that was never stamped. Used to emit
@@ -368,13 +378,19 @@ protected:
     // --- Shared state (protected so subclass execution / init_* / finalize()
     // can read or write directly) ----------------------------------------
 
-    // Configuration. device_id_ is set once in attach_current_thread() during
-    // simpler_init and read afterwards; the user's call sequence is single-
-    // threaded with respect to it so plain int is sufficient.
+    // Configuration. device_id_ is which device this context is on — not a
+    // claim of ownership, which the execution-mode latch carries instead. Set
+    // once in attach_current_thread() during simpler_init and read afterwards;
+    // the user's call sequence is single-threaded with respect to it so plain
+    // int is sufficient.
     int device_id_{-1};
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};
+
+    // This context's execution identity. Write-once: the first init entry to
+    // run latches it, and it never changes afterwards.
+    ExecutionModeLatch execution_mode_latch_;
 
     // Executor binaries — populated once via set_executors() during simpler_init,
     // owned for the rest of the runner's lifetime.

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -40,6 +40,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "arg_direction.h"
@@ -108,6 +109,20 @@ struct Callable {
     int32_t child_count_;
     char config_name_[CALLABLE_FUNC_NAME_MAX];
     uint32_t config_name_len_;
+    // Cached derivation of the signature: the number of ArgDirection::SCALAR
+    // entries in signature_[0..sig_count_). The factory rejects a nonzero
+    // value that disagrees with the signature; 0 additionally means "not
+    // recorded", which a legacy blob and a scalar-free orchestration share.
+    // sig_count_ includes the scalar entries, so a consumer derives the
+    // effective count first — this field when nonzero, otherwise the
+    // signature's SCALAR entries, the split count_callable_tensor_args
+    // already computes — and takes sig_count_ minus that as the tensor
+    // comparandum. Subtracting this field directly counts an unrecorded
+    // callable's scalars as tensors. Occupies
+    // four bytes of the historical padding between config_name_len_ and the
+    // 16-byte-aligned storage_, so every other field keeps its wire offset
+    // and a legacy zero-initialized blob reads as scalar_count == 0.
+    int32_t scalar_count_;
     // Children live in storage_ at CALLABLE_ALIGN-aligned offsets, but the
     // all-uint32 header above can leave offsetof(storage_) at 4-mod-8, which
     // would place an 8-byte-aligned Child (CoreCallable has a uint64) on a
@@ -129,6 +144,9 @@ struct Callable {
     uint32_t func_name_len() const { return func_name_len_; }
     const char *config_name() const { return config_name_; }
     uint32_t config_name_len() const { return config_name_len_; }
+    // 0 means either an artifact built before this field existed or an
+    // orchestration that takes no scalars; the two are indistinguishable.
+    int32_t scalar_count() const { return scalar_count_; }
 
     const Child &child(int32_t i) const {
         if (i < 0 || i >= child_count_) throw std::out_of_range("Callable: child index out of range");
@@ -149,9 +167,9 @@ private:
 
     template <typename C, int MS, int MC>
     friend std::vector<uint8_t> make_callable(
-        const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
-        const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
-        const char *config_name
+        const ArgDirection *sig, int32_t sig_count, int32_t scalar_count, const char *func_name, const void *binary,
+        uint32_t binary_size, const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers,
+        int32_t child_count, const char *config_name
     );
 };
 
@@ -176,6 +194,43 @@ static_assert(
     offsetof(ChipCallable, storage_) % CALLABLE_CHILD_ALIGN == 0,
     "ChipCallable.storage_ must be CALLABLE_CHILD_ALIGN-aligned for SIMT kernel binaries"
 );
+
+// Callable bytes are shipped through L3/L4 IPC and the on-disk kernel cache,
+// so the header layout is wire ABI. scalar_count_ must consume tail padding
+// rather than move any historical field. The constants below encode
+// CHIP_MAX_TENSOR_ARGS = 256, CORE_MAX_TENSOR_ARGS = 32,
+// CALLABLE_FUNC_NAME_MAX = 64, and MaxChildren = 1024; a deliberate capacity
+// change updates them in the same commit.
+static_assert(
+    std::is_trivially_copyable_v<ChipCallable> && std::is_standard_layout_v<ChipCallable>,
+    "ChipCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(
+    std::is_trivially_copyable_v<CoreCallable> && std::is_standard_layout_v<CoreCallable>,
+    "CoreCallable wire ABI: must stay memcpy-able POD"
+);
+static_assert(offsetof(ChipCallable, signature_) == 0, "ChipCallable wire ABI: signature offset changed");
+static_assert(offsetof(ChipCallable, sig_count_) == 1024, "ChipCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(ChipCallable, binary_size_) == 1028, "ChipCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(ChipCallable, func_name_) == 1032, "ChipCallable wire ABI: func_name offset changed");
+static_assert(offsetof(ChipCallable, func_name_len_) == 1096, "ChipCallable wire ABI: func_name_len offset changed");
+static_assert(offsetof(ChipCallable, child_func_ids_) == 1100, "ChipCallable wire ABI: child_func_ids offset changed");
+static_assert(offsetof(ChipCallable, child_offsets_) == 5196, "ChipCallable wire ABI: child_offsets offset changed");
+static_assert(offsetof(ChipCallable, child_count_) == 9292, "ChipCallable wire ABI: child_count offset changed");
+static_assert(offsetof(ChipCallable, config_name_) == 9296, "ChipCallable wire ABI: config_name offset changed");
+static_assert(
+    offsetof(ChipCallable, config_name_len_) == 9360, "ChipCallable wire ABI: config_name_len offset changed"
+);
+static_assert(offsetof(ChipCallable, scalar_count_) == 9364, "ChipCallable wire ABI: scalar_count offset changed");
+static_assert(offsetof(ChipCallable, storage_) == 9376, "ChipCallable wire ABI: storage offset changed");
+static_assert(sizeof(ChipCallable) == 9376, "ChipCallable wire ABI: header size changed");
+static_assert(offsetof(CoreCallable, signature_) == 0, "CoreCallable wire ABI: signature offset changed");
+static_assert(offsetof(CoreCallable, sig_count_) == 128, "CoreCallable wire ABI: sig_count offset changed");
+static_assert(offsetof(CoreCallable, binary_size_) == 132, "CoreCallable wire ABI: binary_size offset changed");
+static_assert(offsetof(CoreCallable, resolved_addr_) == 136, "CoreCallable wire ABI: resolved_addr offset changed");
+static_assert(offsetof(CoreCallable, storage_) == 144, "CoreCallable wire ABI: storage offset changed");
+static_assert(sizeof(CoreCallable) == 144, "CoreCallable wire ABI: header size changed");
+static_assert(CoreCallable::binary_data_offset() == 192, "CoreCallable wire ABI: binary data offset changed");
 
 // ============================================================================
 // Factory: make_callable for static leaf
@@ -216,8 +271,8 @@ make_callable(const ArgDirection *sig, int32_t sig_count, const void *binary, ui
 
 template <typename Child, int MaxSig, int MaxChildren>
 std::vector<uint8_t> make_callable(
-    const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
-    const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
+    const ArgDirection *sig, int32_t sig_count, int32_t scalar_count, const char *func_name, const void *binary,
+    uint32_t binary_size, const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
     // No default arg here: the friend declaration above has none, so a default
     // on this definition is a "redeclaration may not have default arguments"
     // error once ChipCallable is instantiated (the static_assert below does
@@ -230,6 +285,27 @@ std::vector<uint8_t> make_callable(
             "make_callable: requested tensor count " + std::to_string(sig_count) + " exceeds supported tensor count " +
             std::to_string(MaxSig)
         );
+    }
+    if (scalar_count < 0 || scalar_count > CHIP_MAX_SCALAR_ARGS) {
+        throw std::invalid_argument(
+            "make_callable: requested scalar count " + std::to_string(scalar_count) +
+            " is outside the supported range [0, " + std::to_string(CHIP_MAX_SCALAR_ARGS) + "]"
+        );
+    }
+    // scalar_count is a cached derivation of the signature, so a nonzero
+    // value must match the signature's SCALAR entries; 0 stays valid with any
+    // signature because it also means "not recorded" (legacy semantics).
+    if (scalar_count != 0) {
+        int32_t signature_scalars = 0;
+        for (int32_t i = 0; i < sig_count; ++i) {
+            if (sig[i] == ArgDirection::SCALAR) ++signature_scalars;
+        }
+        if (scalar_count != signature_scalars) {
+            throw std::invalid_argument(
+                "make_callable: requested scalar count " + std::to_string(scalar_count) +
+                " disagrees with the signature's " + std::to_string(signature_scalars) + " SCALAR entries"
+            );
+        }
     }
     if (child_count > MaxChildren) throw std::invalid_argument("make_callable: child_count exceeds MaxChildren");
 
@@ -250,6 +326,7 @@ std::vector<uint8_t> make_callable(
     for (int32_t i = 0; i < sig_count; ++i)
         obj->signature_[i] = sig[i];
     obj->sig_count_ = sig_count;
+    obj->scalar_count_ = scalar_count;
     obj->binary_size_ = binary_size;
 
     // Store func_name (null-terminated, truncated to CALLABLE_FUNC_NAME_MAX-1)

--- a/src/common/task_interface/execution_mode.h
+++ b/src/common/task_interface/execution_mode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * The one definition of a context's execution mode, shared by every layer
+ * that names it: the host-side identity latch on the platform runners, the
+ * invocation wire header, and the C ABI documentation. A context's mode is
+ * decided by which init entry runs first and never changes afterwards.
+ */
+
+#pragma once
+
+typedef enum SimplerExecutionMode {
+    /* Historical exclusive-device semantics, claimed by simpler_init. */
+    SIMPLER_MODE_PROGRAM = 0,
+    /* Borrowed-device semantics, claimed by simpler_kernel_mode_init. */
+    SIMPLER_MODE_KERNEL = 1,
+} SimplerExecutionMode;

--- a/src/common/task_interface/kernel_invocation_header.h
+++ b/src/common/task_interface/kernel_invocation_header.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unified invocation-args wire header (host → AICPU).
+ *
+ * Every kernel-mode launch ships one immutable args snapshot to the AICPU:
+ * this fixed header followed by `payload_bytes` of runtime-specific payload.
+ * The header is the shared envelope both runtimes use; the payload format
+ * under it belongs to each runtime (tensormap_and_ringbuffer carries
+ * graph-build input, host_build_graph carries a serialized graph blob) and is
+ * not constrained here. Validating identity, generation, and capacity against
+ * this header before dispatching to the runtime payload consumer is the AICPU
+ * dispatch entry's obligation: that validation lives with the consumers, not
+ * in this header, and no consumer implements it.
+ *
+ * Both sides of this wire are produced by the same build (`build_runtimes.py`
+ * emits the host runtime and the AICPU executor into one
+ * `build/lib/{arch}/{variant}/{runtime}/`), so the struct carries no version
+ * or size negotiation: evolving it means changing both sides in one tree.
+ * The layout is still shipped by memcpy through CANN's HostArgs deep copy, so
+ * the struct is POD, position-independent, and carries no pointers.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include "execution_mode.h"
+
+typedef struct SimplerKernelInvocationHeader {
+    uint32_t mode;       /* SimplerExecutionMode of the issuing context */
+    int32_t callable_id; /* target callable; matches the prepared registration */
+    /* Occupancy generation of the residency slot `callable_id` resolves to —
+       a property of the slot, not of the callable in it. The counter advances
+       when the slot takes a different tenant, so a generation carried by the
+       callable could not detect slot reuse. Zero means "not recorded"; a live
+       generation starts at 1, matching PipelineSlotLease and CanonicalIdentity.
+       The comparison belongs on the AICPU dispatch path because replay does
+       not return to the host, so a stale captured snapshot has to be caught
+       on-device. Nothing mints this value and no device-side comparand
+       exists. */
+    uint64_t generation;
+    /* Byte length of the runtime-specific payload that follows this header. */
+    uint64_t payload_bytes;
+    /* Arg counts of this invocation. ChipCallable's sig_count includes the
+       scalar entries, and its scalar_count() reads 0 both for a scalar-free
+       orchestration and for an artifact built before that field existed, so
+       a consumer derives the effective scalar count first — scalar_count()
+       when nonzero, otherwise the signature's ArgDirection::SCALAR entries —
+       then checks tensor_count against sig_count minus it and scalar_count
+       against it. Subtracting scalar_count() directly would count an
+       unrecorded callable's scalars as tensors. */
+    int32_t tensor_count;
+    int32_t scalar_count;
+    /* Count of host-only duplicate tensor args (a tensor the host must read
+       is passed twice: a device arg plus a host-only copy). Zero until the
+       host-only copy contract lands; consumers reject nonzero meanwhile. */
+    int32_t host_copy_tensor_count;
+} SimplerKernelInvocationHeader;
+
+#ifdef __cplusplus
+#include <type_traits>
+
+static_assert(
+    std::is_trivially_copyable_v<SimplerKernelInvocationHeader> &&
+    std::is_standard_layout_v<SimplerKernelInvocationHeader>
+);
+#endif

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -253,6 +253,14 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = load_symbol<CommGlobalDomainReleaseFn>(handle, "comm_global_domain_release");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
         comm_destroy_fn_ = load_symbol<CommDestroyFn>(handle, "comm_destroy");
+        // Kernel-mode lifecycle entries are part of the uniform host_runtime.so
+        // ABI like the ACL/comm group above: every runtime exports them, and
+        // variants without kernel-mode support ship validating stubs.
+        kernel_supported_fn_ = load_symbol<SimplerKernelSupportedFn>(handle, "simpler_kernel_mode_supported");
+        kernel_init_fn_ = load_symbol<SimplerKernelInitFn>(handle, "simpler_kernel_mode_init");
+        kernel_prepare_callable_fn_ =
+            load_symbol<SimplerKernelPrepareCallableFn>(handle, "simpler_kernel_mode_prepare_callable");
+        kernel_launch_fn_ = load_symbol<SimplerKernelLaunchFn>(handle, "simpler_kernel_mode_launch");
     } catch (...) {
         throw;
     }
@@ -380,6 +388,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw;
     }
@@ -439,6 +451,10 @@ void ChipWorker::init(
         comm_global_domain_release_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
+        kernel_supported_fn_ = nullptr;
+        kernel_init_fn_ = nullptr;
+        kernel_prepare_callable_fn_ = nullptr;
+        kernel_launch_fn_ = nullptr;
         runtime_bufs_.clear();
         throw std::runtime_error("simpler_init failed with code " + std::to_string(init_rc));
     }
@@ -529,6 +545,10 @@ void ChipWorker::finalize() {
     comm_global_domain_release_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
+    kernel_supported_fn_ = nullptr;
+    kernel_init_fn_ = nullptr;
+    kernel_prepare_callable_fn_ = nullptr;
+    kernel_launch_fn_ = nullptr;
     runtime_bufs_.clear();
     pipeline_generations_.reset();
     pipeline_contract_ = {PTO_PIPELINE_CONTRACT_ABI_VERSION, 0, 1, {}};

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -296,6 +296,10 @@ private:
     using CommGlobalDomainReleaseFn = int (*)(uint64_t);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
+    using SimplerKernelSupportedFn = decltype(&simpler_kernel_mode_supported);
+    using SimplerKernelInitFn = decltype(&simpler_kernel_mode_init);
+    using SimplerKernelPrepareCallableFn = decltype(&simpler_kernel_mode_prepare_callable);
+    using SimplerKernelLaunchFn = decltype(&simpler_kernel_mode_launch);
 
     struct CommSession {
         void *handle = nullptr;
@@ -356,6 +360,10 @@ private:
     CommGlobalDomainReleaseFn comm_global_domain_release_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;
+    SimplerKernelSupportedFn kernel_supported_fn_ = nullptr;
+    SimplerKernelInitFn kernel_init_fn_ = nullptr;
+    SimplerKernelPrepareCallableFn kernel_prepare_callable_fn_ = nullptr;
+    SimplerKernelLaunchFn kernel_launch_fn_ = nullptr;
     void *device_ctx_ = nullptr;
     std::vector<CommSession> comm_sessions_;
     std::unordered_map<uint64_t, size_t> comm_session_index_;

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -30,6 +30,9 @@
  *                   simpler_unregister_callable,
  *                   get_aicpu_dlopen_count, get_host_dlopen_count,
  *                   get_run_stream_set_create_count
+ *   - kernel mode:  simpler_kernel_mode_supported, simpler_kernel_mode_init,
+ *                   simpler_kernel_mode_prepare_callable,
+ *                   simpler_kernel_mode_launch
  *   - pipeline:     get_pipeline_contract,
  *                   supports_concurrent_native_prepare_ctx,
  *                   get_arena_bank_gm_heap_base_ctx,
@@ -102,6 +105,10 @@ enum {
     /* The request names a capability this platform/runtime does not implement. */
     PTO_RUNTIME_ERR_UNSUPPORTED = PTO_RUNTIME_ERR_BASE - 1,
     PTO_RUNTIME_ERR_PREPARED_INCOMPATIBLE = PTO_RUNTIME_ERR_BASE - 2,
+    /* The call is structurally valid but arrives out of order for this
+       context's lifecycle (e.g. launch on a context with no live kernel
+       claim). */
+    PTO_RUNTIME_ERR_INVALID_STATE = PTO_RUNTIME_ERR_BASE - 3,
 };
 
 /** Return values from simpler_poll_run(). */
@@ -324,7 +331,8 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  *      separate call. Only `prewarm_config->runtime_env` is read.
  *
  * Returns 0 on success, negative on attach, provisioning, or prewarm-build
- * failure.
+ * failure, and PTO_RUNTIME_ERR_INVALID_STATE when the context is already
+ * latched to kernel mode.
  */
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
@@ -522,6 +530,108 @@ size_t get_host_dlopen_count(DeviceContextHandle ctx);
  * bootstrap pair.
  */
 size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
+
+/* ===========================================================================
+ * Kernel-mode lifecycle (four entries + finalize_device)
+ *
+ * A context has one of two execution modes for its whole lifetime, decided by
+ * which init entry runs first. simpler_init latches program mode — the
+ * historical exclusive-device path driven through the prepared-run family
+ * above. simpler_kernel_mode_init latches kernel mode, which borrows the
+ * caller's already-current device and caller-owned stream to enqueue one
+ * bounded asynchronous operator per launch: no device reset, no internal
+ * stream/device synchronize on the prepare/launch/close paths, zero
+ * allocation at launch, and no capture/model-state queries, so a launch is
+ * capturable by ACLGraph as an ordinary node.
+ *
+ * Identity is a write-once property of the context, not a state that evolves:
+ * ExecutionModeLatch on the platform runner holds it, the first init entry to
+ * run latches it, and it never changes — not on finalize, not on error. There
+ * is no separate declaration call to forget, and no unlatch, so a handle from
+ * a failed kernel init can never be recycled into a program context.
+ * simpler_init latches PROGRAM before touching any process or runner state, so
+ * the mutual exclusion is enforced on every program init. Every kernel-mode
+ * guard on the device/ACL lifecycle and arena paths keys on the latch reading
+ * kernel; none of the entries below latches yet, so today only program
+ * contexts exist and those guards never fire.
+ *
+ * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
+ * context-static, so each pooled arena region is committed at most once and
+ * never grown or released afterwards. The platform arena reports a growth or
+ * release request under kernel mode as an internal invariant break
+ * (PTO_RUNTIME_ERR_INTERNAL), and capacity intent travels in
+ * CallConfig.runtime_env like everywhere else.
+ *
+ * All four entries below are part of the required dlsym surface: every
+ * host_runtime.so exports them, and variants without kernel-mode support
+ * export stubs that run the same structural validation and then refuse —
+ * supported returns 0, init reports PTO_RUNTIME_ERR_UNSUPPORTED, and
+ * prepare_callable and launch report PTO_RUNTIME_ERR_INVALID_STATE because
+ * no kernel context is live. The fifth lifecycle entry is the existing
+ * finalize_device(): in kernel mode it releases only context-owned resources
+ * and never resets the device or finalizes ACL. device_id_ records which
+ * device a context is on rather than a claim on it, so a kernel context
+ * reaches that teardown path; the platform finalize() skips the per-thread
+ * device bind on a kernel latch, because the caller already holds its own
+ * device current.
+ *
+ * These entries accept only POD structs, serialized blobs, and device/stream
+ * pointers — never framework objects. The caller stream is always an explicit
+ * parameter and is never stored beyond the call or destroyed by simpler.
+ * =========================================================================== */
+
+/** Return nonzero when this runtime/context can execute kernel-mode launches. */
+int simpler_kernel_mode_supported(DeviceContextHandle ctx);
+
+/**
+ * Initialize a kernel-mode context on the caller's already-current device.
+ *
+ * A successful call latches kernel mode on the context — mutually exclusive
+ * with the program-mode simpler_init — and the claim is what arms the
+ * kernel-mode guards on the platform's device/ACL lifecycle and arena paths.
+ *
+ * Takes no device ownership: no device reset, no ACL init/finalize, and no
+ * stream or device synchronize on this path. Creates only context-owned
+ * persistent handles used by asynchronous preparation and launch. `config`
+ * is context-static; launches never mutate it. `context_generation` is a
+ * nonzero host-process-unique identity minted by the caller for sequential
+ * contexts; generation zero is invalid.
+ */
+int simpler_kernel_mode_init(
+    DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
+    const uint8_t *aicore_binary, size_t aicore_size, const uint8_t *dispatcher_binary, size_t dispatcher_size,
+    const CallConfig *config, uint64_t context_generation
+);
+
+/**
+ * Stage one callable for kernel-mode launches, outside ACLGraph capture.
+ *
+ * `callable` points to a canonical ChipCallable image of exactly
+ * `callable_size` bytes. Validating every flexible-array offset before the
+ * image is hashed or uploaded is the implementation's obligation; the shared
+ * entry validation checks only the image's alignment, its size floor, and the
+ * callable id range. Preparation may allocate persistent state and
+ * enqueue asynchronous device work on `caller_stream`, but never synchronizes
+ * a stream or device — preparation errors surface through the caller's own
+ * warmup + synchronize. The stream is borrowed for this call only.
+ */
+int simpler_kernel_mode_prepare_callable(
+    DeviceContextHandle ctx, int32_t callable_id, const void *callable, size_t callable_size, void *caller_stream
+);
+
+/**
+ * Enqueue one bounded asynchronous kernel-mode operator invocation.
+ *
+ * `args` points to a ChipStorageTaskArgs POD whose tensor addresses are
+ * caller-owned device addresses; they are passed through without ever being
+ * dereferenced on the host. A launch performs no device malloc/free, no
+ * tensor staging, no synchronize, no capture-state query, and no
+ * stream-to-model attachment: KernelLaunchOps is the vocabulary that makes
+ * those unrepresentable, and routing every runtime call through it is the
+ * implementation's obligation. A return of 0 means the sequence was enqueued;
+ * device execution may still be in flight and may still fail asynchronously.
+ */
+int simpler_kernel_mode_launch(DeviceContextHandle ctx, int32_t callable_id, const void *args, void *caller_stream);
 
 #ifdef __cplusplus
 }

--- a/src/common/worker/runtime_c_api.h
+++ b/src/common/worker/runtime_c_api.h
@@ -557,8 +557,9 @@ size_t get_run_stream_set_create_count(DeviceContextHandle ctx);
  *
  * Kernel-mode capacity is a mode invariant, not a gated state: `config` is
  * context-static, so each pooled arena region is committed at most once and
- * never grown or released afterwards. The platform arena reports a growth or
- * release request under kernel mode as an internal invariant break
+ * never grown or released afterwards, and the trb retained temporary buffer is
+ * allocated at most once. Both report a request that would re-base or release
+ * what they already hold as an internal invariant break
  * (PTO_RUNTIME_ERR_INTERNAL), and capacity intent travels in
  * CallConfig.runtime_env like everywhere else.
  *

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -1325,6 +1325,33 @@ add_dependencies(test_host_log_cross_dso test_host_log_consumer)
 add_test(NAME test_host_log_cross_dso COMMAND test_host_log_cross_dso)
 set_tests_properties(test_host_log_cross_dso PROPERTIES LABELS "no_hardware")
 
+# Arena-bank capacity rule shared by the onboard and sim runners
+# (host/static_arena_bank.h). Pure host logic over DeviceArena's libc backend,
+# so a kernel-mode context's address stability is provable with no CANN and no
+# device; the logger sources satisfy the rule's LOG_ERROR. Placed after
+# SIMPLER_LOG_DIR / HOST_LOG_TEST_SOURCES rather than beside the other
+# common-utils tests, which are declared before those are set.
+add_executable(test_static_arena_bank
+    common/test_static_arena_bank.cpp
+    ${HOST_LOG_TEST_SOURCES}
+)
+target_include_directories(test_static_arena_bank PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    # src/common resolves the "utils/..." and "worker/..." prefixes.
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    ${SIMPLER_LOG_DIR}
+    ${SIMPLER_LOG_DIR}/include
+)
+target_link_libraries(test_static_arena_bank PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_static_arena_bank COMMAND test_static_arena_bank)
+set_tests_properties(test_static_arena_bank PROPERTIES LABELS "no_hardware")
+
 set(COMMON_PLATFORM_DIR ${CMAKE_SOURCE_DIR}/../../../src/common/platform)
 function(add_device_phase_capture_test name host_strace device_strace expected)
     add_executable(${name}

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -500,6 +500,37 @@ set_tests_properties(test_native_run_acceptance PROPERTIES LABELS "no_hardware")
 # callers invoke it from different host threads.
 add_common_utils_test(test_host_api common/test_host_api.cpp)
 
+# Kernel-mode entry argument validation: shared by every host-runtime
+# component (real implementation and stub alike), so its rejection rules are
+# provable here without any device or built .so.
+add_executable(test_kernel_entry_validation common/test_kernel_entry_validation.cpp)
+target_include_directories(test_kernel_entry_validation PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_kernel_entry_validation PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_entry_validation COMMAND test_kernel_entry_validation)
+set_tests_properties(test_kernel_entry_validation PROPERTIES LABELS "no_hardware")
+
+# Kernel-mode phase machine and restricted-vocabulary tables, table-driven with
+# fake ops: init/close balance, poison, sticky CLOSING with retry, and the
+# separate runtime-error vs teardown-error slots.
+add_executable(test_kernel_execution_state
+    common/test_kernel_execution_state.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/kernel_execution_state.cpp
+)
+target_include_directories(test_kernel_execution_state PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/worker
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_link_libraries(test_kernel_execution_state PRIVATE ${GTEST_MAIN_LIB} ${GTEST_LIB} pthread)
+add_test(NAME test_kernel_execution_state COMMAND test_kernel_execution_state)
+set_tests_properties(test_kernel_execution_state PROPERTIES LABELS "no_hardware")
+
 # Runtime extension payloads are per-run state even though the collector's
 # shared-memory resources remain resident across runs.
 add_executable(test_chip_swimlane_collector
@@ -544,7 +575,9 @@ set_tests_properties(test_sim_run_completion PROPERTIES LABELS "no_hardware")
 add_task_interface_test(test_buffer types/test_buffer.cpp)
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
+add_task_interface_test(test_callable_scalar_count types/test_callable_scalar_count.cpp)
 add_task_interface_test(test_call_config types/test_call_config.cpp)
+add_task_interface_test(test_kernel_invocation_header types/test_kernel_invocation_header.cpp)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/common/test_kernel_entry_validation.cpp
+++ b/tests/ut/cpp/common/test_kernel_entry_validation.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include "host/kernel_entry_validation.h"
+
+namespace {
+
+int dummy_ctx_storage = 0;
+void *const kCtx = &dummy_ctx_storage;
+const uint8_t kBinary[4] = {1, 2, 3, 4};
+const int kConfigStorage = 0;
+const void *const kConfig = &kConfigStorage;
+int dummy_stream_storage = 0;
+void *const kStream = &dummy_stream_storage;
+alignas(ChipCallable) const unsigned char kCallableImage[sizeof(ChipCallable)] = {};
+
+TEST(KernelEntryValidation, BinarySpanRequiresPointerAndSizeTogether) {
+    EXPECT_TRUE(kernel_binary_span_is_consistent(nullptr, 0));
+    EXPECT_TRUE(kernel_binary_span_is_consistent(kBinary, sizeof(kBinary)));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(nullptr, 4));
+    EXPECT_FALSE(kernel_binary_span_is_consistent(kBinary, 0));
+}
+
+TEST(KernelEntryValidation, InitAcceptsConsistentArgs) {
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        0
+    );
+}
+
+TEST(KernelEntryValidation, InitRejectsEachStructuralViolation) {
+    EXPECT_EQ(
+        validate_kernel_init_args(
+            nullptr, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1
+        ),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, nullptr, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, -1, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), nullptr, 0, kConfig, 0),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    // One inconsistent span per position, in both directions.
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, nullptr, 4, kBinary, sizeof(kBinary), nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, 0, nullptr, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_init_args(kCtx, 0, kBinary, sizeof(kBinary), kBinary, sizeof(kBinary), kBinary, 0, kConfig, 1),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, PrepareCallableChecksIdRangeAndImageSize) {
+    EXPECT_EQ(validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), kStream), 0);
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS - 1, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        0
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(nullptr, 0, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, nullptr, sizeof(ChipCallable), kStream), PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable), nullptr),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, -1, kCallableImage, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(
+            kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, sizeof(ChipCallable), kStream
+        ),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage, sizeof(ChipCallable) - 1, kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+    // storage_ sits at a CALLABLE_CHILD_ALIGN offset from the header, so an
+    // image the caller placed off-alignment puts every child off-alignment.
+    static_assert(alignof(ChipCallable) > 1, "a misaligned image must be expressible");
+    EXPECT_EQ(
+        validate_kernel_prepare_callable_args(kCtx, 0, kCallableImage + 1, sizeof(ChipCallable), kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+TEST(KernelEntryValidation, LaunchChecksPointersAndIdRange) {
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, kStream), 0);
+    EXPECT_EQ(validate_kernel_launch_args(nullptr, 0, kCallableImage, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, nullptr, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, 0, kCallableImage, nullptr), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(validate_kernel_launch_args(kCtx, -1, kCallableImage, kStream), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(
+        validate_kernel_launch_args(kCtx, MAX_REGISTERED_CALLABLE_IDS, kCallableImage, kStream),
+        PTO_RUNTIME_ERR_INTERNAL
+    );
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_kernel_execution_state.cpp
+++ b/tests/ut/cpp/common/test_kernel_execution_state.cpp
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include "host/execution_mode_latch.h"
+#include "host/kernel_execution_state.h"
+
+namespace {
+
+/**
+ * Fake ops backing the restricted context vocabulary. Handles are small
+ * integers cast to pointers; create/destroy counters prove balance, and the
+ * failure knobs drive the CLOSING-retry and partial-init paths.
+ */
+struct FakeContextOps {
+    int current_device{3};
+    int get_device_rc{0};
+    int create_stream_rc_after{-1};  // fail the Nth create_hidden_stream (0-based); -1 = never
+    int create_event_rc_after{-1};
+    int destroy_failures_remaining{0};
+
+    int streams_created{0};
+    int streams_destroyed{0};
+    int events_created{0};
+    int events_destroyed{0};
+    uintptr_t next_handle{1};
+
+    static FakeContextOps *self(void *context) { return static_cast<FakeContextOps *>(context); }
+
+    static int get_current_device(void *context, int *device_id) {
+        auto *ops = self(context);
+        if (ops->get_device_rc != 0) return ops->get_device_rc;
+        *device_id = ops->current_device;
+        return 0;
+    }
+    static int create_hidden_stream(void *context, void **stream) {
+        auto *ops = self(context);
+        if (ops->create_stream_rc_after >= 0 && ops->streams_created == ops->create_stream_rc_after) return -42;
+        ops->streams_created++;
+        *stream = reinterpret_cast<void *>(ops->next_handle++);
+        return 0;
+    }
+    static int destroy_hidden_stream(void *context, void *) {
+        auto *ops = self(context);
+        if (ops->destroy_failures_remaining > 0) {
+            ops->destroy_failures_remaining--;
+            return -43;
+        }
+        ops->streams_destroyed++;
+        return 0;
+    }
+    static int create_event(void *context, void **event) {
+        auto *ops = self(context);
+        if (ops->create_event_rc_after >= 0 && ops->events_created == ops->create_event_rc_after) return -44;
+        ops->events_created++;
+        *event = reinterpret_cast<void *>(ops->next_handle++);
+        return 0;
+    }
+    static int destroy_event(void *context, void *) {
+        auto *ops = self(context);
+        if (ops->destroy_failures_remaining > 0) {
+            ops->destroy_failures_remaining--;
+            return -43;
+        }
+        ops->events_destroyed++;
+        return 0;
+    }
+
+    KernelContextOps table() {
+        return KernelContextOps{this,          &get_current_device, &create_hidden_stream, &destroy_hidden_stream,
+                                &create_event, &destroy_event};
+    }
+};
+
+constexpr size_t kStreamCount = static_cast<size_t>(KernelStreamKind::Count);
+constexpr size_t kEventCount = static_cast<size_t>(KernelEventKind::Count);
+
+TEST(KernelContextOpsVocabulary, IncompleteTableIsInvalid) {
+    FakeContextOps fake;
+    KernelContextOps ops = fake.table();
+    EXPECT_TRUE(ops.valid());
+    ops.create_event = nullptr;
+    EXPECT_FALSE(ops.valid());
+}
+
+TEST(KernelLaunchOpsVocabulary, IncompleteTableIsInvalid) {
+    KernelLaunchOps ops{};
+    EXPECT_FALSE(ops.valid());
+}
+
+TEST(ExecutionModeLatch, StartsUnlatched) {
+    ExecutionModeLatch latch;
+    EXPECT_FALSE(latch.is_latched());
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, LatchingIsIdempotentForTheHeldMode) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_TRUE(latch.is_latched());
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_FALSE(latch.is_kernel());
+}
+
+TEST(ExecutionModeLatch, ModesAreMutuallyExclusiveInBothDirections) {
+    ExecutionModeLatch program;
+    EXPECT_EQ(program.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(program.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_FALSE(program.is_kernel());
+
+    ExecutionModeLatch kernel;
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_KERNEL), 0);
+    EXPECT_EQ(kernel.latch(SIMPLER_MODE_PROGRAM), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(kernel.is_kernel());
+}
+
+// finalize resets a runner's device state but not its identity, so the
+// init -> finalize -> init sequence the program path already supports must
+// still latch cleanly the second time.
+TEST(ExecutionModeLatch, SameModeRelatchesAfterAFinalizedLifetime) {
+    ExecutionModeLatch latch;
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_PROGRAM), 0);
+    EXPECT_EQ(latch.latched_mode(), SIMPLER_MODE_PROGRAM);
+    EXPECT_EQ(latch.latch(SIMPLER_MODE_KERNEL), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+TEST(KernelExecutionState, EmptyContextInitThenCloseIsClean) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Collecting);
+    EXPECT_TRUE(state.accepts_dispatch());
+    EXPECT_EQ(state.device_id(), 3);
+    EXPECT_EQ(fake.streams_created, static_cast<int>(kStreamCount));
+    EXPECT_EQ(fake.events_created, static_cast<int>(kEventCount));
+    for (size_t i = 0; i < kStreamCount; ++i) {
+        EXPECT_NE(state.hidden_stream(static_cast<KernelStreamKind>(i)), nullptr);
+    }
+    for (size_t i = 0; i < kEventCount; ++i) {
+        EXPECT_NE(state.event(static_cast<KernelEventKind>(i)), nullptr);
+    }
+
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+    // Idempotent close.
+    EXPECT_EQ(state.close(), 0);
+}
+
+TEST(KernelExecutionState, CloseOnNewContextIsANoOpSuccess) {
+    KernelExecutionState state;
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, RepeatedInitializeRejected) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Collecting);
+}
+
+TEST(KernelExecutionState, PreEnqueueValidationLeavesStateUnchanged) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(-1, fake.table()), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    KernelContextOps incomplete = fake.table();
+    incomplete.destroy_event = nullptr;
+    EXPECT_EQ(state.initialize(3, incomplete), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+    // The context stays usable after the clean rejections.
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+}
+
+TEST(KernelExecutionState, DeviceMismatchRejectedBeforeAnyCreation) {
+    FakeContextOps fake;
+    fake.current_device = 7;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, PartialInitFailureRollsBackCleanly) {
+    FakeContextOps fake;
+    fake.create_event_rc_after = 1;  // second event creation fails
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -44);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+    // The rolled-back context is reusable.
+    fake.create_event_rc_after = -1;
+    EXPECT_EQ(state.initialize(3, fake.table()), 0);
+}
+
+TEST(KernelExecutionState, StreamCreateFailureRollsBackCleanly) {
+    FakeContextOps fake;
+    fake.create_stream_rc_after = 1;  // second hidden-stream creation fails
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -42);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, GetCurrentDeviceFailurePropagates) {
+    FakeContextOps fake;
+    fake.get_device_rc = -51;
+    KernelExecutionState state;
+    EXPECT_EQ(state.initialize(3, fake.table()), -51);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(fake.streams_created, 0);
+    EXPECT_EQ(fake.events_created, 0);
+}
+
+TEST(KernelExecutionState, InitFailureWithFailedCleanupLandsInClosing) {
+    FakeContextOps fake;
+    fake.create_event_rc_after = 0;       // first event creation fails
+    fake.destroy_failures_remaining = 1;  // the rollback's first destroy also fails
+    KernelExecutionState state;
+    // The reported error is the create failure; the cleanup failure is
+    // latched in the separate teardown slot.
+    EXPECT_EQ(state.initialize(3, fake.table()), -44);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+    EXPECT_TRUE(state.has_live_resources());
+    EXPECT_FALSE(state.accepts_dispatch());
+    // The kept ops table lets an explicit close retry release the remainder.
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+}
+
+TEST(KernelExecutionState, ReadyEnqueuedKeepsAdmissionOpen) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    EXPECT_EQ(state.mark_ready_enqueued(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::ReadyEnqueued);
+    EXPECT_EQ(state.mark_ready_enqueued(), 0);  // append admission stays open
+    EXPECT_TRUE(state.accepts_dispatch());
+}
+
+TEST(KernelExecutionState, MarkReadyEnqueuedRejectedOffPath) {
+    KernelExecutionState state;
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+}
+
+TEST(KernelExecutionState, PoisonRejectsDispatchButAllowsClose) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    ASSERT_EQ(state.mark_ready_enqueued(), 0);
+    state.poison(-7);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Poisoned);
+    EXPECT_FALSE(state.accepts_dispatch());
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    // First poison cause wins; later ones do not overwrite it.
+    state.poison(-8);
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, PoisonOutsideDispatchPhasesIsIgnored) {
+    KernelExecutionState state;
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::New);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, PoisonDuringClosingIsIgnored) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 1;
+    ASSERT_EQ(state.close(), -43);
+    ASSERT_EQ(state.phase(), KernelContextPhase::Closing);
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, PoisonAfterCloseIsIgnored) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    ASSERT_EQ(state.close(), 0);
+    state.poison(-9);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_EQ(state.last_runtime_error(), 0);
+}
+
+TEST(KernelExecutionState, InitializeRejectedFromEveryNonNewPhase) {
+    FakeContextOps fake;
+
+    KernelExecutionState ready;
+    ASSERT_EQ(ready.initialize(3, fake.table()), 0);
+    ASSERT_EQ(ready.mark_ready_enqueued(), 0);
+    EXPECT_EQ(ready.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(ready.phase(), KernelContextPhase::ReadyEnqueued);
+
+    KernelExecutionState poisoned;
+    ASSERT_EQ(poisoned.initialize(3, fake.table()), 0);
+    poisoned.poison(-7);
+    EXPECT_EQ(poisoned.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(poisoned.phase(), KernelContextPhase::Poisoned);
+
+    KernelExecutionState closing;
+    ASSERT_EQ(closing.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 1;
+    ASSERT_EQ(closing.close(), -43);
+    ASSERT_EQ(closing.phase(), KernelContextPhase::Closing);
+    EXPECT_EQ(closing.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(closing.phase(), KernelContextPhase::Closing);
+
+    KernelExecutionState closed;
+    EXPECT_EQ(closed.close(), 0);
+    EXPECT_EQ(closed.initialize(3, fake.table()), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_EQ(closed.phase(), KernelContextPhase::Closed);
+}
+
+TEST(KernelExecutionState, ClosingIsStickyAndRetriable) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    fake.destroy_failures_remaining = 2;
+    const int rc = state.close();
+    EXPECT_EQ(rc, -43);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closing);
+    EXPECT_FALSE(state.accepts_dispatch());
+    EXPECT_EQ(state.mark_ready_enqueued(), PTO_RUNTIME_ERR_INVALID_STATE);
+    EXPECT_TRUE(state.has_live_resources());
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+
+    // Retry succeeds and releases only what is still live.
+    EXPECT_EQ(state.close(), 0);
+    EXPECT_EQ(state.phase(), KernelContextPhase::Closed);
+    EXPECT_FALSE(state.has_live_resources());
+    EXPECT_EQ(fake.streams_destroyed, fake.streams_created);
+    EXPECT_EQ(fake.events_destroyed, fake.events_created);
+}
+
+TEST(KernelExecutionState, TeardownErrorSlotIsSeparateFromRuntimeError) {
+    FakeContextOps fake;
+    KernelExecutionState state;
+    ASSERT_EQ(state.initialize(3, fake.table()), 0);
+    state.poison(-7);
+    fake.destroy_failures_remaining = 1;
+    EXPECT_EQ(state.close(), -43);
+    // The controlled poison cause and the real teardown failure are reported
+    // through separate slots; neither masks the other.
+    EXPECT_EQ(state.last_runtime_error(), -7);
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+    EXPECT_EQ(state.close(), 0);
+    // The first teardown failure stays latched after a successful retry.
+    EXPECT_EQ(state.unexpected_teardown_error(), -43);
+}
+
+}  // namespace

--- a/tests/ut/cpp/common/test_static_arena_bank.cpp
+++ b/tests/ut/cpp/common/test_static_arena_bank.cpp
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+// Capacity rule for an arena bank's three pooled regions, shared verbatim by
+// the onboard and simulation runners' setup_static_arena.
+//
+// A kernel-mode context is the case under test: a captured graph replays the
+// base addresses the regions held when it was captured, so the assertions are
+// about addresses and about the underlying allocator, not about return codes
+// alone. DeviceArena defaults to a libc backend and counts its own alloc/free
+// calls, so an unwanted re-base is observable here with no device present.
+
+#include <cstddef>
+#include <cstdlib>
+
+#include <gtest/gtest.h>
+
+#include "host/static_arena_bank.h"
+#include "worker/runtime_c_api.h"
+
+namespace {
+
+constexpr size_t kGmHeapBytes = 64 * 1024;
+constexpr size_t kGmSmBytes = 16 * 1024;
+constexpr size_t kRuntimePoolBytes = 8 * 1024;
+
+// Backing allocator that fails a chosen allocation, which is what makes the
+// rollback path reachable here: DeviceArena's default libc backend never fails.
+struct FailingBackend {
+    int allocs{0};
+    int fail_on{0};  // 1-based index of the allocation to fail; 0 never fails
+
+    static void *alloc(void *ctx, size_t size) {
+        auto *self = static_cast<FailingBackend *>(ctx);
+        ++self->allocs;
+        if (self->fail_on != 0 && self->allocs == self->fail_on) return nullptr;
+        return std::malloc(size);
+    }
+    static void release(void * /*ctx*/, void *ptr) { std::free(ptr); }
+};
+
+// One bank's regions plus the sizes it remembers for them: the state a runner
+// keeps between calls.
+struct Bank {
+    Bank() = default;
+    explicit Bank(FailingBackend *backend) :
+        gm_heap(&FailingBackend::alloc, &FailingBackend::release, backend),
+        gm_sm(&FailingBackend::alloc, &FailingBackend::release, backend),
+        runtime_pool(&FailingBackend::alloc, &FailingBackend::release, backend) {}
+
+    DeviceArena gm_heap;
+    DeviceArena gm_sm;
+    DeviceArena runtime_pool;
+    size_t cached_gm_heap_size{0};
+    size_t cached_gm_sm_size{0};
+    size_t cached_runtime_pool_size{0};
+
+    StaticArenaBankRequest request(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_pool_size) {
+        return StaticArenaBankRequest{
+            {&gm_heap, &cached_gm_heap_size, gm_heap_size},
+            {&gm_sm, &cached_gm_sm_size, gm_sm_size},
+            {&runtime_pool, &cached_runtime_pool_size, runtime_pool_size},
+        };
+    }
+
+    StaticArenaBankOutcome commit(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_pool_size, bool kernel_mode) {
+        return commit_static_arena_bank(request(gm_heap_size, gm_sm_size, runtime_pool_size), kernel_mode);
+    }
+
+    size_t alloc_calls() const { return gm_heap.alloc_count() + gm_sm.alloc_count() + runtime_pool.alloc_count(); }
+    size_t free_calls() const { return gm_heap.free_count() + gm_sm.free_count() + runtime_pool.free_count(); }
+};
+
+// The three base addresses a caller may have handed to a captured graph.
+struct Bases {
+    void *gm_heap;
+    void *gm_sm;
+    void *runtime_pool;
+
+    bool operator==(const Bases &other) const {
+        return gm_heap == other.gm_heap && gm_sm == other.gm_sm && runtime_pool == other.runtime_pool;
+    }
+};
+
+Bases bases_of(const Bank &bank) { return Bases{bank.gm_heap.base(), bank.gm_sm.base(), bank.runtime_pool.base()}; }
+
+}  // namespace
+
+// The first commit is the context's own, and kernel mode must let it through:
+// a rule that refused it would leave a kernel context with no arena at all.
+TEST(StaticArenaBankKernelMode, FirstCommitIsPermitted) {
+    Bank bank;
+    const StaticArenaBankOutcome outcome = bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true);
+
+    EXPECT_EQ(outcome.rc, 0);
+    EXPECT_TRUE(outcome.bases_changed);
+    EXPECT_TRUE(bank.gm_heap.is_committed());
+    EXPECT_TRUE(bank.gm_sm.is_committed());
+    EXPECT_TRUE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.cached_gm_heap_size, kGmHeapBytes);
+    EXPECT_EQ(bank.cached_gm_sm_size, kGmSmBytes);
+    EXPECT_EQ(bank.cached_runtime_pool_size, kRuntimePoolBytes);
+}
+
+// Acceptance 1 and 2: base and capacity per region survive repeated calls at
+// the context's own sizes, and the allocator is not entered at all.
+TEST(StaticArenaBankKernelMode, RepeatedCommitsMoveNoBaseAndCallNoAllocator) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true).rc, 0);
+    const Bases pinned = bases_of(bank);
+    const size_t allocs_after_commit = bank.alloc_calls();
+    const size_t frees_after_commit = bank.free_calls();
+
+    for (int call = 0; call < 8; ++call) {
+        const StaticArenaBankOutcome outcome = bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true);
+        EXPECT_EQ(outcome.rc, 0);
+        EXPECT_FALSE(outcome.bases_changed);
+        EXPECT_TRUE(bases_of(bank) == pinned);
+    }
+
+    EXPECT_EQ(bank.alloc_calls(), allocs_after_commit);
+    EXPECT_EQ(bank.free_calls(), frees_after_commit);
+    EXPECT_EQ(bank.cached_gm_heap_size, kGmHeapBytes);
+    EXPECT_EQ(bank.cached_gm_sm_size, kGmSmBytes);
+    EXPECT_EQ(bank.cached_runtime_pool_size, kRuntimePoolBytes);
+}
+
+// Acceptance 3: a request landing exactly on the committed capacity succeeds,
+// and a smaller one is served from the same buffer.
+TEST(StaticArenaBankKernelMode, ExactAndSmallerRequestsAreServedInPlace) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true).rc, 0);
+    const Bases pinned = bases_of(bank);
+    const size_t allocs = bank.alloc_calls();
+
+    EXPECT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true).rc, 0);
+    EXPECT_EQ(bank.commit(kGmHeapBytes - 1, kGmSmBytes - 1, kRuntimePoolBytes - 1, true).rc, 0);
+
+    EXPECT_TRUE(bases_of(bank) == pinned);
+    EXPECT_EQ(bank.alloc_calls(), allocs);
+    // A request under capacity does not shrink what the bank remembers.
+    EXPECT_EQ(bank.cached_gm_heap_size, kGmHeapBytes);
+}
+
+// Acceptance 4 and 5: one byte over capacity is refused with
+// PTO_RUNTIME_ERR_INTERNAL, and the refusal leaves the bank able to serve the
+// layout it already holds.
+TEST(StaticArenaBankKernelMode, OneByteOverCapacityIsRefusedAndChangesNothing) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true).rc, 0);
+    const Bases pinned = bases_of(bank);
+    const size_t allocs = bank.alloc_calls();
+    const size_t frees = bank.free_calls();
+
+    const StaticArenaBankOutcome refused = bank.commit(kGmHeapBytes + 1, kGmSmBytes, kRuntimePoolBytes, true);
+
+    EXPECT_EQ(refused.rc, PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_FALSE(refused.bases_changed);
+    EXPECT_TRUE(bases_of(bank) == pinned);
+    EXPECT_TRUE(bank.gm_heap.is_committed());
+    EXPECT_TRUE(bank.gm_sm.is_committed());
+    EXPECT_TRUE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.alloc_calls(), allocs);
+    EXPECT_EQ(bank.free_calls(), frees);
+    EXPECT_EQ(bank.cached_gm_heap_size, kGmHeapBytes);
+
+    // The plan the bank held before the refusal is still the plan it serves.
+    const StaticArenaBankOutcome after = bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true);
+    EXPECT_EQ(after.rc, 0);
+    EXPECT_FALSE(after.bases_changed);
+    EXPECT_TRUE(bases_of(bank) == pinned);
+    EXPECT_EQ(bank.alloc_calls(), allocs);
+    EXPECT_EQ(bank.free_calls(), frees);
+}
+
+// A refusal naming a later region must not roll the earlier ones back. This is
+// the shape the whole rule protects: the rollback releases every region, so a
+// refusal routed through it would drop the addresses it just declined to move.
+TEST(StaticArenaBankKernelMode, RefusalOnALaterRegionKeepsItsPeersCommitted) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true).rc, 0);
+    const Bases pinned = bases_of(bank);
+    const size_t frees = bank.free_calls();
+
+    const StaticArenaBankOutcome refused = bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes + 1, true);
+
+    EXPECT_EQ(refused.rc, PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_TRUE(bases_of(bank) == pinned);
+    EXPECT_TRUE(bank.gm_heap.is_committed());
+    EXPECT_TRUE(bank.gm_sm.is_committed());
+    EXPECT_TRUE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.free_calls(), frees);
+    EXPECT_EQ(bank.cached_gm_heap_size, kGmHeapBytes);
+    EXPECT_EQ(bank.cached_gm_sm_size, kGmSmBytes);
+    EXPECT_EQ(bank.cached_runtime_pool_size, kRuntimePoolBytes);
+}
+
+// Releasing is the other way a base goes away, and hbg's runtime-arena path
+// asks for it by passing zero on every bind.
+TEST(StaticArenaBankKernelMode, ReleasingACommittedRegionIsRefused) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true).rc, 0);
+    const Bases pinned = bases_of(bank);
+    const size_t frees = bank.free_calls();
+
+    const StaticArenaBankOutcome refused = bank.commit(kGmHeapBytes, kGmSmBytes, 0, true);
+
+    EXPECT_EQ(refused.rc, PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_TRUE(bank.runtime_pool.is_committed());
+    EXPECT_TRUE(bases_of(bank) == pinned);
+    EXPECT_EQ(bank.free_calls(), frees);
+    EXPECT_EQ(bank.cached_runtime_pool_size, kRuntimePoolBytes);
+}
+
+// A region the bank never committed carries no address anyone can hold, so a
+// zero request for it is the ordinary case of hbg passing zero, not a release.
+TEST(StaticArenaBankKernelMode, ZeroRequestForAnUncommittedRegionIsPermitted) {
+    Bank bank;
+    const StaticArenaBankOutcome outcome = bank.commit(kGmHeapBytes, kGmSmBytes, 0, true);
+
+    EXPECT_EQ(outcome.rc, 0);
+    EXPECT_TRUE(bank.gm_heap.is_committed());
+    EXPECT_FALSE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.cached_runtime_pool_size, 0u);
+
+    // And it stays permitted on every later bind.
+    EXPECT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, 0, true).rc, 0);
+}
+
+// An allocation failure is the other failure class, and it takes the opposite
+// exit: the whole bank is released, peers that committed fine included, so a
+// caller retries from the post-construction state rather than a partial layout.
+TEST(StaticArenaBankProgramMode, AllocationFailureRollsTheWholeBankBack) {
+    FailingBackend backend;
+    Bank bank(&backend);
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, false).rc, 0);
+    ASSERT_TRUE(bank.gm_heap.is_committed());
+
+    // Let the gm_heap grow succeed and fail the gm_sm one behind it.
+    backend.fail_on = backend.allocs + 2;
+    const StaticArenaBankOutcome outcome = bank.commit(kGmHeapBytes * 2, kGmSmBytes * 2, kRuntimePoolBytes, false);
+
+    EXPECT_EQ(outcome.rc, PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_TRUE(outcome.bases_changed);
+    EXPECT_FALSE(bank.gm_heap.is_committed());
+    EXPECT_FALSE(bank.gm_sm.is_committed());
+    EXPECT_FALSE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.cached_gm_heap_size, 0u);
+    EXPECT_EQ(bank.cached_gm_sm_size, 0u);
+    EXPECT_EQ(bank.cached_runtime_pool_size, 0u);
+}
+
+// A kernel-mode context's first commit can still fail on allocation, and that
+// is not a capacity refusal: it rolls back like any other allocation failure,
+// because a setup that never completed published no address for a captured
+// graph to hold. The two failure classes are distinguished by what happened,
+// not by the mode.
+TEST(StaticArenaBankKernelMode, AllocationFailureOnTheFirstCommitStillRollsBack) {
+    FailingBackend backend;
+    backend.fail_on = 3;  // gm_heap and gm_sm commit; runtime_pool fails
+    Bank bank(&backend);
+
+    const StaticArenaBankOutcome outcome = bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, true);
+
+    EXPECT_EQ(outcome.rc, PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_TRUE(outcome.bases_changed);
+    EXPECT_FALSE(bank.gm_heap.is_committed());
+    EXPECT_FALSE(bank.gm_sm.is_committed());
+    EXPECT_FALSE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.cached_gm_heap_size, 0u);
+    EXPECT_EQ(bank.cached_gm_sm_size, 0u);
+    EXPECT_EQ(bank.cached_runtime_pool_size, 0u);
+}
+
+// Program mode keeps the growth and rollback behavior it has always had: the
+// rule is selected by the context's identity, not applied to every caller.
+TEST(StaticArenaBankProgramMode, GrowthRebasesTheRegion) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, false).rc, 0);
+    const size_t frees_before = bank.free_calls();
+
+    const StaticArenaBankOutcome grown = bank.commit(kGmHeapBytes * 2, kGmSmBytes, kRuntimePoolBytes, false);
+
+    EXPECT_EQ(grown.rc, 0);
+    EXPECT_TRUE(grown.bases_changed);
+    EXPECT_EQ(bank.cached_gm_heap_size, kGmHeapBytes * 2);
+    EXPECT_GT(bank.free_calls(), frees_before);
+}
+
+TEST(StaticArenaBankProgramMode, ZeroRequestReleasesACommittedRegion) {
+    Bank bank;
+    ASSERT_EQ(bank.commit(kGmHeapBytes, kGmSmBytes, kRuntimePoolBytes, false).rc, 0);
+
+    const StaticArenaBankOutcome outcome = bank.commit(kGmHeapBytes, kGmSmBytes, 0, false);
+
+    EXPECT_EQ(outcome.rc, 0);
+    EXPECT_TRUE(outcome.bases_changed);
+    EXPECT_FALSE(bank.runtime_pool.is_committed());
+    EXPECT_EQ(bank.cached_runtime_pool_size, 0u);
+}

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -64,6 +64,10 @@ struct FakeHostApi {
     int setup_static_arena_count = 0;
     int fail_copy_to_on_call = 0;
     int fail_device_malloc_on_call = 0;
+    // The context's execution identity, as the platform reports it. A
+    // kernel-mode context's retained buffer keeps its address for the
+    // context's life.
+    bool kernel_mode = false;
     // The retained temporary-buffer slot the platform remembers across runs.
     void *retained_addr = nullptr;
     size_t retained_size = 0;
@@ -137,6 +141,8 @@ int fake_copy_from_device(void * /*runner_ctx*/, void *host_ptr, const void *dev
     std::memcpy(host_ptr, dev_ptr, size);
     return 0;
 }
+
+bool fake_is_kernel_mode(void * /*runner_ctx*/) { return g_fake->kernel_mode; }
 
 void *fake_register_device_memory_to_host(void * /*runner_ctx*/, void *dev_ptr, size_t /* bytes */) { return dev_ptr; }
 
@@ -222,6 +228,7 @@ HostApi make_host_api() {
         .lookup_prebuilt_runtime_arena_cache = fake_lookup_prebuilt_runtime_arena_cache,
         .mark_prebuilt_runtime_arena_cached = fake_mark_prebuilt_runtime_arena_cached,
         .upload_chip_callable_buffer = fake_upload_chip_callable_buffer,
+        .is_kernel_mode = fake_is_kernel_mode,
     };
     return HostApi(nullptr, 0, 0, &ops);
 }
@@ -483,4 +490,223 @@ TEST_F(TrbRuntimeTempBufferTest, PreparedRuntimeEnvRequiresTheActiveArenaKey) {
     heap[2] = 2048;
     EXPECT_EQ(prepared_run_config_compatible_impl(&compatibility_api, task_window, heap, dep_pool), 0);
     EXPECT_NE(fake_.observed_key, fake_.compatibility_key);
+}
+
+// ---------------------------------------------------------------------------
+// Kernel-mode capacity: the retained buffer is context-static, so a run that
+// would grow it is refused rather than served. Growing is free + malloc, which
+// re-bases every slice the buffer has handed out, and a captured graph replays
+// the addresses of the run it captured. An empty slot holds no such address, so
+// the context's first allocation is not a re-base and is taken normally.
+//
+// The latch is write-once, so a real context is in kernel mode from its very
+// first bind -- KernelModeAllocatesOnceThenRefusesToGrow is that shape. The
+// cases that warm up in program mode and then flip the flag isolate the guard
+// itself against a slot that already holds a buffer.
+// ---------------------------------------------------------------------------
+
+// A run whose tensors are all device memory stages nothing: the packed
+// temporary size is zero, so the retained slot is never reached and no grow is
+// considered. This is the shape a kernel bind is meant to have.
+TEST_F(TrbRuntimeTempBufferTest, KernelModeDeviceTensorRunTouchesNoAllocator) {
+    fake_.reset();
+    fake_.kernel_mode = true;
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> first(64, 1);
+    std::vector<uint8_t> second(64, 2);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(first, true));
+    args.add_tensor(make_tensor(second, true));
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+
+    ASSERT_EQ(bind_runtime(runtime, api_, args, signature, 2), 0);
+
+    EXPECT_EQ(fake_.device_malloc_count, 0);
+    EXPECT_EQ(fake_.device_free_count, 0);
+    EXPECT_EQ(fake_.retained_addr, nullptr);
+    EXPECT_EQ(fake_.retained_size, 0u);
+}
+
+// The shape a real kernel context takes. Its first bind finds an empty slot and
+// must be allowed to allocate, since no captured graph can hold a slice of a
+// buffer that never existed; every later bind that would outgrow that buffer is
+// refused, because by then the address is one a replay may reference.
+TEST_F(TrbRuntimeTempBufferTest, KernelModeAllocatesOnceThenRefusesToGrow) {
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+    fake_.reset();
+    fake_.kernel_mode = true;
+
+    std::vector<uint8_t> sized_in(64, 1);
+    std::vector<uint8_t> sized_out(64, 0);
+    ChipStorageTaskArgs sized = make_args(sized_in, sized_out);
+    Runtime first_run = make_runtime();
+    ASSERT_EQ(bind_runtime(first_run, api_, sized, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&first_run, &api_, 0), 0);
+    void *pinned_addr = fake_.retained_addr;
+    const size_t pinned_size = fake_.retained_size;
+    ASSERT_NE(pinned_addr, nullptr);
+    EXPECT_EQ(pinned_size, align_up(64, kAlign) * 2);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.device_free_count, 0);
+
+    // Past that one allocation the slot is frozen.
+    std::vector<uint8_t> big_in(64, 1);
+    std::vector<uint8_t> big_out(kAlign + 1, 0);
+    ChipStorageTaskArgs big = make_args(big_in, big_out);
+    Runtime big_run = make_runtime();
+    EXPECT_EQ(bind_runtime(big_run, api_, big, signature, 2), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(fake_.retained_addr, pinned_addr);
+    EXPECT_EQ(fake_.retained_size, pinned_size);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.device_free_count, 0);
+
+    // The run the context was sized for still binds, from the same address.
+    Runtime again = make_runtime();
+    EXPECT_EQ(bind_runtime(again, api_, sized, signature, 2), 0);
+    EXPECT_EQ(validate_runtime_impl(&again, &api_, 0), 0);
+    EXPECT_EQ(fake_.retained_addr, pinned_addr);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.device_free_count, 0);
+}
+
+// A run larger than the retained buffer is refused, and the refusal happens
+// ahead of the free: the slot still holds the address and size the previous
+// run left there.
+TEST_F(TrbRuntimeTempBufferTest, KernelModeRefusesToGrowTheRetainedBuffer) {
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+    fake_.reset();
+
+    // The buffer the context was prepared with.
+    std::vector<uint8_t> warm_in(64, 1);
+    std::vector<uint8_t> warm_out(64, 0);
+    ChipStorageTaskArgs warm = make_args(warm_in, warm_out);
+    Runtime warm_run = make_runtime();
+    ASSERT_EQ(bind_runtime(warm_run, api_, warm, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&warm_run, &api_, 0), 0);
+    void *pinned_addr = fake_.retained_addr;
+    const size_t pinned_size = fake_.retained_size;
+    ASSERT_EQ(pinned_size, align_up(64, kAlign) * 2);
+    const int mallocs = fake_.device_malloc_count;
+    const int frees = fake_.device_free_count;
+
+    fake_.kernel_mode = true;
+    // One alignment unit past what the buffer holds.
+    std::vector<uint8_t> big_in(64, 1);
+    std::vector<uint8_t> big_out(kAlign + 1, 0);
+    ChipStorageTaskArgs big = make_args(big_in, big_out);
+    Runtime refused = make_runtime();
+
+    EXPECT_EQ(bind_runtime(refused, api_, big, signature, 2), PTO_RUNTIME_ERR_INTERNAL);
+    EXPECT_EQ(fake_.retained_addr, pinned_addr);
+    EXPECT_EQ(fake_.retained_size, pinned_size);
+    EXPECT_EQ(fake_.device_malloc_count, mallocs);
+    EXPECT_EQ(fake_.device_free_count, frees);
+    EXPECT_TRUE(refused.tensor_leases_.empty());
+}
+
+// The refused run leaves the plan the context was prepared with intact: a run
+// that fits still binds, from the same address, without entering the allocator.
+TEST_F(TrbRuntimeTempBufferTest, KernelModeRefusalLeavesTheRetainedBufferUsable) {
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+    fake_.reset();
+
+    std::vector<uint8_t> warm_in(64, 1);
+    std::vector<uint8_t> warm_out(64, 0);
+    ChipStorageTaskArgs warm = make_args(warm_in, warm_out);
+    Runtime warm_run = make_runtime();
+    ASSERT_EQ(bind_runtime(warm_run, api_, warm, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&warm_run, &api_, 0), 0);
+    void *pinned_addr = fake_.retained_addr;
+    const size_t pinned_size = fake_.retained_size;
+
+    fake_.kernel_mode = true;
+    std::vector<uint8_t> big_in(64, 1);
+    std::vector<uint8_t> big_out(kAlign + 1, 0);
+    ChipStorageTaskArgs big = make_args(big_in, big_out);
+    Runtime refused = make_runtime();
+    ASSERT_EQ(bind_runtime(refused, api_, big, signature, 2), PTO_RUNTIME_ERR_INTERNAL);
+    const int mallocs = fake_.device_malloc_count;
+    const int frees = fake_.device_free_count;
+
+    Runtime after = make_runtime();
+    EXPECT_EQ(bind_runtime(after, api_, warm, signature, 2), 0);
+    EXPECT_EQ(validate_runtime_impl(&after, &api_, 0), 0);
+    EXPECT_EQ(fake_.retained_addr, pinned_addr);
+    EXPECT_EQ(fake_.retained_size, pinned_size);
+    EXPECT_EQ(fake_.device_malloc_count, mallocs);
+    EXPECT_EQ(fake_.device_free_count, frees);
+}
+
+// Address and capacity hold across repeated runs, including a run that fills
+// the buffer exactly and runs whose tensors arrive in a different order.
+TEST_F(TrbRuntimeTempBufferTest, KernelModeHoldsOneAddressAcrossRepeatedRuns) {
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+    fake_.reset();
+
+    std::vector<uint8_t> warm_in(kAlign * 2, 1);
+    std::vector<uint8_t> warm_out(kAlign * 2, 0);
+    ChipStorageTaskArgs warm = make_args(warm_in, warm_out);
+    Runtime warm_run = make_runtime();
+    ASSERT_EQ(bind_runtime(warm_run, api_, warm, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&warm_run, &api_, 0), 0);
+    void *pinned_addr = fake_.retained_addr;
+    const size_t pinned_size = fake_.retained_size;
+    ASSERT_EQ(pinned_size, kAlign * 4);
+
+    fake_.kernel_mode = true;
+    const int mallocs = fake_.device_malloc_count;
+    const int frees = fake_.device_free_count;
+
+    // A run that exactly fills the buffer, four times over.
+    for (int run = 0; run < 4; ++run) {
+        Runtime exact = make_runtime();
+        EXPECT_EQ(bind_runtime(exact, api_, warm, signature, 2), 0);
+        EXPECT_EQ(validate_runtime_impl(&exact, &api_, 0), 0);
+        EXPECT_EQ(fake_.retained_addr, pinned_addr);
+        EXPECT_EQ(fake_.retained_size, pinned_size);
+    }
+
+    // A run that packs to strictly less than the retained size, and one whose
+    // tensors are the same pair reversed.
+    std::vector<uint8_t> small_in(64, 1);
+    std::vector<uint8_t> small_out(64, 0);
+    ChipStorageTaskArgs small = make_args(small_in, small_out);
+    ASSERT_LT(align_up(64, kAlign) * 2, pinned_size);
+    Runtime small_run = make_runtime();
+    EXPECT_EQ(bind_runtime(small_run, api_, small, signature, 2), 0);
+    EXPECT_EQ(validate_runtime_impl(&small_run, &api_, 0), 0);
+
+    ChipStorageTaskArgs reordered = make_args(warm_out, warm_in);
+    Runtime reordered_run = make_runtime();
+    EXPECT_EQ(bind_runtime(reordered_run, api_, reordered, signature, 2), 0);
+    EXPECT_EQ(validate_runtime_impl(&reordered_run, &api_, 0), 0);
+
+    EXPECT_EQ(fake_.retained_addr, pinned_addr);
+    EXPECT_EQ(fake_.retained_size, pinned_size);
+    EXPECT_EQ(fake_.device_malloc_count, mallocs);
+    EXPECT_EQ(fake_.device_free_count, frees);
+}
+
+// Program mode still grows, so the rule is selected by the context's identity
+// rather than applied to every caller.
+TEST_F(TrbRuntimeTempBufferTest, ProgramModeStillGrowsTheRetainedBuffer) {
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+    fake_.reset();
+
+    std::vector<uint8_t> small_in(64, 1);
+    std::vector<uint8_t> small_out(64, 0);
+    ChipStorageTaskArgs small = make_args(small_in, small_out);
+    Runtime small_run = make_runtime();
+    ASSERT_EQ(bind_runtime(small_run, api_, small, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&small_run, &api_, 0), 0);
+
+    std::vector<uint8_t> big_in(64, 1);
+    std::vector<uint8_t> big_out(kAlign + 1, 0);
+    ChipStorageTaskArgs big = make_args(big_in, big_out);
+    Runtime big_run = make_runtime();
+    EXPECT_EQ(bind_runtime(big_run, api_, big, signature, 2), 0);
+    EXPECT_EQ(validate_runtime_impl(&big_run, &api_, 0), 0);
+    EXPECT_EQ(fake_.device_malloc_count, 2);
+    EXPECT_EQ(fake_.device_free_count, 1);
+    EXPECT_EQ(fake_.retained_size, align_up(64, kAlign) + align_up(kAlign + 1, kAlign));
 }

--- a/tests/ut/cpp/types/test_callable_scalar_count.cpp
+++ b/tests/ut/cpp/types/test_callable_scalar_count.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// ChipCallable::scalar_count_ contract: the field is a cached derivation of
+// the signature's SCALAR entries (0 also meaning "not recorded"), the factory
+// validates range and signature agreement, the field occupies former header
+// padding only, and a blob written by a producer that predates the field
+// (whose padding make_callable zero-initialized) reads back as
+// scalar_count == 0.
+
+#include <cstddef>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "callable.h"
+
+namespace {
+
+// Builds a chip callable whose signature carries `scalar_entries` trailing
+// SCALAR entries after one IN and one OUT tensor, declaring `declared_count`
+// as its scalar count.
+std::vector<uint8_t> build_chip_callable(int32_t declared_count, int32_t scalar_entries) {
+    std::vector<ArgDirection> sig{ArgDirection::IN, ArgDirection::OUT};
+    for (int32_t i = 0; i < scalar_entries; ++i)
+        sig.push_back(ArgDirection::SCALAR);
+
+    ArgDirection core_sig[1] = {ArgDirection::IN};
+    const uint8_t kernel[] = {0x01, 0x02, 0x03, 0x04};
+    auto core = make_callable<CORE_MAX_TENSOR_ARGS>(core_sig, 1, kernel, sizeof(kernel));
+
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F'};
+    int32_t child_ids[1] = {3};
+    std::vector<uint8_t> children[1] = {std::move(core)};
+
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        sig.data(), static_cast<int32_t>(sig.size()), declared_count, "orch_fn", fake_orch_so, sizeof(fake_orch_so),
+        child_ids, children, 1, "cfg_name"
+    );
+}
+
+// scalar_count() reads 0 both for a scalar-free orchestration and for an
+// artifact built before the field existed, so the wire contract has a consumer
+// derive the effective count from the signature when the field is 0 rather
+// than subtracting it. This pins the answer the naive formula gets wrong, so a
+// consumer that reintroduces it fails here rather than on device.
+TEST(CallableScalarCount, SubtractingAnUnrecordedCountMiscountsScalarsAsTensors) {
+    auto buf = build_chip_callable(0, 9);
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    ASSERT_EQ(callable->sig_count(), 11);
+    ASSERT_EQ(callable->scalar_count(), 0);
+
+    int32_t signature_scalars = 0;
+    for (int32_t i = 0; i < callable->sig_count(); ++i) {
+        if (callable->sig(i) == ArgDirection::SCALAR) ++signature_scalars;
+    }
+    ASSERT_EQ(signature_scalars, 9);
+
+    const int32_t effective_scalars = callable->scalar_count() != 0 ? callable->scalar_count() : signature_scalars;
+    EXPECT_EQ(callable->sig_count() - effective_scalars, 2);
+    EXPECT_EQ(callable->sig_count() - callable->scalar_count(), 11);
+}
+
+}  // namespace
+
+TEST(CallableScalarCount, RoundTripsThroughFactory) {
+    for (int32_t count : {0, 1, 7, CHIP_MAX_SCALAR_ARGS}) {
+        auto buf = build_chip_callable(count, count);
+        const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+        EXPECT_EQ(callable->scalar_count(), count);
+        EXPECT_EQ(callable->sig_count(), 2 + count);
+    }
+}
+
+TEST(CallableScalarCount, RejectsOutOfRangeWithValueAndLimit) {
+    for (int32_t count : {-1, CHIP_MAX_SCALAR_ARGS + 1}) {
+        try {
+            (void)build_chip_callable(count, count > 0 ? count : 0);
+            FAIL() << "expected scalar count validation to fail for " << count;
+        } catch (const std::invalid_argument &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(std::to_string(count)), std::string::npos) << message;
+            EXPECT_NE(message.find(std::to_string(CHIP_MAX_SCALAR_ARGS)), std::string::npos) << message;
+        }
+    }
+}
+
+// A nonzero count is a cached derivation of the signature, so a value that
+// disagrees with the signature's SCALAR entries is rejected naming both
+// numbers. Zero stays valid with any signature (legacy "not recorded").
+TEST(CallableScalarCount, RejectsCountDisagreeingWithSignature) {
+    struct Case {
+        int32_t declared;
+        int32_t entries;
+    };
+    for (const Case &c : {Case{5, 0}, Case{3, 9}}) {
+        try {
+            (void)build_chip_callable(c.declared, c.entries);
+            FAIL() << "expected consistency validation to fail for declared=" << c.declared << " entries=" << c.entries;
+        } catch (const std::invalid_argument &error) {
+            const std::string message = error.what();
+            EXPECT_NE(message.find(std::to_string(c.declared)), std::string::npos) << message;
+            EXPECT_NE(message.find(std::to_string(c.entries)), std::string::npos) << message;
+        }
+    }
+    auto unrecorded = build_chip_callable(0, 9);
+    EXPECT_EQ(reinterpret_cast<const ChipCallable *>(unrecorded.data())->scalar_count(), 0);
+}
+
+// A legacy blob is byte-identical to a current one built with the same inputs
+// except that the four bytes now holding scalar_count_ were zero-initialized
+// padding. Zeroing them reproduces such a blob exactly.
+TEST(CallableScalarCount, LegacyBlobReadsZero) {
+    auto buf = build_chip_callable(9, 9);
+    std::memset(buf.data() + offsetof(ChipCallable, scalar_count_), 0, sizeof(int32_t));
+
+    const auto *callable = reinterpret_cast<const ChipCallable *>(buf.data());
+    EXPECT_EQ(callable->scalar_count(), 0);
+    EXPECT_EQ(callable->sig_count(), 11);
+    EXPECT_EQ(std::string(callable->func_name(), callable->func_name_len()), "orch_fn");
+    EXPECT_EQ(std::string(callable->config_name(), callable->config_name_len()), "cfg_name");
+    ASSERT_EQ(callable->child_count(), 1);
+    EXPECT_EQ(callable->child_func_id(0), 3);
+    EXPECT_EQ(callable->child(0).binary_size(), 4u);
+}
+
+// Two builds with the same signature that differ only in the declared count
+// (0 = "not recorded" vs the real derivation) must differ only in that
+// field's four bytes — every other header byte, the orchestration binary,
+// and the child payload keep their positions and values.
+TEST(CallableScalarCount, OnlyTheFieldBytesVary) {
+    auto unrecorded = build_chip_callable(0, 9);
+    auto nine = build_chip_callable(9, 9);
+    ASSERT_EQ(unrecorded.size(), nine.size());
+
+    constexpr size_t field_begin = offsetof(ChipCallable, scalar_count_);
+    constexpr size_t field_end = field_begin + sizeof(int32_t);
+    for (size_t i = 0; i < unrecorded.size(); ++i) {
+        if (i >= field_begin && i < field_end) continue;
+        ASSERT_EQ(unrecorded[i], nine[i]) << "byte " << i << " must not depend on scalar_count";
+    }
+    EXPECT_NE(std::memcmp(unrecorded.data() + field_begin, nine.data() + field_begin, sizeof(int32_t)), 0);
+}

--- a/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
+++ b/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
@@ -60,7 +60,7 @@ std::vector<uint8_t> build_test_chip_callable() {
     std::vector<uint8_t> children[2] = {std::move(core0), std::move(core1)};
 
     return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-        nullptr, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
+        nullptr, 0, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
     );
 }
 

--- a/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
+++ b/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
@@ -50,7 +50,7 @@ TEST(ChipMaxTensorArgs, ChipStorageHoldsCapacity) {
 TEST(ChipMaxTensorArgs, ChipCallableAcceptsCapacity) {
     std::vector<ArgDirection> signature(256, ArgDirection::IN);
     auto buffer = make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-        signature.data(), static_cast<int32_t>(signature.size()), "composed", nullptr, 0, nullptr, nullptr, 0, ""
+        signature.data(), static_cast<int32_t>(signature.size()), 0, "composed", nullptr, 0, nullptr, nullptr, 0, ""
     );
 
     const auto &callable = *reinterpret_cast<const ChipCallable *>(buffer.data());
@@ -63,7 +63,7 @@ TEST(ChipMaxTensorArgs, ChipCallableOverflowReportsRequestedAndSupportedCounts) 
 
     try {
         (void)make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
-            signature.data(), requested, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
+            signature.data(), requested, 0, "overflow", nullptr, 0, nullptr, nullptr, 0, ""
         );
         FAIL() << "expected signature capacity validation to fail";
     } catch (const std::invalid_argument &error) {

--- a/tests/ut/cpp/types/test_kernel_invocation_header.cpp
+++ b/tests/ut/cpp/types/test_kernel_invocation_header.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "kernel_invocation_header.h"
+
+namespace {
+
+TEST(KernelInvocationHeaderWire, ModeValuesArePinned) {
+    EXPECT_EQ(SIMPLER_MODE_PROGRAM, 0);
+    EXPECT_EQ(SIMPLER_MODE_KERNEL, 1);
+}
+
+TEST(KernelInvocationHeaderWire, SurvivesMemcpyRoundtrip) {
+    SimplerKernelInvocationHeader header{};
+    header.mode = SIMPLER_MODE_KERNEL;
+    header.callable_id = 17;
+    header.generation = 0x1122334455667788ull;
+    header.payload_bytes = 4096;
+    header.tensor_count = 12;
+    header.scalar_count = 5;
+
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)];
+    std::memcpy(wire, &header, sizeof(header));
+    SimplerKernelInvocationHeader restored{};
+    std::memcpy(&restored, wire, sizeof(restored));
+
+    EXPECT_EQ(restored.mode, static_cast<uint32_t>(SIMPLER_MODE_KERNEL));
+    EXPECT_EQ(restored.callable_id, 17);
+    EXPECT_EQ(restored.generation, 0x1122334455667788ull);
+    EXPECT_EQ(restored.payload_bytes, 4096u);
+    EXPECT_EQ(restored.tensor_count, 12);
+    EXPECT_EQ(restored.scalar_count, 5);
+    EXPECT_EQ(restored.host_copy_tensor_count, 0);
+}
+
+TEST(KernelInvocationHeaderWire, ZeroInitializedBlobReadsAsEmpty) {
+    unsigned char wire[sizeof(SimplerKernelInvocationHeader)] = {};
+    SimplerKernelInvocationHeader header;
+    std::memcpy(&header, wire, sizeof(header));
+    EXPECT_EQ(header.mode, static_cast<uint32_t>(SIMPLER_MODE_PROGRAM));
+    EXPECT_EQ(header.payload_bytes, 0u);
+    EXPECT_EQ(header.tensor_count, 0);
+    EXPECT_EQ(header.scalar_count, 0);
+    EXPECT_EQ(header.host_copy_tensor_count, 0);
+}
+
+}  // namespace

--- a/tests/ut/py/test_host_runtime_abi.py
+++ b/tests/ut/py/test_host_runtime_abi.py
@@ -23,6 +23,15 @@ _NEWLY_REQUIRED_PIPELINE_SYMBOLS = {
     "get_retained_temp_addr_ctx",
     "supports_concurrent_native_prepare_ctx",
 }
+# Kernel-mode lifecycle surface: every host-runtime component exports all of
+# these; components without kernel-mode support export validating stubs that
+# report unsupported rather than omitting the symbols.
+_KERNEL_MODE_SYMBOLS = {
+    "simpler_kernel_mode_init",
+    "simpler_kernel_mode_launch",
+    "simpler_kernel_mode_prepare_callable",
+    "simpler_kernel_mode_supported",
+}
 _REMOVED_AMBIENT_SELECTION_SYMBOLS = {
     "select_arena_bank_ctx",
     "select_pipeline_slot_ctx",
@@ -73,4 +82,5 @@ def test_host_runtime_exports_required_pipeline_symbols(arch: str, variant: str,
     symbols = _defined_external_symbols(runtime_path)
 
     assert _NEWLY_REQUIRED_PIPELINE_SYMBOLS <= symbols, sorted(_NEWLY_REQUIRED_PIPELINE_SYMBOLS - symbols)
+    assert _KERNEL_MODE_SYMBOLS <= symbols, sorted(_KERNEL_MODE_SYMBOLS - symbols)
     assert symbols.isdisjoint(_REMOVED_AMBIENT_SELECTION_SYMBOLS), sorted(symbols & _REMOVED_AMBIENT_SELECTION_SYMBOLS)

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -1406,6 +1406,67 @@ class TestChipCallable:
         assert "sig_count=2" in r
         assert "child_count=1" in r
 
+    def test_scalar_count_defaults_to_zero(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN],
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert chip.scalar_count == 0
+
+    def test_scalar_count_keyword_round_trip(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN, ArgDirection.OUT] + [ArgDirection.SCALAR] * 5,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+            scalar_count=5,
+        )
+        assert chip.scalar_count == 5
+
+    def test_scalar_count_survives_from_bytes(self):
+        chip = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 7,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+            scalar_count=7,
+        )
+        raw = ctypes.string_at(int(chip.buffer_ptr()), int(chip.buffer_size()))
+        clone = ChipCallable.from_bytes(raw)
+        assert clone.scalar_count == 7
+
+    def test_scalar_count_out_of_range_reports_value_and_limit(self):
+        for bad in (-1, 129):
+            with pytest.raises(ValueError, match=rf"{bad}.*128"):
+                ChipCallable.build(
+                    signature=[],
+                    func_name="test_func",
+                    binary=b"\x00",
+                    children=[],
+                    scalar_count=bad,
+                )
+
+    def test_scalar_count_disagreeing_with_signature_rejected(self):
+        """A nonzero count is a cached derivation of the signature; zero also
+        means "not recorded" and stays valid with any signature."""
+        with pytest.raises(ValueError, match=r"5.*0.*SCALAR"):
+            ChipCallable.build(
+                signature=[ArgDirection.IN, ArgDirection.OUT],
+                func_name="test_func",
+                binary=b"\x00",
+                children=[],
+                scalar_count=5,
+            )
+        unrecorded = ChipCallable.build(
+            signature=[ArgDirection.IN] + [ArgDirection.SCALAR] * 3,
+            func_name="test_func",
+            binary=b"\x00",
+            children=[],
+        )
+        assert unrecorded.scalar_count == 0
+
 
 # ============================================================================
 # ChipTensor.child_memory


### PR DESCRIPTION
> **Depends on #2064** (①K1) @ `86dd62b4912866a6e96d63891b4c2838a2635b5a`
>
> This branch is built directly on that commit, which is not yet merged. The
> `main` base above is a GitHub constraint — a branch on a fork cannot be a PR
> base — so **the diff shown against `main` includes all of K1**. Exactly one
> commit is mine:
>
> - `b8e739d9` — kernel-mode capacity refusals no longer free what they protect
>
> Incremental diff (this PR only):
> https://github.com/sunkaixuan2018/simpler-PTO/compare/86dd62b4912866a6e96d63891b4c2838a2635b5a...skx/kernel-capacity-freeze-k3
>
> **Draft until #2064 merges**, then rebased and marked ready.

## What this is

A kernel-mode context's device buffers must keep their addresses for the life of
the context, because an ACLGraph replays the addresses that were captured. Every
runtime-time growth is `release + reserve` or `free + malloc`, which re-bases; the
failure mode is **silently wrong data on replay**, not a crash. That makes this a
correctness change, not a sizing one.

K1 landed the first guard on that invariant, in `setup_static_arena`. **Its
predicate is right and is unchanged here.** What this PR fixes is that its
refusal, and the refusal on the second growth point, were both destructive.

## Two refusals that destroyed what they protected

**1. `setup_static_arena` — the guard freed the bases it had just declined to
move.** The refusal returned `PTO_RUNTIME_ERR_INTERNAL`, the caller collapsed that
to `ok = false`, and the `!ok` block released all three regions unconditionally.
`DeviceArena::release()` frees the backing buffer, so a fired guard dropped
exactly the base addresses it names in its own error message. K1's comment above
the guard said so; nothing acted on it.

**2. `RetainedTempBump::begin` — the free came before anything could refuse.** The
grow path is `device_free(old)` then `device_malloc(bigger)`. A refusal placed
anywhere downstream of that — including at the platform's `device_malloc` —
arrives after the address is already gone, and the existing failure path then
clears the slot to `{nullptr, 0}`. The guard has to sit ahead of the free.

The invariant both fixes share, and the one every later growth-point guard will
need: **a refusal must have no side effects.**

## What changed

| | |
| --- | --- |
| `host/static_arena_bank.h` (new) | the bank's commit rule, shared by the onboard and simulation runners instead of hand-duplicated in both |
| the rule's failure handling | an allocation failure still rolls the whole bank back; a capacity refusal leaves every region committed and every cached size intact |
| both `setup_static_arena` bodies | ~55 lines each become a request literal plus a call; each keeps its own prebuilt-arena cache invalidation, now keyed on `bases_changed` |
| `RetainedTempBump::begin` (a2a3 + a5) | refuses a kernel-mode re-base ahead of the `device_free`, leaving the slot as the previous run left it |
| `HostApiOps::is_kernel_mode` (new) | how the context's identity reaches runtime code; a table that does not supply it reports program mode |
| six contract sites | the docs that described the behavior these guards make conditional, listed below |

`is_kernel_mode` is a query of the existing `ExecutionModeLatch`, not a new
switch — no environment variable and no macro, per
[`env-macro-gating.md`](.claude/rules/env-macro-gating.md) §1. Its producer
(`c_api_shared.cpp`) and its consumer (`runtime_maker.cpp`) are compiled into the
same `libhost_runtime.so`, so appending to the ops table creates no ABI skew.

### The retained-buffer guard refuses a re-base, not an allocation

This is the part worth a reviewer's attention, because I got it wrong first.

The guard fires on `required > size && addr != nullptr`. The `addr != nullptr`
half matters: an empty slot holds no address a captured graph could reference, so
a context's **first** allocation moves nothing and is taken normally. Without that
clause the guard refuses the first bind too, and since the grow path is the only
writer of the slot, the slot would stay `{nullptr, 0}` forever — a kernel context
could never reach its frozen size at all.

My first version omitted it, on the premise that a kernel run never stages host
tensors anyway. **That premise is not enforced anywhere in the tree**, and I could
not support it on a re-read:

- `validate_kernel_launch_args` checks null-ness and the callable-id range. It
  never inspects tensors.
- `ChipTensor::address_space` **defaults to `HOST`**, so the default goes the
  opposite way.
- `SimplerKernelInvocationHeader::host_copy_tensor_count` exists precisely to
  carry host-memory args in kernel mode, documented as "zero until the host-only
  copy contract lands". Host tensors there are a planned contract, not an excluded
  one.

So the narrow guard is the correct one: it still refuses every real re-base, and
it refuses nothing else.

### Doc updates in the same commit

The behavior these guards make conditional was described in six places, all of
which now read false for a kernel context and move with the code:
`setup_static_arena` and the retained-temp-buffer entries in `host_api.h`,
`DeviceRunnerBase::setup_static_arena`'s rollback promise (and its `@return`,
which named `-1` for a function that returns `PTO_RUNTIME_ERR_INTERNAL`), the
kernel-mode capacity paragraph in `runtime_c_api.h`, both runners' latch comments,
`docs/task-flow.md`, and `RUNTIME_LOGIC.md` in both architecture trees.

### The extraction is a flagged deviation from "program path byte-identical"

Behavior in program mode is unchanged — `kernel_mode` is false there, so the new
branch is unreachable and growth, release and rollback all take the paths they
took before. But the code moved, so this is not literally untouched, and it is
deliberate for two reasons. The rule was two hand-maintained copies that
[`codestyle.md`](.claude/rules/codestyle.md) §10 warns about, and onboard/sim
symmetry is now structural rather than a review obligation. And it is what makes
the fix testable without a device: `DeviceRunnerBase` needs CANN, the rule needs
nothing.

## The `allocate_tensor` design question, answered

The handover asked whether kernel mode should refuse `allocate_tensor`
unconditionally, or only outside a prepare window borrowed from ④K2. **The
unconditional form holds**: #2176's prepare-once allocator reaches `mem_alloc_`
directly through its own context ops, never through `HostApi::device_malloc`, so
refusing the runtime-facing surface would not block a legitimate kernel-time
allocation. This PR does not install that refusal, because the growth point it is
in scope for needs its guard higher up anyway — but the question is settled and the
next guard does not have to re-derive it.

## Out of scope, and one question for a reviewer

**Growth points #1 `acquire_graph_definition_block` and #2 HBG host-tensor staging
are not closed here.** Both are HBG-only and both live in files #2173 rewrites;
#2173 already carries a disposition for the definition block. @TaoZQY — do you want
to keep #1 (and #2) on your side, or should a follow-up here close both against the
`is_kernel_mode` query this PR adds? Splitting one growth point across two PRs is
the outcome worth avoiding. Note that `acquire_graph_definition_block` is
grow-by-replacement of a **device** block, so it is the same silent-replay hazard,
not a lesser one.

**DFX is outside the frozen capacity, but it is not address-stable.** This is the
question the handover asked, so here is the full answer rather than half of it. The
DFX device buffers — the device-wall buffer and the collectors' workspaces — are
separate `mem_alloc_` allocations, not regions of an arena bank, so nothing this PR
freezes covers them and it correctly writes no DFX teardown logic. The device-wall
buffer is allocated lazily once and never grown, so it does not re-base. **The
collector pools do**: `prepare_execution` calls `finalize_collectors()` whenever
`collector_shape_is_stale(...)`, so a run whose core or AICPU-thread counts differ
from the previous one tears their device memory down and rebuilds it at a new
address. A kernel context's shape is context-static, so that should not fire — but
nothing enforces it, and if the DFX buffers are ever reachable from a captured
graph this is a growth point in its own right. Flagging it rather than guarding it
here: it belongs with whoever owns DFX under the execution claim (#2163).

**The sim-side guard stays.** Simulation never latches KERNEL, so that branch is
never true, but removing it would break the onboard/sim symmetry the stub-parity
argument rests on.

## Verification

All on myserver (aarch64, CANN 9.0.0). No device is needed for any of it.

| Lane | Result |
| --- | --- |
| cpput, no hardware | **144/144 passed** — base `86dd62b4` is **143/143**, built and run the same way |
| new `test_static_arena_bank` | **11/11**, `no_hardware` label |
| `test_trb_runtime_temp_buffer` | **16/16**, was 10 — and identically for `test_a5_trb_runtime_temp_buffer` |
| editable install | all **8** `libhost_runtime.so` built (a2a3 + a5 × onboard + sim × hbg + trb); no warning names a changed file |
| `tests/ut/py/test_host_runtime_abi.py` | 4 passed, 4 skipped — the exported symbol set is unchanged |
| pre-commit | all hooks pass, clang-tidy included, in CI |

The five acceptance criteria are covered twice, once per slot kind:

| | arena bank | retained temp buffer |
| --- | --- | --- |
| base and capacity constant across N calls | `RepeatedCommitsMoveNoBaseAndCallNoAllocator` | `KernelModeHoldsOneAddressAcrossRepeatedRuns` |
| zero underlying alloc/free | same, via `DeviceArena::alloc_count()` | same, via the fake's malloc/free counters |
| exact capacity accepted | `ExactAndSmallerRequestsAreServedInPlace` | same test, a run that exactly fills the buffer |
| over capacity refused with `INTERNAL` | `OneByteOverCapacityIsRefusedAndChangesNothing` | `KernelModeRefusesToGrowTheRetainedBuffer` |
| refusal does not break the held plan | same test's second half | `KernelModeRefusalLeavesTheRetainedBufferUsable` |

`KernelModeAllocatesOnceThenRefusesToGrow` is the production shape: the latch is
write-once, so a real context is in kernel mode from its very first bind. It
asserts one allocation, then a refusal, then the sized run still binding from the
same address.

The other exit is pinned too. `AllocationFailureRollsTheWholeBankBack` and
`AllocationFailureOnTheFirstCommitStillRollsBack` drive a failing backing
allocator through `DeviceArena`'s injectable alloc/free, so the rollback path is
reachable with no device: an allocation failure releases every region and zeroes
every remembered size, in kernel mode exactly as in program mode, because a setup
that never completed published no address to protect.

### Negative controls

A test that passes against the fix is not evidence it would have caught the
defect, so each defect was re-introduced and the suites re-run.

- **Routing the capacity refusal back through the rollback** (dropping the
  `capacity_refused` branch): **3 kernel-mode arena tests fail**, and both
  program-mode tests still pass.
- **Removing the retained-buffer guard**: **2 tests fail, identically on a2a3 and
  a5**; the rest pass.
- **Dropping the `addr != nullptr` clause**: **exactly
  `KernelModeAllocatesOnceThenRefusesToGrow` fails**, on both architectures — the
  first-bind regression has a precise barrier.
- **Removing the rollback entirely**: **exactly the two allocation-failure tests
  fail**; the nine capacity tests still pass, so the two failure classes are
  pinned independently of each other.

## How the findings above were found

The commit was put through a self-review before this update: eight independent
reviewers over separate dimensions of the diff, then three adversarial refutation
lenses per finding. It raised 22 findings and the skeptic panel refuted all 22 —
a verdict I do not report as a clean bill of health, because the refutation lens
set included reachability, and since nothing latches KERNEL yet, *every*
kernel-mode finding is trivially unreachable today. The panel's value was in
surfacing candidates, not in adjudicating them.

Four of those candidates were textually verifiable and are fixed here regardless
of the vote: the first-allocation refusal, the `is_kernel_mode` comment claiming
table-wide address stability that `acquire_graph_definition_block` contradicts,
the stale contracts listed earlier, and the two test defects above — the
"smaller" run that packed to exactly the retained capacity, and the missing
rollback coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
