### PR TITLE
Add: VMM_SHAREABLE canonical Buffer substrate

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1718,6 +1718,89 @@ void check_access_subset(uint8_t granted, TensorArgType tag) {
     }
 }
 
+inline void store_le_u8(uint8_t *dst, uint8_t v) { dst[0] = v; }
+inline void store_le_u16(uint8_t *dst, uint16_t v) {
+    dst[0] = static_cast<uint8_t>(v);
+    dst[1] = static_cast<uint8_t>(v >> 8);
+}
+inline void store_le_u32(uint8_t *dst, uint32_t v) {
+    dst[0] = static_cast<uint8_t>(v);
+    dst[1] = static_cast<uint8_t>(v >> 8);
+    dst[2] = static_cast<uint8_t>(v >> 16);
+    dst[3] = static_cast<uint8_t>(v >> 24);
+}
+inline void store_le_u64(uint8_t *dst, uint64_t v) {
+    store_le_u32(dst, static_cast<uint32_t>(v));
+    store_le_u32(dst + 4, static_cast<uint32_t>(v >> 32));
+}
+inline uint8_t load_le_u8(const uint8_t *src) { return src[0]; }
+inline uint16_t load_le_u16(const uint8_t *src) {
+    return static_cast<uint16_t>(src[0] | (static_cast<uint16_t>(src[1]) << 8));
+}
+inline uint32_t load_le_u32(const uint8_t *src) {
+    return static_cast<uint32_t>(src[0]) | (static_cast<uint32_t>(src[1]) << 8) |
+           (static_cast<uint32_t>(src[2]) << 16) | (static_cast<uint32_t>(src[3]) << 24);
+}
+inline uint64_t load_le_u64(const uint8_t *src) {
+    return static_cast<uint64_t>(load_le_u32(src)) | (static_cast<uint64_t>(load_le_u32(src + 4)) << 32);
+}
+
+// Fieldwise 88-byte BufferDescriptor codec. Structural padding and unused body tail stay zero
+// because encoding starts from a zero-initialized buffer and never copies the native struct.
+std::array<uint8_t, sizeof(BufferDescriptor)> encode_buffer_descriptor_wire(const BufferDescriptor &desc) {
+    std::array<uint8_t, sizeof(BufferDescriptor)> wire{};
+    store_le_u16(wire.data() + offsetof(BufferDescriptor, magic), desc.magic);
+    store_le_u8(wire.data() + offsetof(BufferDescriptor, address_space), desc.address_space);
+    store_le_u8(wire.data() + offsetof(BufferDescriptor, access), desc.access);
+    store_le_u8(wire.data() + offsetof(BufferDescriptor, backend_kind), desc.backend_kind);
+    std::memcpy(
+        wire.data() + offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, owner_instance_id),
+        desc.identity.owner_instance_id, OWNER_INSTANCE_ID_BYTES
+    );
+    store_le_u64(
+        wire.data() + offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, buffer_id),
+        desc.identity.buffer_id
+    );
+    store_le_u32(
+        wire.data() + offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, generation),
+        desc.identity.generation
+    );
+    store_le_u64(wire.data() + offsetof(BufferDescriptor, nbytes), desc.nbytes);
+    store_le_u32(wire.data() + offsetof(BufferDescriptor, owner_worker_path_id), desc.owner_worker_path_id);
+    store_le_u16(wire.data() + offsetof(BufferDescriptor, body_len), desc.body_len);
+    std::memcpy(wire.data() + offsetof(BufferDescriptor, body), desc.body, DESC_MAX_BYTES);
+    return wire;
+}
+
+BufferDescriptor decode_buffer_descriptor_wire(const uint8_t *raw, size_t size) {
+    if (size != sizeof(BufferDescriptor)) {
+        throw std::invalid_argument(
+            "BufferDescriptor wire must be exactly " + std::to_string(sizeof(BufferDescriptor)) + " bytes, got " +
+            std::to_string(size)
+        );
+    }
+    BufferDescriptor desc{};
+    desc.magic = load_le_u16(raw + offsetof(BufferDescriptor, magic));
+    desc.address_space = load_le_u8(raw + offsetof(BufferDescriptor, address_space));
+    desc.access = load_le_u8(raw + offsetof(BufferDescriptor, access));
+    desc.backend_kind = load_le_u8(raw + offsetof(BufferDescriptor, backend_kind));
+    std::memcpy(
+        desc.identity.owner_instance_id,
+        raw + offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, owner_instance_id),
+        OWNER_INSTANCE_ID_BYTES
+    );
+    desc.identity.buffer_id =
+        load_le_u64(raw + offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, buffer_id));
+    desc.identity.generation =
+        load_le_u32(raw + offsetof(BufferDescriptor, identity) + offsetof(CanonicalIdentity, generation));
+    desc.nbytes = load_le_u64(raw + offsetof(BufferDescriptor, nbytes));
+    desc.owner_worker_path_id = load_le_u32(raw + offsetof(BufferDescriptor, owner_worker_path_id));
+    desc.body_len = load_le_u16(raw + offsetof(BufferDescriptor, body_len));
+    std::memcpy(desc.body, raw + offsetof(BufferDescriptor, body), DESC_MAX_BYTES);
+    validate_buffer_descriptor(desc);
+    return desc;
+}
+
 }  // namespace
 
 // ============================================================================
@@ -1919,8 +2002,8 @@ NB_MODULE(_task_interface, m) {
     m.attr("CHIP_TENSOR_ADDRESS_SPACE_OFFSET") = static_cast<int>(offsetof(ChipTensor, address_space));
 
     // Width of the opaque per-incarnation nonce, so the owner can draw one of the right size.
-    // The struct sizes stay unexported: no Python path turns these types into bytes or back, so a
-    // byte count here would have no reader — the layout is pinned by buffer.h's static_asserts.
+    // Public Python still has no `.pack()`: the only byte path is the module-private 88-byte
+    // codec below, which writes fieldwise into zero-initialized storage.
     m.attr("OWNER_INSTANCE_ID_BYTES") = static_cast<int>(OWNER_INSTANCE_ID_BYTES);
 
     // --- Buffer ABI enums ---
@@ -1941,7 +2024,8 @@ NB_MODULE(_task_interface, m) {
         .value("VMM_WINDOW", BackendKind::VMM_WINDOW)
         .value("REMOTE_SIDECAR", BackendKind::REMOTE_SIDECAR)
         .value("DEVICE_MALLOC", BackendKind::DEVICE_MALLOC)
-        .value("FORK_COW", BackendKind::FORK_COW);
+        .value("FORK_COW", BackendKind::FORK_COW)
+        .value("VMM_SHAREABLE", BackendKind::VMM_SHAREABLE);
 
     // --- CanonicalIdentity ---
     // Equality and hashing fold exactly the three meaningful fields, so a decode with dirty wire
@@ -2099,6 +2183,23 @@ NB_MODULE(_task_interface, m) {
                << ", nbytes=" << self.nbytes << ", body_len=" << self.body_len << ")";
             return os.str();
         });
+
+    m.def(
+        "_encode_buffer_descriptor_wire",
+        [](const BufferDescriptor &desc) {
+            const auto wire = encode_buffer_descriptor_wire(desc);
+            return nb::bytes(reinterpret_cast<const char *>(wire.data()), wire.size());
+        },
+        nb::arg("desc"),
+        "Module-private 88-byte BufferDescriptor encoding. Fieldwise, zero-padded; not a public pack API."
+    );
+    m.def(
+        "_decode_buffer_descriptor_wire",
+        [](nb::bytes raw) {
+            return decode_buffer_descriptor_wire(reinterpret_cast<const uint8_t *>(raw.c_str()), raw.size());
+        },
+        nb::arg("raw"), "Module-private 88-byte BufferDescriptor decoding. Exact size, then canonical validation."
+    );
 
     // --- Tensor ---
     // The L3+ task argument: a strided view over a buffer, carrying that buffer's descriptor whole

--- a/python/simpler/buffer.py
+++ b/python/simpler/buffer.py
@@ -456,6 +456,44 @@ def wrap_vmm_window(
     )
 
 
+def _wrap_vmm_shareable(
+    device_ptr: int,
+    nbytes: int,
+    device_id: int,
+    mapping_bytes: int,
+    shareable_handle: int,
+    identity: CanonicalIdentity,
+    owner_worker_path: str = "",
+    owner_worker_id: int = 0,
+) -> Buffer:
+    """Wrap an already-exported shareable VMM mapping as a Region-private ``VMM_SHAREABLE`` ``Buffer``.
+
+    ``identity`` is the caller-supplied canonical identity; this helper does not mint a nonce or
+    buffer id. The body is the 24-byte overlay ``device_id``, reserved 0, ``shareable_handle``,
+    ``mapping_bytes``. ``nbytes`` is the logical footprint and is not replaced by the mapping span.
+    ``shm`` stays ``None``: physical VMM release stays with the caller. ``device_ptr`` is the
+    provider-local base and may be 0.
+    """
+    body = (
+        int(device_id).to_bytes(4, "little", signed=True)
+        + (0).to_bytes(4, "little")
+        + int(shareable_handle).to_bytes(8, "little")
+        + int(mapping_bytes).to_bytes(8, "little")
+    )
+    return Buffer(
+        identity=identity,
+        owner_worker_path_id=intern_worker_path(owner_worker_path),
+        address_space=AddressSpace.DEVICE,
+        access=AccessMode.READWRITE,
+        backend_kind=BackendKind.VMM_SHAREABLE,
+        nbytes=int(nbytes),
+        body=body,
+        shm=None,
+        base=int(device_ptr),
+        owner_worker_id=int(owner_worker_id),
+    )
+
+
 def _descriptor_delta(a: BufferDescriptor, b: BufferDescriptor) -> str:
     """The fields on which two descriptors differ, as ``name: old -> new``.
 

--- a/src/common/task_interface/buffer.h
+++ b/src/common/task_interface/buffer.h
@@ -65,13 +65,16 @@ inline constexpr uint16_t BUFFER_DESCRIPTOR_MAGIC = 0x5342;  // 'BS' little-endi
 // process and second.
 inline constexpr uint32_t OWNER_INSTANCE_ID_BYTES = 8;
 
-// Backend body upper bound. Only POSIX_SHM uses more than 8 bytes (a shm name); every other backend
-// stores a single u64 address.
+// Backend body upper bound. POSIX_SHM uses a shm name; VMM_SHAREABLE uses a fixed 24-byte overlay;
+// every address-bearing backend stores a single u64 address.
 inline constexpr uint32_t DESC_MAX_BYTES = 32;
 
 // Body width of every address-bearing backend: one u64 little-endian base. Exact, not a maximum —
 // a shorter body reads as a truncated pointer indistinguishable from a real one.
 inline constexpr uint32_t BACKEND_ADDRESS_BODY_BYTES = 8;
+
+// VMM_SHAREABLE body: int32 device_id, uint32 reserved 0, uint64 shareable_handle, uint64 mapping_bytes.
+inline constexpr uint32_t VMM_SHAREABLE_BODY_BYTES = 24;
 
 // The backing's granted permission. A per-arg TensorArgType requests read/write and is validated
 // against this at submit (requested must be a subset of granted).
@@ -83,13 +86,18 @@ enum class AccessMode : uint8_t {
 
 // Materialization backend of a buffer. The consumer resolves a Tensor to a local address via the
 // import registry keyed by canonical identity; this tag selects how. REMOTE_SIDECAR is reserved for
-// P2 and rejected on decode in P1. Values are frozen; 6.. reserved (unknown tag => reject).
+// P2 and rejected on decode in P1. Values 0–5 are frozen; VMM_SHAREABLE is 6; 7.. reserved
+// (unknown tag => reject).
 //
 // FORK_SHM and FORK_COW materialize identically — the body is a base VA the child already has,
 // inherited across the fork — but the kernel's write semantics are opposite, so they are separate
 // tags rather than one tag plus a hint. A child's write to a MAP_SHARED page lands in the physical
 // page the parent reads; a write to a copy-on-write page splits it into a private copy the parent
 // never sees, silently. FORK_COW therefore grants READ only, and that is enforced on decode.
+//
+// VMM_WINDOW and VMM_SHAREABLE are distinct tags: the former's body is an already-valid owner-chip
+// device VA that cannot leave that context, while the latter carries a shareable handle an importer
+// maps for itself.
 enum class BackendKind : uint8_t {
     FORK_SHM = 0,
     POSIX_SHM = 1,
@@ -97,6 +105,7 @@ enum class BackendKind : uint8_t {
     REMOTE_SIDECAR = 3,
     DEVICE_MALLOC = 4,
     FORK_COW = 5,
+    VMM_SHAREABLE = 6,
 };
 
 /**
@@ -289,7 +298,7 @@ inline void validate_buffer_descriptor(const BufferDescriptor &h) {
     if (h.address_space > static_cast<uint8_t>(AddressSpace::DEVICE))
         reject("invalid BufferDescriptor: address_space out of range");
     if (h.access > static_cast<uint8_t>(AccessMode::READWRITE)) reject("invalid BufferDescriptor: access out of range");
-    if (h.backend_kind > static_cast<uint8_t>(BackendKind::FORK_COW))
+    if (h.backend_kind > static_cast<uint8_t>(BackendKind::VMM_SHAREABLE))
         reject("invalid BufferDescriptor: backend_kind out of range");
     if (h.body_len > DESC_MAX_BYTES) reject("invalid BufferDescriptor: body_len exceeds DESC_MAX_BYTES");
     if (h.identity.generation == 0) reject("invalid BufferDescriptor: generation 0 is reserved (uninitialized)");
@@ -298,7 +307,8 @@ inline void validate_buffer_descriptor(const BufferDescriptor &h) {
     const auto backend = static_cast<BackendKind>(h.backend_kind);
     const bool device_space = h.address_space == static_cast<uint8_t>(AddressSpace::DEVICE);
     if (backend != BackendKind::REMOTE_SIDECAR) {
-        const bool device_backend = backend == BackendKind::VMM_WINDOW || backend == BackendKind::DEVICE_MALLOC;
+        const bool device_backend = backend == BackendKind::VMM_WINDOW || backend == BackendKind::DEVICE_MALLOC ||
+                                    backend == BackendKind::VMM_SHAREABLE;
         if (device_backend != device_space)
             reject("invalid BufferDescriptor: unsupported address_space x backend_kind (capability matrix)");
     }
@@ -338,6 +348,24 @@ inline void validate_buffer_descriptor(const BufferDescriptor &h) {
                 reject("invalid BufferDescriptor: POSIX_SHM shm name must be printable ASCII without '/'");
             }
         }
+        break;
+    }
+    case BackendKind::VMM_SHAREABLE: {
+        if (h.body_len != VMM_SHAREABLE_BODY_BYTES)
+            reject("invalid BufferDescriptor: VMM_SHAREABLE body must be exactly 24 bytes");
+        int32_t device_id = 0;
+        uint32_t reserved = 0;
+        uint64_t shareable_handle = 0;
+        uint64_t mapping_bytes = 0;
+        std::memcpy(&device_id, h.body, sizeof(device_id));
+        std::memcpy(&reserved, h.body + 4, sizeof(reserved));
+        std::memcpy(&shareable_handle, h.body + 8, sizeof(shareable_handle));
+        std::memcpy(&mapping_bytes, h.body + 16, sizeof(mapping_bytes));
+        if (device_id < 0) reject("invalid BufferDescriptor: VMM_SHAREABLE device_id out of range");
+        if (reserved != 0) reject("invalid BufferDescriptor: VMM_SHAREABLE reserved bytes must be zero");
+        if (shareable_handle == 0) reject("invalid BufferDescriptor: VMM_SHAREABLE shareable_handle must be nonzero");
+        if (mapping_bytes == 0) reject("invalid BufferDescriptor: VMM_SHAREABLE mapping_bytes must be nonzero");
+        if (mapping_bytes < h.nbytes) reject("invalid BufferDescriptor: VMM_SHAREABLE mapping_bytes must cover nbytes");
         break;
     }
     case BackendKind::REMOTE_SIDECAR:

--- a/tests/ut/cpp/types/test_buffer.cpp
+++ b/tests/ut/cpp/types/test_buffer.cpp
@@ -66,6 +66,28 @@ void set_address_body(Tensor &r, uint64_t base) {
     std::memcpy(r.buffer.body, &base, sizeof(base));
 }
 
+void set_vmm_shareable_body(BufferDescriptor &h, int32_t device_id, uint64_t handle, uint64_t mapping_bytes) {
+    std::memset(h.body, 0, DESC_MAX_BYTES);
+    h.body_len = static_cast<uint16_t>(VMM_SHAREABLE_BODY_BYTES);
+    std::memcpy(h.body, &device_id, sizeof(device_id));
+    uint32_t reserved = 0;
+    std::memcpy(h.body + 4, &reserved, sizeof(reserved));
+    std::memcpy(h.body + 8, &handle, sizeof(handle));
+    std::memcpy(h.body + 16, &mapping_bytes, sizeof(mapping_bytes));
+}
+
+BufferDescriptor make_vmm_shareable_descriptor() {
+    BufferDescriptor h{};
+    h.magic = BUFFER_DESCRIPTOR_MAGIC;
+    h.address_space = static_cast<uint8_t>(AddressSpace::DEVICE);
+    h.access = static_cast<uint8_t>(AccessMode::READWRITE);
+    h.backend_kind = static_cast<uint8_t>(BackendKind::VMM_SHAREABLE);
+    h.identity = make_identity();
+    h.nbytes = 64;
+    set_vmm_shareable_body(h, 0, 0x1111ULL, 128);
+    return h;
+}
+
 Tensor make_device_tensor() {
     Tensor r = make_tensor();
     r.buffer.backend_kind = static_cast<uint8_t>(BackendKind::DEVICE_MALLOC);
@@ -100,6 +122,7 @@ TEST(BufferAbi, EnumValuesAreFrozen) {
     EXPECT_EQ(static_cast<uint8_t>(BackendKind::REMOTE_SIDECAR), 3);
     EXPECT_EQ(static_cast<uint8_t>(BackendKind::DEVICE_MALLOC), 4);
     EXPECT_EQ(static_cast<uint8_t>(BackendKind::FORK_COW), 5);
+    EXPECT_EQ(static_cast<uint8_t>(BackendKind::VMM_SHAREABLE), 6);
 }
 
 // --- memcpy round trip -------------------------------------------------------------------------
@@ -294,6 +317,70 @@ TEST(BufferAbi, DecodeRejectsABodyThatDoesNotMatchItsBackend) {
     sidecar.buffer.body_len = 0;
     std::memset(sidecar.buffer.body, 0, DESC_MAX_BYTES);
     EXPECT_NO_THROW(validate_tensor(sidecar));
+}
+
+TEST(BufferAbi, VmmShareableAcceptsLegalDeviceBody) {
+    BufferDescriptor h = make_vmm_shareable_descriptor();
+    EXPECT_NO_THROW(validate_buffer_descriptor(h));
+
+    set_vmm_shareable_body(h, 0, 0x1ULL, 64);  // mapping_bytes == nbytes is legal
+    EXPECT_NO_THROW(validate_buffer_descriptor(h));
+}
+
+TEST(BufferAbi, VmmShareableRejectsHostAddressSpace) {
+    BufferDescriptor h = make_vmm_shareable_descriptor();
+    h.address_space = static_cast<uint8_t>(AddressSpace::HOST);
+    EXPECT_THROW(validate_buffer_descriptor(h), std::invalid_argument);
+}
+
+TEST(BufferAbi, VmmShareableRejectsMalformedBody) {
+    BufferDescriptor h = make_vmm_shareable_descriptor();
+    EXPECT_NO_THROW(validate_buffer_descriptor(h));
+
+    for (uint16_t bad_len : {uint16_t{0}, uint16_t{8}, uint16_t{23}, uint16_t{25}, uint16_t{DESC_MAX_BYTES}}) {
+        SCOPED_TRACE(bad_len);
+        BufferDescriptor bad = make_vmm_shareable_descriptor();
+        bad.body_len = bad_len;
+        EXPECT_THROW(validate_buffer_descriptor(bad), std::invalid_argument);
+    }
+
+    BufferDescriptor reserved = make_vmm_shareable_descriptor();
+    reserved.body[4] = 1;
+    EXPECT_THROW(validate_buffer_descriptor(reserved), std::invalid_argument);
+
+    BufferDescriptor tail = make_vmm_shareable_descriptor();
+    tail.body[24] = 1;
+    EXPECT_THROW(validate_buffer_descriptor(tail), std::invalid_argument);
+
+    BufferDescriptor zero_handle = make_vmm_shareable_descriptor();
+    set_vmm_shareable_body(zero_handle, 0, 0, 128);
+    EXPECT_THROW(validate_buffer_descriptor(zero_handle), std::invalid_argument);
+
+    BufferDescriptor zero_mapping = make_vmm_shareable_descriptor();
+    set_vmm_shareable_body(zero_mapping, 0, 0x1ULL, 0);
+    zero_mapping.nbytes = 0;
+    EXPECT_THROW(validate_buffer_descriptor(zero_mapping), std::invalid_argument);
+
+    BufferDescriptor short_mapping = make_vmm_shareable_descriptor();
+    set_vmm_shareable_body(short_mapping, 0, 0x1ULL, 63);
+    EXPECT_THROW(validate_buffer_descriptor(short_mapping), std::invalid_argument);
+
+    BufferDescriptor negative_device = make_vmm_shareable_descriptor();
+    set_vmm_shareable_body(negative_device, -1, 0x1ULL, 128);
+    EXPECT_THROW(validate_buffer_descriptor(negative_device), std::invalid_argument);
+
+    BufferDescriptor out_of_range = make_vmm_shareable_descriptor();
+    out_of_range.backend_kind = 7;
+    EXPECT_THROW(validate_buffer_descriptor(out_of_range), std::invalid_argument);
+}
+
+TEST(BufferAbi, VmmShareableIsNotAnAddressBearingEightByteBody) {
+    BufferDescriptor h = make_vmm_shareable_descriptor();
+    h.body_len = static_cast<uint16_t>(BACKEND_ADDRESS_BODY_BYTES);
+    uint64_t base = 0xDEAD0000ULL;
+    std::memset(h.body, 0, DESC_MAX_BYTES);
+    std::memcpy(h.body, &base, sizeof(base));
+    EXPECT_THROW(validate_buffer_descriptor(h), std::invalid_argument);
 }
 
 // The unused tail of `body` crosses a process boundary with the descriptor, so whatever the owner's

--- a/tests/ut/py/test_buffer.py
+++ b/tests/ut/py/test_buffer.py
@@ -10,10 +10,10 @@
 
 The three wire types are the C++ structs of buffer.h bound directly, so what is pinned here is the
 Python-visible contract over them — construction rejects what `validate_buffer_descriptor` rejects,
-and equality and hashing ignore wire padding. There is deliberately no `pack`/`unpack`: no Python
-path turns these types into bytes or back, which is what keeps construction the only way in.
-Imports come from `simpler.buffer` because that is where a caller reaches them, alongside the
-registry and the Buffer constructors that are genuinely defined there.
+and equality and hashing ignore wire padding. There is no public `pack`/`unpack`; the only Python
+byte path is the module-private 88-byte codec on `_task_interface`, and decode reuses the canonical
+validator. Imports come from `simpler.buffer` because that is where a caller reaches them, alongside
+the registry and the Buffer constructors that are genuinely defined there.
 """
 
 import ctypes
@@ -23,7 +23,13 @@ from multiprocessing.shared_memory import SharedMemory
 from unittest.mock import patch
 
 import pytest
-from _task_interface import OWNER_INSTANCE_ID_BYTES, DataType
+from _task_interface import (
+    OWNER_INSTANCE_ID_BYTES,
+    DataType,
+    _decode_buffer_descriptor_wire,
+    _encode_buffer_descriptor_wire,
+)
+from simpler import buffer as buffer_mod
 from simpler.buffer import (
     AccessMode,
     AddressSpace,
@@ -45,7 +51,15 @@ from simpler.buffer import (
     wrap_fork_inherited,
     wrap_vmm_window,
 )
-from simpler.comm_endpoints import DEVICE_AICPU, HOST_CPU, AdapterKind, AdapterProfile, RegionAccessReasonCode
+from simpler.comm_endpoints import (
+    DEVICE_AICPU,
+    HOST_CPU,
+    AdapterKind,
+    AdapterProfile,
+    BufferAccessQuery,
+    RegionAccessReasonCode,
+    buffer_adapter_candidates,
+)
 from simpler.task_interface import ChipTensor
 
 _OID = bytes(range(0xA0, 0xA0 + OWNER_INSTANCE_ID_BYTES))
@@ -77,12 +91,23 @@ def _identity(oid=_OID, buffer_id=7, generation=2):
     return CanonicalIdentity(oid, buffer_id, generation)
 
 
+def _vmm_shareable_body(device_id=0, shareable_handle=0x1111, mapping_bytes=64):
+    return (
+        int(device_id).to_bytes(4, "little", signed=True)
+        + (0).to_bytes(4, "little")
+        + int(shareable_handle).to_bytes(8, "little")
+        + int(mapping_bytes).to_bytes(8, "little")
+    )
+
+
 def _legal_body(backend: BackendKind) -> bytes:
     """A body that satisfies ``backend``'s schema, so a rejection is attributable to something else."""
     if backend == BackendKind.POSIX_SHM:
         return b"psm_legal"
     if backend == BackendKind.REMOTE_SIDECAR:
         return b""
+    if backend == BackendKind.VMM_SHAREABLE:
+        return _vmm_shareable_body()
     return (0x1000).to_bytes(8, "little")  # the four address-bearing backends
 
 
@@ -732,6 +757,7 @@ def test_owner_instance_ids_are_distinct():
     [
         (AddressSpace.HOST, BackendKind.VMM_WINDOW),
         (AddressSpace.HOST, BackendKind.DEVICE_MALLOC),
+        (AddressSpace.HOST, BackendKind.VMM_SHAREABLE),
         (AddressSpace.DEVICE, BackendKind.FORK_SHM),
         (AddressSpace.DEVICE, BackendKind.POSIX_SHM),
     ],
@@ -757,6 +783,7 @@ def test_descriptor_accepts_legal_combos():
         (AddressSpace.HOST, BackendKind.POSIX_SHM),
         (AddressSpace.DEVICE, BackendKind.VMM_WINDOW),
         (AddressSpace.DEVICE, BackendKind.DEVICE_MALLOC),
+        (AddressSpace.DEVICE, BackendKind.VMM_SHAREABLE),
         (AddressSpace.HOST, BackendKind.REMOTE_SIDECAR),
         (AddressSpace.DEVICE, BackendKind.REMOTE_SIDECAR),
     ]:
@@ -888,3 +915,161 @@ def test_mapped_arg_buffer_is_read_only_for_a_read_access_descriptor():
     assert view.readonly
     with pytest.raises(TypeError):
         view.cast("B")[0:4] = b"\x01\x02\x03\x04"
+
+
+def test_backend_kind_vmm_shareable_is_six_and_existing_values_stay_frozen():
+    assert int(BackendKind.FORK_SHM) == 0
+    assert int(BackendKind.POSIX_SHM) == 1
+    assert int(BackendKind.VMM_WINDOW) == 2
+    assert int(BackendKind.REMOTE_SIDECAR) == 3
+    assert int(BackendKind.DEVICE_MALLOC) == 4
+    assert int(BackendKind.FORK_COW) == 5
+    assert int(BackendKind.VMM_SHAREABLE) == 6
+
+
+def _vmm_shareable_descriptor(*, nbytes=64, body=None, access=AccessMode.READWRITE):
+    return BufferDescriptor(
+        identity=_identity(),
+        address_space=AddressSpace.DEVICE,
+        access=access,
+        backend_kind=BackendKind.VMM_SHAREABLE,
+        nbytes=nbytes,
+        body=_vmm_shareable_body() if body is None else body,
+    )
+
+
+def test_construction_rejects_malformed_vmm_shareable_bodies():
+    for bad in (b"", b"\x00" * 8, b"\x00" * 23, b"\x00" * 25, b"\x00" * 32):
+        with pytest.raises(ValueError, match="exactly 24 bytes"):
+            _vmm_shareable_descriptor(body=bad)
+
+    reserved = bytearray(_vmm_shareable_body())
+    reserved[4] = 1
+    with pytest.raises(ValueError, match="reserved"):
+        _vmm_shareable_descriptor(body=bytes(reserved))
+
+    with pytest.raises(ValueError, match="shareable_handle"):
+        _vmm_shareable_descriptor(body=_vmm_shareable_body(shareable_handle=0))
+
+    with pytest.raises(ValueError, match="mapping_bytes"):
+        _vmm_shareable_descriptor(body=_vmm_shareable_body(mapping_bytes=0))
+
+    with pytest.raises(ValueError, match="mapping_bytes"):
+        _vmm_shareable_descriptor(nbytes=64, body=_vmm_shareable_body(mapping_bytes=63))
+
+    with pytest.raises(ValueError, match="device_id"):
+        _vmm_shareable_descriptor(body=_vmm_shareable_body(device_id=-1))
+
+
+def test_buffer_descriptor_wire_codec_round_trips_and_zeros_padding():
+    desc = _vmm_shareable_descriptor(nbytes=96, body=_vmm_shareable_body(device_id=3, mapping_bytes=128))
+    wire = _encode_buffer_descriptor_wire(desc)
+    assert len(wire) == 88
+    assert wire[5:8] == b"\x00" * 3
+    assert wire[28:40] == b"\x00" * 12
+    assert wire[54:56] == b"\x00" * 2
+    assert wire[80:88] == b"\x00" * 8
+
+    decoded = _decode_buffer_descriptor_wire(wire)
+    assert decoded == desc
+    assert decoded.identity == desc.identity
+    assert decoded.backend_kind is BackendKind.VMM_SHAREABLE
+    assert decoded.nbytes == 96
+    assert decoded.body == _vmm_shareable_body(device_id=3, mapping_bytes=128)
+    assert _encode_buffer_descriptor_wire(decoded) == wire
+
+
+def test_buffer_descriptor_wire_codec_rejects_malformed_input():
+    desc = _vmm_shareable_descriptor()
+    wire = bytearray(_encode_buffer_descriptor_wire(desc))
+
+    with pytest.raises(ValueError, match="exactly 88 bytes"):
+        _decode_buffer_descriptor_wire(bytes(wire[:-1]))
+    with pytest.raises(ValueError, match="exactly 88 bytes"):
+        _decode_buffer_descriptor_wire(bytes(wire) + b"\x00")
+
+    dirty_reserved = bytearray(wire)
+    dirty_reserved[60] = 1  # body reserved at body[4]
+    with pytest.raises(ValueError, match="reserved"):
+        _decode_buffer_descriptor_wire(bytes(dirty_reserved))
+
+    dirty_tail = bytearray(wire)
+    dirty_tail[80] = 1  # unused body tail
+    with pytest.raises(ValueError, match="reserved bytes"):
+        _decode_buffer_descriptor_wire(bytes(dirty_tail))
+
+    dirty_handle = bytearray(wire)
+    dirty_handle[64:72] = (0).to_bytes(8, "little")
+    with pytest.raises(ValueError, match="shareable_handle"):
+        _decode_buffer_descriptor_wire(bytes(dirty_handle))
+
+    dirty_pad = bytearray(wire)
+    dirty_pad[5] = 0xA5
+    dirty_pad[54] = 0xA5
+    assert _decode_buffer_descriptor_wire(bytes(dirty_pad)) == desc
+
+
+def test_wrap_vmm_shareable_uses_supplied_identity_and_is_not_public():
+    identity = CanonicalIdentity(b"\x11" * OWNER_INSTANCE_ID_BYTES, 42, 3)
+    wrapped = buffer_mod._wrap_vmm_shareable(
+        device_ptr=0,
+        nbytes=64,
+        device_id=2,
+        mapping_bytes=128,
+        shareable_handle=0xABCD,
+        identity=identity,
+        owner_worker_path="L3/L2[1]",
+        owner_worker_id=7,
+    )
+    assert wrapped.identity == identity
+    assert wrapped.identity.buffer_id == 42
+    assert wrapped.identity.generation == 3
+    assert wrapped.address_space is AddressSpace.DEVICE
+    assert wrapped.access is AccessMode.READWRITE
+    assert wrapped.backend_kind is BackendKind.VMM_SHAREABLE
+    assert wrapped.nbytes == 64
+    assert wrapped.body == _vmm_shareable_body(device_id=2, shareable_handle=0xABCD, mapping_bytes=128)
+    assert wrapped.base == 0
+    assert wrapped.shm is None
+    assert wrapped.owner_worker_id == 7
+
+    desc = wrapped.to_descriptor()
+    assert desc.identity == identity
+    assert desc.nbytes == 64
+    assert desc.body == wrapped.body
+
+    wrapped.close()
+    assert wrapped.closed
+    with pytest.raises(ValueError, match="released"):
+        wrapped.to_descriptor()
+    wrapped.close()
+    assert wrapped.closed
+
+    assert "_wrap_vmm_shareable" not in buffer_mod.__all__
+    assert not hasattr(BufferDescriptor, "pack")
+    assert not hasattr(BufferDescriptor, "unpack")
+
+
+def test_vmm_shareable_stays_closed_dispatch_in_importer_paths():
+    identity = _identity()
+    wrapped = buffer_mod._wrap_vmm_shareable(
+        device_ptr=0x1000,
+        nbytes=64,
+        device_id=0,
+        mapping_bytes=64,
+        shareable_handle=1,
+        identity=identity,
+    )
+    desc = wrapped.to_descriptor()
+    query = BufferAccessQuery(BackendKind.VMM_SHAREABLE, DEVICE_AICPU, True, True)
+    candidates = buffer_adapter_candidates(query)
+    assert candidates
+    assert all(c.profile is not AdapterProfile.DEVICE_LOCAL for c in candidates)
+    assert all(c.profile is not AdapterProfile.HOST_VMM_COPY for c in candidates)
+
+    chip = ImportContext(deployment=DEVICE_AICPU, device_owner_instance_id=bytes(identity.owner_instance_id))
+    with pytest.raises(ValueError, match="unsupported backend"):
+        select_adapter(desc, chip)
+    reg = ImportRegistry(chip)
+    with pytest.raises(ValueError, match="unsupported backend"):
+        reg.materialize(desc)


### PR DESCRIPTION
## Summary

This change adds the canonical Buffer substrate that #2198 consumes.

It introduces `BackendKind.VMM_SHAREABLE`, a module-private 88-byte
fieldwise `BufferDescriptor` codec, and private `_wrap_vmm_shareable()`.
It does not change Region, endpoint identity, delegated-region control,
or worker-chip materialization. Those land in #2198.

Ordinary CommDomain `VMM_WINDOW` identity is unchanged. Existing
`BackendKind` values 0–5 and the 88-byte `BufferDescriptor` layout are
unchanged.

## Why This Exists

Shareable-handle VMM is not the same importer contract as owner-chip
`VMM_WINDOW`. Region needs a precise actual-backend tag and a single
canonical descriptor encoding so PAYLOAD and COUNTER can be real
Buffers instead of a second private export schema.

The codec and wrapper have to exist before Region can adopt them. This
PR is that substrate only: it can be reviewed and tested as Buffer ABI,
without mixing in the Region cutover.

## What This Lands

- `BackendKind.VMM_SHAREABLE = 6`, DEVICE-only, with a fixed 24-byte
  body:

  `device_id:i32 | reserved0:u32 | shareable_handle:u64 | mapping_bytes:u64`

  The generic validator checks structure: nonzero handle, zero
  reserved/tail, and `mapping_bytes >= nbytes`. It does not query
  runtime granularity or mapped addresses.

- A module-private fieldwise 88-byte `BufferDescriptor` wire codec:

  - encoder writes zero-initialized storage, including structural padding
    and unused body tail
  - decoder is strict and reuses the canonical validator
  - this is not a public `.pack()` API and does not enter
    `buffer.__all__`

- Private `_wrap_vmm_shareable()`:

  - uses the caller-supplied `CanonicalIdentity`; it does not mint a
    new one
  - does not take native VMM cleanup authority

Focused Buffer tests cover malformed VMM bodies, codec round-trip,
wrapper close/visibility, and the C++ ABI layout.

## Breaking Change

None for Region or delegated-region wire. Those remain on the previous
export schema until #2198.

Callers that assume `BackendKind` has only values 0–5 must accept the
new enumerator. Descriptor size and existing backend encodings do not
change.

## Non-Goals

This change intentionally does not add:

- Region Provider/Consumer adoption or typed attachments
- endpoint nonce / allocator startup
- delegated-region allocate reply v2
- HOST_CPU or DEVICE_AICORE Region Providers
- a public `wrap_vmm_shareable()` / `wrap_existing_posix_shm()`
- public `ResourceBundle`, generic `ImportRegistry`, Buffer escape, or
  retain/release
- changes to ordinary CommDomain `VMM_WINDOW` identity
- Buffer ABI design-doc rewrites; those stay gated on this change
  merging to `main`

## Stacking

Merge this before #2198. #2198 is stacked on this head and must rebase
onto `main` after this merge SHA is available.