### PR TITLE
Refactor: unify scalar reads across host_build_graph and TaskArgsTpl

### DIFF
--- a/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
+++ b/examples/a2a3/host_build_graph/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd_graph.cpp
@@ -1267,18 +1267,18 @@ void csa_moe_block(const GraphTaskArgs &args, bool route_by_hash) {
     // pushes to a truncated window address — an MTE bus fault on the AIV, not a
     // wrong number. The peeled hash_moe_l*_block bodies below already bind them
     // this way.
-    int32_t csa_layer_inline714 = static_cast<int32_t>(args.scalar(0));
-    int32_t csa_moe_epoch_inline715 = static_cast<int32_t>(args.scalar(1));
-    uint64_t arrived_ctx = args.scalar(2);
-    uint64_t combine_arrived_ctx = args.scalar(3);
-    uint64_t data_arrived_ctx = args.scalar(4);
-    int32_t my_rank = static_cast<int32_t>(args.scalar(5));
-    int32_t nt_inline677__rv_v2 = static_cast<int32_t>(args.scalar(6));
-    uint64_t recv_meta_ctx = args.scalar(7);
-    uint64_t recv_x_ctx = args.scalar(8);
-    uint64_t recv_aux_ctx = args.scalar(9);
-    uint64_t recv_route_ctx = args.scalar(10);
-    uint64_t routed_y_buf_ctx = args.scalar(11);
+    int32_t csa_layer_inline714 = args.scalar<int32_t>(0);
+    int32_t csa_moe_epoch_inline715 = args.scalar<int32_t>(1);
+    uint64_t arrived_ctx = args.scalar<uint64_t>(2);
+    uint64_t combine_arrived_ctx = args.scalar<uint64_t>(3);
+    uint64_t data_arrived_ctx = args.scalar<uint64_t>(4);
+    int32_t my_rank = args.scalar<int32_t>(5);
+    int32_t nt_inline677__rv_v2 = args.scalar<int32_t>(6);
+    uint64_t recv_meta_ctx = args.scalar<uint64_t>(7);
+    uint64_t recv_x_ctx = args.scalar<uint64_t>(8);
+    uint64_t recv_aux_ctx = args.scalar<uint64_t>(9);
+    uint64_t recv_route_ctx = args.scalar<uint64_t>(10);
+    uint64_t routed_y_buf_ctx = args.scalar<uint64_t>(11);
     SIMPLER_SCOPE() {
         uint32_t x_mixed_inline11049_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11049_ci(x_mixed_inline11049_ci_shapes, 2, DataType::BFLOAT16);
@@ -2989,17 +2989,17 @@ void hca_moe_block(const GraphTaskArgs &args) {
     // pushes to a truncated window address — an MTE bus fault on the AIV, not a
     // wrong number. The peeled hash_moe_l*_block bodies below already bind them
     // this way.
-    int32_t hca_moe_epoch_inline716 = static_cast<int32_t>(args.scalar(0));
-    uint64_t arrived_ctx = args.scalar(1);
-    uint64_t combine_arrived_ctx = args.scalar(2);
-    uint64_t data_arrived_ctx = args.scalar(3);
-    int32_t my_rank = static_cast<int32_t>(args.scalar(4));
-    int32_t nt_inline677__rv_v2 = static_cast<int32_t>(args.scalar(5));
-    uint64_t recv_meta_ctx = args.scalar(6);
-    uint64_t recv_x_ctx = args.scalar(7);
-    uint64_t recv_aux_ctx = args.scalar(8);
-    uint64_t recv_route_ctx = args.scalar(9);
-    uint64_t routed_y_buf_ctx = args.scalar(10);
+    int32_t hca_moe_epoch_inline716 = args.scalar<int32_t>(0);
+    uint64_t arrived_ctx = args.scalar<uint64_t>(1);
+    uint64_t combine_arrived_ctx = args.scalar<uint64_t>(2);
+    uint64_t data_arrived_ctx = args.scalar<uint64_t>(3);
+    int32_t my_rank = args.scalar<int32_t>(4);
+    int32_t nt_inline677__rv_v2 = args.scalar<int32_t>(5);
+    uint64_t recv_meta_ctx = args.scalar<uint64_t>(6);
+    uint64_t recv_x_ctx = args.scalar<uint64_t>(7);
+    uint64_t recv_aux_ctx = args.scalar<uint64_t>(8);
+    uint64_t recv_route_ctx = args.scalar<uint64_t>(9);
+    uint64_t routed_y_buf_ctx = args.scalar<uint64_t>(10);
     SIMPLER_SCOPE() {
         uint32_t x_mixed_inline11928_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline11928_ci(x_mixed_inline11928_ci_shapes, 2, DataType::BFLOAT16);
@@ -4508,16 +4508,16 @@ void hash_moe_l0_block(const GraphTaskArgs &args) {
     const simpler::hbg::Tensor &ext_routed_y_buf = args.tensor(27).ref();
     const simpler::hbg::Tensor &ext_combine_arrived = args.tensor(28).ref();
     const simpler::hbg::Tensor &hidden_inline709 = args.tensor(29).ref();
-    int32_t nt_inline677__rv_v2 = static_cast<int32_t>(args.scalar(0));
-    int32_t my_rank = static_cast<int32_t>(args.scalar(1));
-    uint64_t recv_meta_ctx = args.scalar(2);
-    uint64_t arrived_ctx = args.scalar(3);
-    uint64_t recv_x_ctx = args.scalar(4);
-    uint64_t recv_aux_ctx = args.scalar(5);
-    uint64_t recv_route_ctx = args.scalar(6);
-    uint64_t data_arrived_ctx = args.scalar(7);
-    uint64_t routed_y_buf_ctx = args.scalar(8);
-    uint64_t combine_arrived_ctx = args.scalar(9);
+    int32_t nt_inline677__rv_v2 = args.scalar<int32_t>(0);
+    int32_t my_rank = args.scalar<int32_t>(1);
+    uint64_t recv_meta_ctx = args.scalar<uint64_t>(2);
+    uint64_t arrived_ctx = args.scalar<uint64_t>(3);
+    uint64_t recv_x_ctx = args.scalar<uint64_t>(4);
+    uint64_t recv_aux_ctx = args.scalar<uint64_t>(5);
+    uint64_t recv_route_ctx = args.scalar<uint64_t>(6);
+    uint64_t data_arrived_ctx = args.scalar<uint64_t>(7);
+    uint64_t routed_y_buf_ctx = args.scalar<uint64_t>(8);
+    uint64_t combine_arrived_ctx = args.scalar<uint64_t>(9);
     SIMPLER_SCOPE() {
         uint32_t x_mixed_inline9242_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline9242_ci(x_mixed_inline9242_ci_shapes, 2, DataType::BFLOAT16);
@@ -5337,16 +5337,16 @@ void hash_moe_l1_block(const GraphTaskArgs &args) {
     const simpler::hbg::Tensor &ext_routed_y_buf = args.tensor(27).ref();
     const simpler::hbg::Tensor &ext_combine_arrived = args.tensor(28).ref();
     const simpler::hbg::Tensor &hidden_inline709 = args.tensor(29).ref();
-    int32_t nt_inline677__rv_v2 = static_cast<int32_t>(args.scalar(0));
-    int32_t my_rank = static_cast<int32_t>(args.scalar(1));
-    uint64_t recv_meta_ctx = args.scalar(2);
-    uint64_t arrived_ctx = args.scalar(3);
-    uint64_t recv_x_ctx = args.scalar(4);
-    uint64_t recv_aux_ctx = args.scalar(5);
-    uint64_t recv_route_ctx = args.scalar(6);
-    uint64_t data_arrived_ctx = args.scalar(7);
-    uint64_t routed_y_buf_ctx = args.scalar(8);
-    uint64_t combine_arrived_ctx = args.scalar(9);
+    int32_t nt_inline677__rv_v2 = args.scalar<int32_t>(0);
+    int32_t my_rank = args.scalar<int32_t>(1);
+    uint64_t recv_meta_ctx = args.scalar<uint64_t>(2);
+    uint64_t arrived_ctx = args.scalar<uint64_t>(3);
+    uint64_t recv_x_ctx = args.scalar<uint64_t>(4);
+    uint64_t recv_aux_ctx = args.scalar<uint64_t>(5);
+    uint64_t recv_route_ctx = args.scalar<uint64_t>(6);
+    uint64_t data_arrived_ctx = args.scalar<uint64_t>(7);
+    uint64_t routed_y_buf_ctx = args.scalar<uint64_t>(8);
+    uint64_t combine_arrived_ctx = args.scalar<uint64_t>(9);
     SIMPLER_SCOPE() {
         uint32_t x_mixed_inline10004_ci_shapes[2] = {8, 4096};
         TensorCreateInfo x_mixed_inline10004_ci(x_mixed_inline10004_ci_shapes, 2, DataType::BFLOAT16);
@@ -6241,19 +6241,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_num_tokens_per_owner = orch_args.tensor(91).ref();
 
     // Scalar params
-    int32_t my_rank = from_u64<int32_t>(orch_args.scalar(0));
-    uint64_t recv_meta_ctx = orch_args.scalar(1);
-    uint64_t recv_x_ctx = orch_args.scalar(2);
-    uint64_t recv_aux_ctx = orch_args.scalar(3);
-    uint64_t recv_route_ctx = orch_args.scalar(4);
-    uint64_t arrived_ctx = orch_args.scalar(5);
-    uint64_t data_arrived_ctx = orch_args.scalar(6);
-    uint64_t routed_y_buf_ctx = orch_args.scalar(7);
-    uint64_t combine_arrived_ctx = orch_args.scalar(8);
-    uint64_t lm_head_hidden_window_ctx = orch_args.scalar(9);
-    uint64_t lm_head_hidden_done_ctx = orch_args.scalar(10);
-    uint64_t lm_head_logits_window_ctx = orch_args.scalar(11);
-    uint64_t lm_head_logits_done_ctx = orch_args.scalar(12);
+    int32_t my_rank = orch_args.scalar<int32_t>(0);
+    uint64_t recv_meta_ctx = orch_args.scalar<uint64_t>(1);
+    uint64_t recv_x_ctx = orch_args.scalar<uint64_t>(2);
+    uint64_t recv_aux_ctx = orch_args.scalar<uint64_t>(3);
+    uint64_t recv_route_ctx = orch_args.scalar<uint64_t>(4);
+    uint64_t arrived_ctx = orch_args.scalar<uint64_t>(5);
+    uint64_t data_arrived_ctx = orch_args.scalar<uint64_t>(6);
+    uint64_t routed_y_buf_ctx = orch_args.scalar<uint64_t>(7);
+    uint64_t combine_arrived_ctx = orch_args.scalar<uint64_t>(8);
+    uint64_t lm_head_hidden_window_ctx = orch_args.scalar<uint64_t>(9);
+    uint64_t lm_head_hidden_done_ctx = orch_args.scalar<uint64_t>(10);
+    uint64_t lm_head_logits_window_ctx = orch_args.scalar<uint64_t>(11);
+    uint64_t lm_head_logits_done_ctx = orch_args.scalar<uint64_t>(12);
 
     uint32_t ori_slot_mapping_inline614_ci_shapes[1] = {8};
     TensorCreateInfo ori_slot_mapping_inline614_ci(ori_slot_mapping_inline614_ci_shapes, 1, DataType::INT64);

--- a/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/host_build_graph/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -102,7 +102,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, 128UL);
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;

--- a/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deepseek_v4_flash_decode/kernels/orchestration/decode_fwd.cpp
@@ -133,7 +133,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::tmr::Tensor &ext_num_tokens_per_owner = orch_args.tensor(91).ref();
 
     // Scalar params
-    int32_t my_rank = from_u64<int32_t>(orch_args.scalar(0));
+    int32_t my_rank = orch_args.scalar<int32_t>(0);
     uint64_t recv_meta_ctx = orch_args.scalar(1);
     uint64_t recv_x_ctx = orch_args.scalar(2);
     uint64_t recv_aux_ctx = orch_args.scalar(3);

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
@@ -35,7 +35,7 @@ __attribute__((visibility("default"))) void sdma_async_completion_orchestration(
     const simpler::tmr::Tensor &input = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &out = orch_args.tensor(1).ref();
     const simpler::tmr::Tensor &result = orch_args.tensor(2).ref();
-    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(orch_args.scalar<uintptr_t>(0));
 
     CoreTaskArgs producer_args;
     producer_args.add_input(input);

--- a/examples/a2a3/tensormap_and_ringbuffer/sliding_window_deps/kernels/orchestration/sliding_window_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sliding_window_deps/kernels/orchestration/sliding_window_orch.cpp
@@ -56,7 +56,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::tmr::Tensor &base = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &result = orch_args.tensor(1).ref();
 
-    int steps = static_cast<int>(orch_args.scalar(0));
+    int steps = orch_args.scalar<int>(0);
     if (steps <= 0) {
         return;
     }

--- a/examples/a5/host_build_graph/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/host_build_graph/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -39,10 +39,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_B = orch_args.tensor(1).ref();
     const simpler::hbg::Tensor &ext_C = orch_args.tensor(2).ref();
 
-    int tile_size = static_cast<int>(orch_args.scalar(0));
-    int grid_k = static_cast<int>(orch_args.scalar(1));
-    int num_groups = static_cast<int>(orch_args.scalar(2));
-    int incore_loop = static_cast<int>(orch_args.scalar(3));
+    int tile_size = orch_args.scalar<int>(0);
+    int grid_k = orch_args.scalar<int>(1);
+    int num_groups = orch_args.scalar<int>(2);
+    int incore_loop = orch_args.scalar<int>(3);
     uint64_t tile_elems = static_cast<uint64_t>(tile_size) * tile_size;
 
     LOG_INFO(

--- a/examples/a5/host_build_graph/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/host_build_graph/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -101,7 +101,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;

--- a/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -39,10 +39,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::tmr::Tensor &ext_B = orch_args.tensor(1).ref();
     const simpler::tmr::Tensor &ext_C = orch_args.tensor(2).ref();
 
-    int tile_size = static_cast<int>(orch_args.scalar(0));
-    int grid_k = static_cast<int>(orch_args.scalar(1));
-    int num_groups = static_cast<int>(orch_args.scalar(2));
-    int incore_loop = static_cast<int>(orch_args.scalar(3));
+    int tile_size = orch_args.scalar<int>(0);
+    int grid_k = orch_args.scalar<int>(1);
+    int num_groups = orch_args.scalar<int>(2);
+    int incore_loop = orch_args.scalar<int>(3);
     uint64_t tile_elems = static_cast<uint64_t>(tile_size) * tile_size;
 
     LOG_INFO(

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
@@ -35,7 +35,7 @@ __attribute__((visibility("default"))) void sdma_async_completion_orchestration(
     const simpler::tmr::Tensor &input = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &out = orch_args.tensor(1).ref();
     const simpler::tmr::Tensor &result = orch_args.tensor(2).ref();
-    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(orch_args.scalar<uintptr_t>(0));
 
     CoreTaskArgs producer_args;
     producer_args.add_input(input);

--- a/examples/a5/tensormap_and_ringbuffer/sliding_window_deps/kernels/orchestration/sliding_window_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sliding_window_deps/kernels/orchestration/sliding_window_orch.cpp
@@ -58,7 +58,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::tmr::Tensor &base = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &result = orch_args.tensor(1).ref();
 
-    int steps = static_cast<int>(orch_args.scalar(0));
+    int steps = orch_args.scalar<int>(0);
     if (steps <= 0) {
         return;
     }

--- a/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/kernels/orchestration/urma_deferred_completion_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/urma_deferred_completion_demo/kernels/orchestration/urma_deferred_completion_orch.cpp
@@ -35,7 +35,7 @@ __attribute__((visibility("default"))) void urma_deferred_completion_orchestrati
     const simpler::tmr::Tensor &input = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &out = orch_args.tensor(1).ref();
     const simpler::tmr::Tensor &result = orch_args.tensor(2).ref();
-    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(orch_args.scalar<uintptr_t>(0));
 
     CoreTaskArgs producer_args;
     producer_args.add_input(input);

--- a/examples/workers/l3/worker_chip_orch_comm_stream/README.md
+++ b/examples/workers/l3/worker_chip_orch_comm_stream/README.md
@@ -25,7 +25,7 @@ mechanism.
 | **Explicit payload transfer** | `region.payload_write(offset, tensor, nbytes)` and `payload_read(...)`, at offsets the host lays out itself: header at 0, input at 64, output after the input. |
 | **A monotonic sequence as the protocol** | Round *n* sets `data_ready` to *n* and waits for `completion >= n`. `GE`, not `EQ`, so a host that fell behind still makes progress. |
 | **In-band shutdown** | The stop is round `_ROUNDS + 1` with opcode 2 in the header — the same notify path as a data round, no separate channel. |
-| **Passing a typed scalar** | `scalar_to_uint64(ctypes.c_float(7.0))` reinterprets a float's bits for `add_scalar`. |
+| **Passing a typed scalar** | `add_scalar(ctypes.c_float(7.0))` stores the float's bits. A ctypes scalar is read at its own width and zero-extended, so the encoding matches C++ `to_u64()`; a bare Python float narrows to single precision. |
 
 ## Run
 

--- a/examples/workers/l3/worker_chip_orch_comm_stream/test_worker_chip_orch_comm_stream.py
+++ b/examples/workers/l3/worker_chip_orch_comm_stream/test_worker_chip_orch_comm_stream.py
@@ -20,7 +20,7 @@ import struct
 
 import pytest
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import CallConfig, ChipCallable, CoreCallable, DataType, TaskArgs, scalar_to_uint64
+from simpler.task_interface import CallConfig, ChipCallable, CoreCallable, DataType, TaskArgs
 from simpler.worker import Worker
 from simpler.worker_chip_orch_comm import NotifyOp, WaitCmp
 
@@ -139,7 +139,7 @@ def run_closed_loop_stream(platform: str, device_id: int) -> None:
             task_args.add_scalar(_NUMEL)
             task_args.add_scalar(DataType.FLOAT32.value)
             task_args.add_scalar(_NBYTES)
-            task_args.add_scalar(scalar_to_uint64(_SCALAR))
+            task_args.add_scalar(_SCALAR)
             task_args.add_scalar(_DATA_READY_COUNTER)
             task_args.add_scalar(_COMPLETION_COUNTER)
             orch_handle.submit_next_level(handle, task_args, cfg, worker=0)

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -1666,6 +1666,67 @@ nb::tuple dims_tuple(const uint32_t *dims, uint32_t ndims) {
     return nb::tuple(out);
 }
 
+// `ctypes._SimpleCData` is the common base of every ctypes scalar. Cached after the first
+// lookup: importing `ctypes` and walking its attributes on every add_scalar call would cost far
+// more than the check it guards.
+PyObject *ctypes_simple_cdata_type() {
+    static PyObject *cached = nb::module_::import_("ctypes").attr("_SimpleCData").inc_ref().ptr();
+    return cached;
+}
+
+// A ctypes scalar's buffer format is a byte-order prefix plus one `struct` format character
+// ("<I", ">d"). Both halves decide whether it can encode, which is why the buffer's format
+// answers this rather than the type's `_type_`: `_type_` carries the character alone.
+//
+// **The prefix is the scalar's actual byte order**, and ctypes spells it out even for a native
+// type, so admission is a match against the host's. `ctypes.c_uint32.__ctype_be__` is an
+// ordinary `_SimpleCData` subclass whose `_type_` is `'I'`, indistinguishable from `c_uint32`,
+// but whose format is `">I"` and whose bytes for the value 1 are `00 00 00 01`. Copying those
+// raw would store `0x01000000` where `to_u64(uint32_t{1})` is `0x1`. A reversed-order scalar has
+// no native C++ counterpart to agree with, so it is refused rather than byte-swapped into one.
+//
+// **The character decides whether the value is a number at all**: the integer widths, `f`, `d`
+// and `?` encode. The pointer and character types (`P`, `z`, `Z`, `c`, `u`) and long double
+// (`g`) do not — they name no number a slot can carry, and encoding a host pointer into a
+// device-bound slot is a defect wherever it happens. A subclass inherits its base's format, so
+// it is admitted with the base, which dispatching on the type's `__name__` would not do.
+enum class CtypesFormat { Encodable, ForeignByteOrder, NotNumeric };
+
+#if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+constexpr char NATIVE_BYTE_ORDER = '>';
+#else
+constexpr char NATIVE_BYTE_ORDER = '<';
+#endif
+
+CtypesFormat classify_ctypes_format(const char *format) {
+    // ctypes always emits the prefix, so a format without one did not come from one of its
+    // scalars and is refused rather than guessed at.
+    if (format == nullptr || (format[0] != '<' && format[0] != '>')) {
+        return CtypesFormat::NotNumeric;
+    }
+    if (format[1] == '\0' || format[2] != '\0') {
+        return CtypesFormat::NotNumeric;
+    }
+    switch (format[1]) {
+    case 'b':
+    case 'B':
+    case 'h':
+    case 'H':
+    case 'i':
+    case 'I':
+    case 'l':
+    case 'L':
+    case 'q':
+    case 'Q':
+    case 'f':
+    case 'd':
+    case '?':
+        return format[0] == NATIVE_BYTE_ORDER ? CtypesFormat::Encodable : CtypesFormat::ForeignByteOrder;
+    default:
+        return CtypesFormat::NotNumeric;
+    }
+}
+
 // Resolve one wire tensor onto a local base and build the address-bearing device POD.
 // `resolved` maps CanonicalIdentity -> (local_base, address_space); the caller populates it by
 // materializing each embedded descriptor.
@@ -1690,6 +1751,129 @@ ChipTensor materialize_one(const Tensor &r, nb::dict resolved) {
         reinterpret_cast<void *>(static_cast<uintptr_t>(base + r.byte_offset)), r.shapes, r.strides, r.ndims, r.dtype,
         static_cast<AddressSpace>(addr_space)
     );
+}
+
+// Read an exact PyLong as the 64-bit pattern a slot stores, accepting the whole two's-complement
+// range: signed first, then unsigned for anything above INT64_MAX. Out of that range is an error
+// rather than a silent truncation to the low 64 bits.
+uint64_t encode_python_int(PyObject *long_ptr) {
+    int64_t signed_value = PyLong_AsLongLong(long_ptr);
+    if (signed_value == -1 && PyErr_Occurred()) {
+        PyErr_Clear();
+        unsigned long long unsigned_value = PyLong_AsUnsignedLongLong(long_ptr);
+        if (PyErr_Occurred()) {
+            PyErr_Clear();
+            throw std::overflow_error("add_scalar: integer value out of 64-bit range");
+        }
+        return static_cast<uint64_t>(unsigned_value);
+    }
+    return static_cast<uint64_t>(signed_value);
+}
+
+// The one place a Python scalar becomes the uint64_t a wire slot stores. Its output must match
+// C++ `to_u64` bit for bit for the same value, so that a slot written from Python and one written
+// from orchestration read back identically.
+//
+// Three encodings, in the order checked:
+//
+// - A Python int is read as a 64-bit quantity, which is what `to_u64(int64_t)` / `to_u64(uint64_t)`
+//   also produce. PyLong_CheckExact short-circuits the common case; the general branch further
+//   down goes through __index__ (PyIndex_Check), not PyLong_Check, so bool, IntEnum members, and
+//   numpy integer scalars are admitted -- none of which are actual `int` instances -- while every
+//   float type, numpy's included, is still rejected, since none of them define __index__.
+// - A ctypes scalar is read through the buffer protocol and **zero-extended** into the slot, which
+//   is exactly what to_u64's union does. Reading `.value` instead would sign-extend a narrow
+//   signed type (c_int8(-1) -> 0xFFFF'FFFF'FFFF'FFFF where to_u64(int8_t{-1}) is 0xFF), and
+//   dispatching on the type's __name__ to find the float types would miss their subclasses and
+//   silently narrow a c_double subclass to single precision. One buffer read has neither problem,
+//   and its format answers admission and byte order in the same step -- see classify_ctypes_format.
+// - A native Python float narrows to IEEE-754 single precision, matching to_u64(float). Out of
+//   single-precision range is an error, not an infinity: a finite input that narrowed to inf would
+//   be stored as a different number. This is the one encoding that cannot align with its C++
+//   counterpart by construction, because a Python float carries no width: to_u64(1.5) in
+//   orchestration is a double. ctypes.c_double is the spelling for full precision, and the
+//   docstrings say so.
+uint64_t encode_scalar(nb::handle value) {
+    PyObject *ptr = value.ptr();
+
+    if (PyLong_CheckExact(ptr)) {
+        return encode_python_int(ptr);
+    }
+
+    // PyObject_IsInstance answers -1 on error, which is truthy -- test for it explicitly rather
+    // than walking into the ctypes branch with a Python exception already set.
+    int is_ctypes = PyObject_IsInstance(ptr, ctypes_simple_cdata_type());
+    if (is_ctypes < 0) {
+        throw nb::python_error();
+    }
+    if (is_ctypes) {
+        // One buffer request answers both questions: its format decides admission and byte
+        // order, its length decides the width. Taking the width from the buffer rather than
+        // inferring it from the format character is what keeps a subclass whose format
+        // disagrees with its layout from reading past its own storage.
+        Py_buffer view;
+        if (PyObject_GetBuffer(ptr, &view, PyBUF_FORMAT) != 0) {
+            throw std::invalid_argument("add_scalar: ctypes scalar does not support the buffer protocol");
+        }
+        CtypesFormat verdict = classify_ctypes_format(view.format);
+        size_t width = static_cast<size_t>(view.len);
+        uint64_t bits = 0;
+        if (verdict == CtypesFormat::Encodable && width <= sizeof(uint64_t)) {
+            std::memcpy(&bits, view.buf, width);
+        }
+        PyBuffer_Release(&view);
+
+        if (verdict == CtypesFormat::ForeignByteOrder) {
+            throw std::invalid_argument(
+                "add_scalar: ctypes scalar is not in host byte order (e.g. c_uint32.__ctype_be__ on a "
+                "little-endian host); its bytes would encode to a different number than the same value "
+                "written from orchestration"
+            );
+        }
+        if (verdict == CtypesFormat::NotNumeric) {
+            throw std::invalid_argument(
+                "add_scalar: ctypes scalar must be an integer width (c_int8..c_uint64), c_float, "
+                "c_double or c_bool -- a pointer or character type carries no value a slot can hold"
+            );
+        }
+        if (width > sizeof(uint64_t)) {
+            throw std::invalid_argument("add_scalar: ctypes scalar is wider than the 8-byte slot");
+        }
+        return bits;
+    }
+
+    if (PyFloat_Check(ptr)) {
+        double d = PyFloat_AsDouble(ptr);
+        if (d == -1.0 && PyErr_Occurred()) {
+            throw nb::python_error();
+        }
+        float f = static_cast<float>(d);
+        // A finite value that narrows to an infinity is out of single-precision range, and
+        // storing that infinity would silently be a different number. An input that is already
+        // infinite or NaN passes through as itself.
+        if (std::isfinite(d) && !std::isfinite(f)) {
+            throw std::overflow_error(
+                "add_scalar: float value out of IEEE-754 single-precision range; pass ctypes.c_double "
+                "for full precision"
+            );
+        }
+        uint32_t bits;
+        std::memcpy(&bits, &f, sizeof(bits));
+        return static_cast<uint64_t>(bits);
+    }
+
+    if (PyIndex_Check(ptr)) {
+        // Normalize through __index__ into an exact PyLong first: PyLong_As* is only
+        // guaranteed against one, and ptr may be a numpy integer scalar or an IntEnum member,
+        // neither of which is a PyLong itself.
+        nb::object as_long = nb::steal<nb::object>(PyNumber_Index(ptr));
+        if (!as_long.is_valid()) {
+            throw nb::python_error();
+        }
+        return encode_python_int(as_long.ptr());
+    }
+
+    throw std::invalid_argument("add_scalar: value must be int, float, bool, or a ctypes scalar");
 }
 
 // Which device allocations a dispatch's operands may name: the private snapshot of every live
@@ -2333,8 +2517,18 @@ NB_MODULE(_task_interface, m) {
         )
 
         .def(
-            "add_scalar", &ChipStorageTaskArgs::add_scalar, nb::arg("s"),
-            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed."
+            "add_scalar",
+            [](ChipStorageTaskArgs &self, nb::object value) {
+                self.add_scalar(encode_scalar(value));
+            },
+            nb::arg("s"),
+            "Add a scalar -- Python int, float, bool, or a ctypes scalar (c_int8..c_uint64, "
+            "c_float, c_double, c_bool; a pointer or character type, and any scalar not in host "
+            "byte order, is refused). Bit-encoded exactly like scalar_to_uint64(), which matches "
+            "C++ to_u64(): a ctypes scalar zero-extends from its own width, and a native float "
+            "narrows to IEEE-754 single precision -- a finite value out of that range raises "
+            "rather than becoming an infinity, so use ctypes.c_double for full precision. "
+            "After this, add_tensor() is no longer allowed."
         )
 
         .def(
@@ -2413,8 +2607,18 @@ NB_MODULE(_task_interface, m) {
         )
 
         .def(
-            "add_scalar", &TaskArgs::add_scalar, nb::arg("s"),
-            "Add a uint64_t scalar. After this, add_tensor() is no longer allowed."
+            "add_scalar",
+            [](TaskArgs &self, nb::object value) {
+                self.add_scalar(encode_scalar(value));
+            },
+            nb::arg("s"),
+            "Add a scalar -- Python int, float, bool, or a ctypes scalar (c_int8..c_uint64, "
+            "c_float, c_double, c_bool; a pointer or character type, and any scalar not in host "
+            "byte order, is refused). Bit-encoded exactly like scalar_to_uint64(), which matches "
+            "C++ to_u64(): a ctypes scalar zero-extends from its own width, and a native float "
+            "narrows to IEEE-754 single precision -- a finite value out of that range raises "
+            "rather than becoming an infinity, so use ctypes.c_double for full precision. "
+            "After this, add_tensor() is no longer allowed."
         )
 
         .def(
@@ -3465,6 +3669,19 @@ NB_MODULE(_task_interface, m) {
         .def("comm_destroy_all", &ChipWorker::comm_destroy_all, "Destroy all owned communicators in LIFO order.");
 
     // --- Standalone blob helpers ---
+
+    m.def(
+        "scalar_to_uint64", &encode_scalar, nb::arg("value"),
+        "Bit-encode a Python int, float, bool, or ctypes scalar into the uint64 a scalar slot "
+        "stores, matching C++ to_u64() bit for bit. A ctypes scalar is read at its own width and "
+        "zero-extended, so ctypes.c_int8(-1) is 0xFF rather than a sign-extended 0xFF..FF; the "
+        "admitted ctypes types are c_int8..c_uint64, c_float, c_double and c_bool in host byte "
+        "order, and a pointer type, a character type, or a byte-order-qualified variant such as "
+        "c_uint32.__ctype_be__ is refused. A native Python float narrows to IEEE-754 single "
+        "precision and zero-extends, and a finite value out of single-precision range raises "
+        "rather than becoming an infinity; pass ctypes.c_double for full precision, or another "
+        "ctypes scalar for exact width."
+    );
 
     m.def(
         "materialize_task_args",

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -99,6 +99,9 @@ from _task_interface import (
 from _task_interface import (
     _start_host_log_writer as _native_start_host_log_writer,
 )
+from _task_interface import (
+    scalar_to_uint64 as _native_scalar_to_uint64,
+)
 
 from .buffer import Buffer, Tensor
 
@@ -957,26 +960,46 @@ assert ctypes.sizeof(_CommContextStruct) == 1056
 def scalar_to_uint64(value) -> int:
     """Convert a scalar value to ``uint64``.
 
-    *value* can be a Python int, float, a ctypes scalar (``c_int64``,
-    ``c_float``, etc.), or any object convertible to ``int``.
+    *value* can be a Python int, float, bool, a numpy integer scalar, an
+    ``IntEnum`` member, or a ctypes scalar.
 
-    Python float values are converted to IEEE 754 single precision (32-bit)
-    and their bit pattern is zero-extended to uint64. This may cause a loss of
-    precision. For double precision, use ``ctypes.c_double``.
+    The accepted ctypes types are the integer widths (``c_int8`` ..
+    ``c_uint64``), ``c_float``, ``c_double`` and ``c_bool``, and any subclass
+    of one of them. A pointer or character type (``c_void_p``, ``c_char_p``,
+    ``c_char``, ``c_wchar``) is refused: its buffer holds an address or a
+    character rather than a number a slot can carry.
+
+    A byte-order-qualified variant (``c_uint32.__ctype_be__`` on a
+    little-endian host, and its ``__ctype_le__`` counterpart on a big-endian
+    one) is also refused. Its bytes are stored in the opposite order, so
+    copying them would encode a different number than the same value written
+    from orchestration, and ``to_u64`` has no reversed-order form to agree
+    with.
+
+    The encoding matches C++ ``to_u64()`` bit for bit, so a slot written from
+    Python and one written from orchestration read back identically.
+
+    A ctypes scalar is read at its own width and **zero-extended**, never
+    sign-extended: ``c_int8(-1)`` is ``0xFF``, matching ``to_u64(int8_t{-1})``.
+    Reading it back with the matching width (``scalar<int8_t>``) still yields
+    ``-1``.
+
+    Python float values (and ``numpy.float64``, which is itself a ``float``
+    subclass) are converted to IEEE 754 single precision (32-bit) and their
+    bit pattern is zero-extended to uint64. This may cause a loss of
+    precision. A finite value outside single-precision range (``1e100``)
+    raises rather than being stored as an infinity; ``inf`` and ``nan`` pass
+    through as themselves. For double precision, use ``ctypes.c_double`` -- a
+    bare Python float carries no width, so this is the one encoding that
+    cannot align with its C++ counterpart, where ``to_u64(1.5)`` is a double.
+    A narrower numpy float (e.g. ``numpy.float32``) is rejected rather than
+    silently coerced through ``int()`` -- wrap it in ``float(...)`` first if
+    that narrowing is what you want.
+
+    An integer outside the 64-bit two's-complement range raises rather than
+    truncating to its low 64 bits.
     """
-    import struct as _struct
-
-    if isinstance(value, float):
-        bits = _struct.unpack("<I", _struct.pack("<f", value))[0]
-        return bits
-    import ctypes as _ct
-
-    if isinstance(value, _ct._SimpleCData):
-        if isinstance(value, (_ct.c_float, _ct.c_double)):
-            uint_type = _ct.c_uint32 if isinstance(value, _ct.c_float) else _ct.c_uint64
-            return uint_type.from_buffer_copy(value).value
-        return int(value.value) & 0xFFFFFFFFFFFFFFFF
-    return int(value) & 0xFFFFFFFFFFFFFFFF
+    return _native_scalar_to_uint64(value)
 
 
 @dataclass

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -587,7 +587,7 @@ def _build_l2_ref_args(test_args: TaskArgsBuilder, orch_signature: list, worker)
         args: TaskArgs (TensorArg)
         output_names: list of tensor names that are OUTPUT or INOUT
     """
-    from simpler.task_interface import ArgDirection, TaskArgs, TensorArgType, scalar_to_uint64  # noqa: PLC0415
+    from simpler.task_interface import ArgDirection, TaskArgs, TensorArgType  # noqa: PLC0415
 
     from simpler_setup.torch_interop import make_tensor_arg  # noqa: PLC0415
 
@@ -613,7 +613,7 @@ def _build_l2_ref_args(test_args: TaskArgsBuilder, orch_signature: list, worker)
                 output_names.append(spec.name)
             tensor_idx += 1
         elif isinstance(spec, Scalar):
-            args.add_scalar(scalar_to_uint64(spec.value))
+            args.add_scalar(spec.value)
 
     return args, output_names
 
@@ -632,7 +632,6 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
     from simpler.task_interface import (  # noqa: PLC0415
         ArgDirection,
         ChipStorageTaskArgs,
-        scalar_to_uint64,
     )
 
     # make_chip_tensor_arg builds the chip POD (ChipTensor, carries an address) for the direct
@@ -657,7 +656,7 @@ def _build_chip_task_args(test_args: TaskArgsBuilder, orch_signature: list):
                 output_names.append(spec.name)
             tensor_idx += 1
         elif isinstance(spec, Scalar):
-            chip_args.add_scalar(scalar_to_uint64(spec.value))
+            chip_args.add_scalar(spec.value)
 
     return chip_args, output_names
 
@@ -727,7 +726,6 @@ def _build_l3_task_args(test_args: TaskArgsBuilder, orch_signature: list, worker
         ArgDirection,
         TaskArgs,
         TensorArgType,
-        scalar_to_uint64,
     )
 
     _DIR_TO_TAG = {
@@ -757,7 +755,7 @@ def _build_l3_task_args(test_args: TaskArgsBuilder, orch_signature: list, worker
                 output_names.append(spec.name)
             tensor_idx += 1
         elif isinstance(spec, Scalar):
-            chip_args.add_scalar(scalar_to_uint64(spec.value))
+            chip_args.add_scalar(spec.value)
 
     return chip_args, output_names
 

--- a/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
+++ b/src/common/host_build_graph/docs/GRAPH_EXECUTION.md
@@ -99,28 +99,33 @@ parameter on every replay. A slot names the parameter it came from, not the
 `Arg` it was copied through, so provenance survives any number of intermediate
 copies.
 
-Reading a parameter as a value freezes it. `uint64_t v = args.scalar(i)` and
-`static_cast<int32_t>(args.scalar(i))` both convert through a **deprecated**
-operator, so the compiler names the file and line: the destination slot becomes
-static Definition data holding the recording invocation's number, and later
-cache hits replay that number. Forwarding never reaches that operator, which is
-what keeps a correct pass-through silent.
+Reading a parameter as a value freezes it, and the type system says so: an
+`InheritableScalar` has no conversion to a number, so `uint64_t v =
+args.scalar(i)` and `static_cast<int32_t>(args.scalar(i))` do not compile. A
+value read has to name the type it is reading — `args.scalar<T>(i)` — and what
+it produces is a plain `T`: the destination slot becomes static Definition data
+holding the recording invocation's number, and later cache hits replay that
+number. Forwarding never converts, which is what keeps a correct pass-through
+silent.
 
-That diagnostic has one limit. GCC suppresses a deprecation instantiated inside
-a system header, so a value read whose conversion happens in third-party
-template code stays silent — `EXPECT_EQ(args.scalar(i), v)` is the case found so
-far. The warning is an inventory of the value reads written here, not a proof
-that none exists.
+Because the diagnostic is the absence of a conversion rather than a
+deprecation, it has no blind spot. A value read inside third-party template
+code — `EXPECT_EQ(args.scalar(i), v)` is the case that motivated this — fails
+there too, where a `[[deprecated]]` attribute would have been suppressed for
+being instantiated inside a system header.
 
-When a value read is what you meant, say so with `args.scalar(i).to<T>()`. It
+When a value read is what you meant, say so with `args.scalar<T>(i)`. It
 applies `to_u64`'s actual inverse, which `static_cast` is not — a float slot
 holds a bit pattern, so `static_cast<float>` of `1.0f`'s pattern yields
-`1065353216.0`. It is also the only spelling that reaches an enum:
-`static_cast<DataType>(args.scalar(i))` does not compile, because a conversion
-to an enumeration does not accept a user-defined one on the way.
+`1065353216.0`. An enum has no other spelling at all:
+`static_cast<DataType>(args.scalar(i))` does not compile, because the handle
+converts to nothing and `static_cast` has no conversion to apply.
+`InheritableScalar::to<T>()` is the same read on a handle already in hand —
+reach for it when the parameter arrived as a function argument and the `Arg` it
+came from is no longer reachable.
 
 Freezing on purpose has a second spelling, and the two do different things.
-`args.scalar(i).to<T>()` hands the body a `T` to compute with, and whatever the
+`args.scalar<T>(i)` hands the body a `T` to compute with, and whatever the
 body does with it afterwards is ordinary host code.
 `task_args.add_static_scalar(args.scalar(i))` instead forwards the parameter
 into a slot and drops its origin: the slot carries the same bit pattern a
@@ -129,10 +134,11 @@ following the parameter. Reach for the first when the body needs the number, the
 second when a destination — typically a nested Graph's boundary — should hold
 the value the enclosing parameter had at record time.
 
-A derived value (`args.scalar(i) + 1`) is a value read and freezes the same way.
-Compute it before constructing the boundary and pass it as its own parameter,
-perform the transformation in a kernel, or use a construction parameter when the
-value changes the Graph's structure.
+A derived value freezes the same way, and needs the same explicit read:
+`args.scalar(i) + 1` does not compile, `args.scalar<uint64_t>(i) + 1` does and
+is frozen. Compute it before constructing the boundary and pass it as its own
+parameter, perform the transformation in a kernel, or use a construction
+parameter when the value changes the Graph's structure.
 
 Boundary scalar slots are read-only: `scalar()` hands out the parameter, not a
 mutable reference, so a binding cannot be overwritten after it is forwarded.

--- a/src/common/host_build_graph/types.h
+++ b/src/common/host_build_graph/types.h
@@ -208,29 +208,20 @@ public:
 
     constexpr const void *origin() const { return origin_; }
 
-    // Read the parameter as a value, with to_u64's actual inverse applied. static_cast on
-    // the pattern is not that inverse: a float slot holds a bit pattern, so
-    // static_cast<float> of 1.0f's pattern yields 1065353216.0. It is also the only
-    // spelling that reaches an enum, since a conversion to an enumeration does not accept
-    // a user-defined one on the way.
-    template <typename T>
-    T to() const {
-        return from_u64<T>(bits_);
-    }
-
-    // Implicit, so an existing value read still compiles; deprecated, so it says so.
-    // Forwarding stores origin() and never reaches here, which is what keeps a
-    // pass-through silent.
-    [[deprecated(
-        "scalar slot read as a value, which breaks inheritance: the destination "
-        "slot holds this invocation's number instead of following the source, so "
-        "a Graph Definition freezes it. Forward it (add_scalar(args.scalar(i))) "
-        "to keep it per-invocation; use args.scalar(i).to<T>() if a static "
-        "value is intended; pass it as a construction parameter if it selects "
-        "the Graph's structure."
-    )]]
-    operator uint64_t() const {
-        return bits_;
+    // Read this handle as a value, with to_u64's actual inverse applied. Arg::scalar<T>(i)
+    // is the spelling when the Arg is in hand; this one is for a handle that has already
+    // been passed on -- a function parameter, say -- where the Arg it came from is no
+    // longer reachable. Both freeze the parameter: whatever the body computes from the
+    // number is ordinary host code, and the destination slot no longer follows the source.
+    //
+    // static_cast is not that inverse: a float slot holds a bit pattern, so
+    // static_cast<float> of 1.0f's pattern yields 1065353216.0. An enum has no other
+    // spelling at all -- the handle converts to nothing, so static_cast<DataType> of one
+    // has no conversion to apply.
+    template <typename ScalarT>
+    ScalarT to() const {
+        static_assert(sizeof(ScalarT) <= sizeof(uint64_t), "to<T>: type must fit in the slot");
+        return from_u64<ScalarT>(bits_);
     }
 
 private:
@@ -558,15 +549,29 @@ public:
         add_scalars_impl(values, count, false);
     }
 
-    // Hand out parameter i for forwarding: its value, plus the slot that value comes from.
-    // Passing the result to another Arg's add_scalar makes that slot follow this one;
-    // reading it as a value goes through InheritableScalar's deprecated conversion, which
-    // is what makes breaking the chain visible at the call site.
+    // Hand out parameter i. The default template argument (InheritableScalar) is for
+    // forwarding: its value, plus the slot that value comes from. Passing the result to
+    // another Arg's add_scalar makes that slot follow this one; InheritableScalar has no
+    // implicit conversion to a raw value, so reading it as one instead of forwarding it
+    // requires explicitly requesting a different ScalarT.
     //
     // An already-inherited slot yields its own origin rather than itself, so the chain a
     // destination records is always one hop: "C inherits B, B inherits A" records C -> A.
-    InheritableScalar scalar(int32_t i) const {
-        return {scalars_[i], scalar_inherited_[i] != nullptr ? scalar_inherited_[i] : &scalars_[i]};
+    //
+    // scalar<T>(i) for any other T reads the slot directly as T, with to_u64's actual
+    // inverse applied -- the same read InheritableScalar::to<T>() performs on a handle
+    // already in hand. static_cast on the pattern is not that inverse: a float slot holds a
+    // bit pattern, so static_cast<float> of 1.0f's pattern yields 1065353216.0. An enum has
+    // no other spelling at all -- the handle converts to nothing, so
+    // static_cast<DataType>(scalar(i)) has no conversion to apply.
+    template <typename ScalarT = InheritableScalar>
+    ScalarT scalar(int32_t i) const {
+        if constexpr (is_inheritable_scalar_v<ScalarT>) {
+            return {scalars_[i], scalar_inherited_[i] != nullptr ? scalar_inherited_[i] : &scalars_[i]};
+        } else {
+            static_assert(sizeof(ScalarT) <= sizeof(uint64_t), "scalar<T>: type must fit in the slot");
+            return from_u64<ScalarT>(scalars_[i]);
+        }
     }
 
     // Copy every value into a compact uint64 array -- what submit and payload
@@ -636,10 +641,9 @@ private:
     void add_scalar_one(T &&value) {
         if constexpr (is_inheritable_scalar_v<T>) {
             // The value travels with the handle, so following the parameter costs no
-            // dereference of the origin -- and lets the origin dangle harmlessly. Read
-            // through to<uint64_t>() rather than a bits() getter: a public bits() would be
-            // a second silent value-read path, exactly what the deprecated conversion
-            // exists to surface.
+            // dereference of the origin -- and lets the origin dangle harmlessly. The
+            // forwarded slot holds the same 8 bytes whatever the source type was, so the
+            // read that pulls them out names uint64_t.
             scalars_[scalar_count_] = value.template to<uint64_t>();
             scalar_inherited_[scalar_count_] = Dynamic ? value.origin() : nullptr;
 #if SIMPLER_DFX

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -43,7 +43,8 @@
 #include <vector>
 
 #include "arg_direction.h"
-#include "tensor.h"  // ChipTensor (device POD) + TensorArgType, the tag TaskArgs carries
+#include "data_type.h"  // from_u64, which scalar<T>() applies to a slot
+#include "tensor.h"     // ChipTensor (device POD) + TensorArgType, the tag TaskArgs carries
 
 // Opaque at the Python surface. The run id prevents a slot from being reused
 // as a dependency after the parent-side Ring resets its monotonic slot ids.
@@ -114,7 +115,20 @@ struct TaskArgsTpl : TensorTagMixin<TensorTag, MaxT> {
     const T &tensor(int32_t i) const { return tensors_[i]; }
     T &tensor(int32_t i) { return tensors_[i]; }
 
-    S scalar(int32_t i) const { return scalars_[i]; }
+    // ScalarT defaults to S (the slot's native type, uint64_t in every instantiation), which
+    // keeps a bare scalar(i) unchanged. scalar<T>(i) for any other T reads the slot as T via
+    // from_u64, not static_cast: a float slot holds a bit pattern, so static_cast<float> of
+    // 1.0f's pattern yields 1065353216.0. The bound is sizeof(S) because what the read has
+    // to fit in is this instantiation's slot, whatever S is.
+    template <typename ScalarT = S>
+    ScalarT scalar(int32_t i) const {
+        if constexpr (std::is_same_v<ScalarT, S>) {
+            return scalars_[i];
+        } else {
+            static_assert(sizeof(ScalarT) <= sizeof(S), "scalar<T>: type must fit in the slot");
+            return from_u64<ScalarT>(scalars_[i]);
+        }
+    }
     S &scalar(int32_t i) { return scalars_[i]; }
 
     const S *scalars() const { return scalars_; }
@@ -165,7 +179,15 @@ struct TaskArgsTpl<T, S, 0, 0, TensorTag> : TensorTagMixin<TensorTag, 0> {
     const T &tensor(int32_t i) const { return tensors_[static_cast<size_t>(i)]; }
     T &tensor(int32_t i) { return tensors_[static_cast<size_t>(i)]; }
 
-    S scalar(int32_t i) const { return scalars_[static_cast<size_t>(i)]; }
+    template <typename ScalarT = S>
+    ScalarT scalar(int32_t i) const {
+        if constexpr (std::is_same_v<ScalarT, S>) {
+            return scalars_[static_cast<size_t>(i)];
+        } else {
+            static_assert(sizeof(ScalarT) <= sizeof(S), "scalar<T>: type must fit in the slot");
+            return from_u64<ScalarT>(scalars_[static_cast<size_t>(i)]);
+        }
+    }
     S &scalar(int32_t i) { return scalars_[static_cast<size_t>(i)]; }
 
     const T *tensor_data() const { return tensors_.data(); }

--- a/tests/st/a2a3/host_build_graph/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -56,11 +56,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_Z = orch_args.tensor(5).ref();
 
     // Scalar config args
-    int batch = static_cast<int>(orch_args.scalar(0));
-    int M = static_cast<int>(orch_args.scalar(1));
-    int N = static_cast<int>(orch_args.scalar(2));
-    int matmul_batch = static_cast<int>(orch_args.scalar(3));
-    int add_batch = static_cast<int>(orch_args.scalar(4));
+    int batch = orch_args.scalar<int>(0);
+    int M = orch_args.scalar<int>(1);
+    int N = orch_args.scalar<int>(2);
+    int matmul_batch = orch_args.scalar<int>(3);
+    int add_batch = orch_args.scalar<int>(4);
 
     LOG_INFO(
         "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d", batch, M, N, matmul_batch,

--- a/tests/st/a2a3/host_build_graph/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -68,7 +68,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
 
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));
     uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;

--- a/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -98,7 +98,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
 
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));

--- a/tests/st/a2a3/host_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -101,17 +101,17 @@ static void process_qtile_scope(const CoreTaskArgs &ctx) {
     const simpler::hbg::Tensor &value_cache = ctx.tensor(2).ref();
     const simpler::hbg::Tensor &block_table = ctx.tensor(3).ref();
     const simpler::hbg::Tensor &out = ctx.tensor(4).ref();
-    uint64_t b_idx = ctx.scalar(0);
-    uint64_t q_idx = ctx.scalar(1);
-    uint64_t q_head_num = ctx.scalar(2);
-    uint64_t q_tile = ctx.scalar(3);
-    uint64_t head_dim = ctx.scalar(4);
-    uint64_t block_size = ctx.scalar(5);
-    uint64_t block_num = ctx.scalar(6);
-    uint64_t scale_value = ctx.scalar(7);
-    uint64_t bn_this_batch = ctx.scalar(8);
-    uint64_t cur_seq = ctx.scalar(9);
-    DataType data_type = ctx.scalar(10).to<DataType>();
+    uint64_t b_idx = ctx.scalar<uint64_t>(0);
+    uint64_t q_idx = ctx.scalar<uint64_t>(1);
+    uint64_t q_head_num = ctx.scalar<uint64_t>(2);
+    uint64_t q_tile = ctx.scalar<uint64_t>(3);
+    uint64_t head_dim = ctx.scalar<uint64_t>(4);
+    uint64_t block_size = ctx.scalar<uint64_t>(5);
+    uint64_t block_num = ctx.scalar<uint64_t>(6);
+    uint64_t scale_value = ctx.scalar<uint64_t>(7);
+    uint64_t bn_this_batch = ctx.scalar<uint64_t>(8);
+    uint64_t cur_seq = ctx.scalar<uint64_t>(9);
+    DataType data_type = ctx.scalar<DataType>(10);
 
     CYCLE_COUNT_START();
 
@@ -266,7 +266,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;

--- a/tests/st/a2a3/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -57,7 +57,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_Y = orch_args.tensor(1).ref();
     const simpler::hbg::Tensor &ext_gate = orch_args.tensor(2).ref();
 
-    uint64_t case_id = orch_args.scalar(0);
+    uint64_t case_id = orch_args.scalar<uint64_t>(0);
     if (case_id != 1 && case_id != 2) {
         rt_report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, "unsupported case_id=%llu", static_cast<unsigned long long>(case_id)

--- a/tests/st/a2a3/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t max_num_blocks_per_req = orch_args.tensor(3).ref().shapes[1];
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
 
     // q_tile adapts to num_heads: use 64 when num_heads >= 64, else 16.
     // The kernel statically dispatches on q_tile == 16 vs 64.

--- a/tests/st/a2a3/host_build_graph/worker_async_fifo/kernels/orchestration/pipelined_vector_orch.cpp
+++ b/tests/st/a2a3/host_build_graph/worker_async_fifo/kernels/orchestration/pipelined_vector_orch.cpp
@@ -32,7 +32,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &a = args.tensor(0).ref();
     const simpler::hbg::Tensor &b = args.tensor(1).ref();
     const simpler::hbg::Tensor &out = args.tensor(2).ref();
-    const uint64_t spin_iters = args.scalar(0);
+    const uint64_t spin_iters = args.scalar<uint64_t>(0);
     uint32_t shape[1] = {a.shapes[0]};
     TensorCreateInfo temporary(shape, 1, DataType::FLOAT32);
 

--- a/tests/st/a2a3/host_build_graph/worker_async_fifo/test_worker_async_fifo.py
+++ b/tests/st/a2a3/host_build_graph/worker_async_fifo/test_worker_async_fifo.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import DataType, TaskArgs, TensorArgType, scalar_to_uint64
+from simpler.task_interface import DataType, TaskArgs, TensorArgType
 from simpler.worker import (
     _FRAME_STAGED,
     _OFF_ACCEPTED,
@@ -73,7 +73,7 @@ def _chip_args(handles, orch_signature, *scalars):
     for handle, direction in zip(handles, orch_signature):
         args.add_tensor(handle.tensor((_SIZE,), DataType.FLOAT32), _DIR_TAGS[direction])
     for value in scalars:
-        args.add_scalar(scalar_to_uint64(value))
+        args.add_scalar(value)
     return args
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -56,11 +56,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::tmr::Tensor &ext_Z = orch_args.tensor(5).ref();
 
     // Scalar config args
-    int batch = static_cast<int>(orch_args.scalar(0));
-    int M = static_cast<int>(orch_args.scalar(1));
-    int N = static_cast<int>(orch_args.scalar(2));
-    int matmul_batch = static_cast<int>(orch_args.scalar(3));
-    int add_batch = static_cast<int>(orch_args.scalar(4));
+    int batch = orch_args.scalar<int>(0);
+    int M = orch_args.scalar<int>(1);
+    int N = orch_args.scalar<int>(2);
+    int matmul_batch = orch_args.scalar<int>(3);
+    int add_batch = orch_args.scalar<int>(4);
 
     LOG_INFO(
         "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d", batch, M, N, matmul_batch,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
@@ -128,7 +128,7 @@ static void submit_consumer(const simpler::tmr::Tensor &out, TaskId producer, in
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
     const simpler::tmr::Tensor &output = orch_args.tensor(0).ref();
     const bool use_pending = orch_args.scalar(0) != 0;
-    const int16_t consumer_blocks = static_cast<int16_t>(orch_args.scalar(1));
+    const int16_t consumer_blocks = orch_args.scalar<int16_t>(1);
     const int32_t blocker_count = static_cast<int32_t>(rt_available_aiv_count());
 
     if (use_pending && (blocker_count <= 0 || blocker_count > BLOCKER_STATUS_CAPACITY || consumer_blocks <= 0 ||

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -50,8 +50,8 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
     const simpler::tmr::Tensor &producer_outputs = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &consumer_outputs = orch_args.tensor(1).ref();
-    int32_t producer_count = static_cast<int32_t>(orch_args.scalar(0));
-    int32_t consumer_count = static_cast<int32_t>(orch_args.scalar(1));
+    int32_t producer_count = orch_args.scalar<int32_t>(0);
+    int32_t consumer_count = orch_args.scalar<int32_t>(1);
     bool use_real_kernels = orch_args.scalar(2) != 0;
     if (producer_count < 1 || producer_count > MAX_PRODUCERS || consumer_count < 1 || consumer_count > MAX_CONSUMERS) {
         rt_report_fatal(

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -111,7 +111,7 @@ static void process_qtile_scope(const CoreTaskArgs &ctx) {
     uint64_t scale_value = ctx.scalar(7);
     uint64_t bn_this_batch = ctx.scalar(8);
     uint64_t cur_seq = ctx.scalar(9);
-    DataType data_type = static_cast<DataType>(ctx.scalar(10));
+    DataType data_type = ctx.scalar<DataType>(10);
 
     CYCLE_COUNT_START();
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/kernels/orchestration/paged_attention_highperf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/kernels/orchestration/paged_attention_highperf_orch.cpp
@@ -26,7 +26,7 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
-    int64_t block_dim = static_cast<int64_t>(orch_args.scalar(0));
+    int64_t block_dim = orch_args.scalar<int64_t>(0);
 
     LOG_INFO("SPMD PA highperf: block_dim=%" PRId64, block_dim);
 

--- a/tests/st/a5/host_build_graph/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a5/host_build_graph/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -56,11 +56,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_Z = orch_args.tensor(5).ref();
 
     // Scalar config args
-    int batch = static_cast<int>(orch_args.scalar(0));
-    int M = static_cast<int>(orch_args.scalar(1));
-    int N = static_cast<int>(orch_args.scalar(2));
-    int matmul_batch = static_cast<int>(orch_args.scalar(3));
-    int add_batch = static_cast<int>(orch_args.scalar(4));
+    int batch = orch_args.scalar<int>(0);
+    int M = orch_args.scalar<int>(1);
+    int N = orch_args.scalar<int>(2);
+    int matmul_batch = orch_args.scalar<int>(3);
+    int add_batch = orch_args.scalar<int>(4);
 
     LOG_INFO(
         "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d", batch, M, N, matmul_batch,

--- a/tests/st/a5/host_build_graph/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -68,7 +68,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
 
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));
     uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;

--- a/tests/st/a5/host_build_graph/multi_core_dag/kernels/orchestration/multi_core_dag_orch.cpp
+++ b/tests/st/a5/host_build_graph/multi_core_dag/kernels/orchestration/multi_core_dag_orch.cpp
@@ -95,8 +95,8 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
     const simpler::hbg::Tensor &task_state = args.tensor(0).ref();
-    const int64_t graph_case = static_cast<int64_t>(args.scalar(0));
-    const int64_t task_count = static_cast<int64_t>(args.scalar(1));
+    const int64_t graph_case = args.scalar<int64_t>(0);
+    const int64_t task_count = args.scalar<int64_t>(1);
     if (task_count < 1 || task_count > kTaskCapacity) {
         rt_report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, "task_count must be in [1, %d], got %ld", kTaskCapacity, task_count

--- a/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -91,7 +91,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
 
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));

--- a/tests/st/a5/host_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -102,7 +102,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;

--- a/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
+++ b/tests/st/a5/host_build_graph/predicated_dispatch/kernels/orchestration/predicated_dispatch_orch.cpp
@@ -57,7 +57,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::hbg::Tensor &ext_Y = orch_args.tensor(1).ref();
     const simpler::hbg::Tensor &ext_gate = orch_args.tensor(2).ref();
 
-    uint64_t case_id = orch_args.scalar(0);
+    uint64_t case_id = orch_args.scalar<uint64_t>(0);
     if (case_id != 1 && case_id != 2) {
         rt_report_fatal(
             SIMPLER_ERROR_INVALID_ARGS, "unsupported case_id=%llu", static_cast<unsigned long long>(case_id)

--- a/tests/st/a5/host_build_graph/single_core_dag/kernels/orchestration/single_core_dag_orch.cpp
+++ b/tests/st/a5/host_build_graph/single_core_dag/kernels/orchestration/single_core_dag_orch.cpp
@@ -107,8 +107,8 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &args) {
     const simpler::hbg::Tensor &task_state = args.tensor(0).ref();
-    int64_t graph_case = static_cast<int64_t>(args.scalar(0));
-    int64_t core_type = static_cast<int64_t>(args.scalar(1));
+    int64_t graph_case = args.scalar<int64_t>(0);
+    int64_t core_type = args.scalar<int64_t>(1);
     switch (graph_case) {
     case 0:
         build_chain(task_state, core_type);

--- a/tests/st/a5/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a5/host_build_graph/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
     uint64_t max_num_blocks_per_req = orch_args.tensor(3).ref().shapes[1];
-    uint64_t scale_value = orch_args.scalar(0);
+    uint64_t scale_value = orch_args.scalar<uint64_t>(0);
 
     uint64_t q_tile = (num_heads < MAX_Q_TILE) ? num_heads : MAX_Q_TILE;
     if ((q_tile != 16 && q_tile != MAX_Q_TILE) || num_heads % q_tile != 0) {

--- a/tests/st/a5/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -56,11 +56,11 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const simpler::tmr::Tensor &ext_Z = orch_args.tensor(5).ref();
 
     // Scalar config args
-    int batch = static_cast<int>(orch_args.scalar(0));
-    int M = static_cast<int>(orch_args.scalar(1));
-    int N = static_cast<int>(orch_args.scalar(2));
-    int matmul_batch = static_cast<int>(orch_args.scalar(3));
-    int add_batch = static_cast<int>(orch_args.scalar(4));
+    int batch = orch_args.scalar<int>(0);
+    int M = orch_args.scalar<int>(1);
+    int N = orch_args.scalar<int>(2);
+    int matmul_batch = orch_args.scalar<int>(3);
+    int add_batch = orch_args.scalar<int>(4);
 
     LOG_INFO(
         "[alternating_orch] Batch: %d, M: %d, N: %d, matmul_batch: %d, add_batch: %d", batch, M, N, matmul_batch,

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/chip_swimlane/kernels/orchestration/sync_start_early_local_owner_orch.cpp
@@ -120,7 +120,7 @@ static void submit_consumer(const simpler::tmr::Tensor &out, TaskId producer, in
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
     const simpler::tmr::Tensor &output = orch_args.tensor(0).ref();
     const bool use_pending = orch_args.scalar(0) != 0;
-    const int16_t consumer_blocks = static_cast<int16_t>(orch_args.scalar(1));
+    const int16_t consumer_blocks = orch_args.scalar<int16_t>(1);
     const int32_t blocker_count = static_cast<int32_t>(rt_available_aiv_count());
 
     if (use_pending && (blocker_count <= 0 || blocker_count > BLOCKER_STATUS_CAPACITY || consumer_blocks <= 0 ||

--- a/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -50,8 +50,8 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
     const simpler::tmr::Tensor &producer_outputs = orch_args.tensor(0).ref();
     const simpler::tmr::Tensor &consumer_outputs = orch_args.tensor(1).ref();
-    int32_t producer_count = static_cast<int32_t>(orch_args.scalar(0));
-    int32_t consumer_count = static_cast<int32_t>(orch_args.scalar(1));
+    int32_t producer_count = orch_args.scalar<int32_t>(0);
+    int32_t consumer_count = orch_args.scalar<int32_t>(1);
     bool use_real_kernels = orch_args.scalar(2) != 0;
     if (producer_count < 1 || producer_count > MAX_PRODUCERS || consumer_count < 1 || consumer_count > MAX_CONSUMERS) {
         rt_report_fatal(

--- a/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
+++ b/tests/st/host_build_graph_validation/kernels/orchestration/validation_orch.cpp
@@ -106,7 +106,7 @@ __attribute__((visibility("default"))) OrchestrationConfig aicpu_orchestration_c
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipTaskArgs &orch_args) {
     const simpler::hbg::Tensor &external = orch_args.tensor(0).ref();
-    uint64_t case_id = orch_args.scalar(0);
+    uint64_t case_id = orch_args.scalar<uint64_t>(0);
     uint32_t index[1] = {0};
 
     switch (case_id) {

--- a/tests/st/worker/comm_region/recursive_single_owner/_helpers.py
+++ b/tests/st/worker/comm_region/recursive_single_owner/_helpers.py
@@ -23,7 +23,7 @@ from simpler import comm_provider
 from simpler.comm_endpoints import DEVICE_AICPU, HOST_CPU, RegionLayoutSpec, SingleOwner, at
 from simpler.comm_provider import ProviderRegionStore, RegionPartKind
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import CallConfig, ChipCallable, CoreCallable, DataType, TaskArgs, scalar_to_uint64
+from simpler.task_interface import CallConfig, ChipCallable, CoreCallable, DataType, TaskArgs
 from simpler.worker import Worker, attach_exception_note
 from simpler.worker_chip_orch_comm import (
     NotifyOp,
@@ -145,7 +145,7 @@ def _chip_task_args(region) -> TaskArgs:
     task_args.add_scalar(_NUMEL)
     task_args.add_scalar(DataType.FLOAT32.value)
     task_args.add_scalar(_NBYTES)
-    task_args.add_scalar(scalar_to_uint64(_SCALAR))
+    task_args.add_scalar(_SCALAR)
     task_args.add_scalar(_DATA_READY_COUNTER)
     task_args.add_scalar(_COMPLETION_COUNTER)
     return task_args

--- a/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_async_submit.cpp
@@ -167,7 +167,7 @@ bool fake_graph_prepare(RuntimeContext *rt, void *recording_handle, const GraphT
         fake.recorded_tensor_storage = &tensor;
     }
     if (args.scalar_count() > 0) {
-        fake.recorded_scalar = args.scalar(0).to<uint64_t>();
+        fake.recorded_scalar = args.scalar<uint64_t>(0);
     }
     if (fake.gate_four_prepares) {
         fake.cv.notify_all();

--- a/tests/ut/cpp/common/test_hbg_graph_cache.cpp
+++ b/tests/ut/cpp/common/test_hbg_graph_cache.cpp
@@ -329,7 +329,7 @@ TEST(GraphScalarProvenance, AnLvalueDeclaresADynamicParameter) {
     EXPECT_FALSE(args.scalar_dynamic(1));
     EXPECT_EQ(args.scalar_origin(1), nullptr);
     EXPECT_FALSE(args.scalar_dynamic(2)) << "add_static_scalar overrides value category";
-    EXPECT_EQ(args.scalar(2).to<uint32_t>(), 17u);
+    EXPECT_EQ(args.scalar<uint32_t>(2), 17u);
 }
 
 TEST(GraphScalarProvenance, ForwardedScalarRetainsBoundarySource) {
@@ -341,7 +341,7 @@ TEST(GraphScalarProvenance, ForwardedScalarRetainsBoundarySource) {
 
     EXPECT_TRUE(task_args.scalar_dynamic(0));
     EXPECT_EQ(task_args.scalar_origin(0), slot_addr(boundary_args.scalar_slot_base(), 1));
-    EXPECT_EQ(task_args.scalar(0).to<uint64_t>(), uint64_t{18});
+    EXPECT_EQ(task_args.scalar<uint64_t>(0), uint64_t{18});
 }
 
 TEST(GraphScalarProvenance, ForwardedScalarNamesOriginThroughAnIntermediary) {
@@ -369,7 +369,7 @@ TEST(GraphScalarProvenance, FreezingAParameterDropsItsOrigin) {
 
     EXPECT_FALSE(task_args.scalar_dynamic(0));
     EXPECT_EQ(task_args.scalar_origin(0), nullptr);
-    EXPECT_EQ(task_args.scalar(0).to<uint64_t>(), uint64_t{18});
+    EXPECT_EQ(task_args.scalar<uint64_t>(0), uint64_t{18});
 }
 
 TEST(GraphScalarProvenance, ValueScalarHoldsItsOwnValue) {
@@ -378,8 +378,8 @@ TEST(GraphScalarProvenance, ValueScalarHoldsItsOwnValue) {
 
     EXPECT_FALSE(task_args.scalar_dynamic(0));
     EXPECT_FALSE(task_args.scalar_dynamic(1));
-    EXPECT_EQ(task_args.scalar(0).to<uint64_t>(), uint64_t{17});
-    EXPECT_EQ(task_args.scalar(1).to<float>(), 2.5F);
+    EXPECT_EQ(task_args.scalar<uint64_t>(0), uint64_t{17});
+    EXPECT_EQ(task_args.scalar<float>(1), 2.5F);
 }
 
 TEST(GraphScalarProvenance, ZeroInitialisedSlotsReadAsStaticZero) {
@@ -421,7 +421,7 @@ TEST(GraphScalarProvenance, AValueOutlivesItsOrigin) {
     // The origin now dangles, and that is by design: the value was copied at add_scalar
     // time, and the address is only ever compared, never read through.
     EXPECT_TRUE(task_args.scalar_dynamic(0));
-    EXPECT_EQ(task_args.scalar(0).to<uint64_t>(), uint64_t{42});
+    EXPECT_EQ(task_args.scalar<uint64_t>(0), uint64_t{42});
 }
 
 TEST(GraphScalarProvenance, TaskSlotsInheritFromEachOther) {
@@ -438,7 +438,7 @@ TEST(GraphScalarProvenance, TaskSlotsInheritFromEachOther) {
     // a[0] itself. A chain is therefore one hop and recording resolves it without a walk.
     EXPECT_TRUE(b.scalar_dynamic(0));
     EXPECT_EQ(b.scalar_origin(0), slot_addr(boundary_args.scalar_slot_base(), 1));
-    EXPECT_EQ(b.scalar(0).to<uint64_t>(), uint64_t{18});
+    EXPECT_EQ(b.scalar<uint64_t>(0), uint64_t{18});
 }
 
 TEST(GraphScalarProvenance, InheritingAValueSlotNamesThatSlot) {
@@ -451,7 +451,7 @@ TEST(GraphScalarProvenance, InheritingAValueSlotNamesThatSlot) {
     // a[0] names no origin, so it is itself the origin.
     EXPECT_TRUE(b.scalar_dynamic(0));
     EXPECT_EQ(b.scalar_origin(0), a.scalar_slot_base());
-    EXPECT_EQ(b.scalar(0).to<uint64_t>(), uint64_t{7});
+    EXPECT_EQ(b.scalar<uint64_t>(0), uint64_t{7});
 }
 
 TEST(GraphExecutionStorage, ComputesAlignedExactSize) {

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -10,9 +10,11 @@
 """Tests for the _task_interface nanobind extension and task_interface wrapper."""
 
 import ctypes
+import enum
 import gc
 import itertools
 import struct
+import sys
 import weakref
 from multiprocessing.shared_memory import SharedMemory
 from types import SimpleNamespace
@@ -294,23 +296,279 @@ class TestTorchInterop:
             assert arg.nbytes() == 2 * 4
 
 
+def _f32_bits(value):
+    return struct.unpack("<I", struct.pack("<f", value))[0]
+
+
+def _struct_pack_f_raises(value):
+    """Whether the pre-binding Python encoder refused this float.
+
+    `scalar_to_uint64` used `struct.pack("<f", ...)`, so these tests assert the C++ encoder
+    accepts and refuses the same set rather than hardcoding a range next to it.
+    """
+    try:
+        struct.pack("<f", value)
+    except OverflowError:
+        return True
+    return False
+
+
+def _HOST_ORDER(ctype):  # noqa: N802
+    """The byte-order-qualified variant naming the host's own order."""
+    return ctype.__ctype_le__ if sys.byteorder == "little" else ctype.__ctype_be__
+
+
+def _FOREIGN_ORDER(ctype):  # noqa: N802
+    """The byte-order-qualified variant naming the order the host does not use."""
+    return ctype.__ctype_be__ if sys.byteorder == "little" else ctype.__ctype_le__
+
+
+def _f64_bits(value):
+    return struct.unpack("<Q", struct.pack("<d", value))[0]
+
+
+class _Opcode(enum.IntEnum):
+    IDLE = 0
+    RUN = 7
+
+
+class _MyDouble(ctypes.c_double):
+    """A c_double subclass — must still encode at double precision."""
+
+
+# Every encoding scalar_to_uint64 must produce, as (value, expected bits). These are the
+# same bits C++ to_u64() produces for the same value, which is what lets a slot written
+# from Python and one written from orchestration read back identically.
+#
+# The ctypes rows are the load-bearing ones: a ctypes scalar is read at its own width and
+# ZERO-extended, so c_int8(-1) is 0xFF, matching to_u64(int8_t{-1}). Sign-extending it to
+# 0xFF..FF — which reading `.value` would do — is the divergence these rows exist to catch.
+_ENCODING_CASES = [
+    ("int_zero", 0, 0),
+    ("int_small", 999, 999),
+    ("int_negative_one", -1, 0xFFFFFFFFFFFFFFFF),
+    ("int_int64_min", -(2**63), 0x8000000000000000),
+    ("int_int64_max", 2**63 - 1, 0x7FFFFFFFFFFFFFFF),
+    ("int_uint64_max", 2**64 - 1, 0xFFFFFFFFFFFFFFFF),
+    ("bool_true", True, 1),
+    ("bool_false", False, 0),
+    ("intenum", _Opcode.RUN, 7),
+    ("c_int8_negative", ctypes.c_int8(-1), 0xFF),
+    ("c_int16_negative", ctypes.c_int16(-1), 0xFFFF),
+    ("c_int32_negative", ctypes.c_int32(-1), 0xFFFFFFFF),
+    ("c_int64_negative", ctypes.c_int64(-1), 0xFFFFFFFFFFFFFFFF),
+    ("c_int64_positive", ctypes.c_int64(42), 42),
+    ("c_uint8_max", ctypes.c_uint8(255), 0xFF),
+    ("c_uint64_max", ctypes.c_uint64(2**64 - 1), 0xFFFFFFFFFFFFFFFF),
+    ("c_bool_true", ctypes.c_bool(True), 1),
+    ("c_bool_false", ctypes.c_bool(False), 0),
+    ("c_float", ctypes.c_float(1.5), _f32_bits(1.5)),
+    ("c_double", ctypes.c_double(1.5), _f64_bits(1.5)),
+    # A subclass is still that ctypes type. Dispatching on the type's __name__ would miss
+    # this one and narrow it to single precision.
+    ("c_double_subclass", _MyDouble(1.5), _f64_bits(1.5)),
+    # A bare Python float carries no width, so it narrows. This is the one encoding that
+    # cannot align with its C++ counterpart, where to_u64(1.5) is a double.
+    ("python_float", 1.5, _f32_bits(1.5)),
+    ("python_float_negative", -2.25, _f32_bits(-2.25)),
+]
+
+_ENCODING_IDS = [case[0] for case in _ENCODING_CASES]
+_ENCODING_PARAMS = [(case[1], case[2]) for case in _ENCODING_CASES]
+
+
 class TestScalarToUint64:
-    def test_scalar_to_uint64_int(self):
+    @pytest.mark.parametrize(("value", "expected"), _ENCODING_PARAMS, ids=_ENCODING_IDS)
+    def test_encoding(self, value, expected):
         from simpler.task_interface import scalar_to_uint64
 
-        assert scalar_to_uint64(999) == 999
+        assert scalar_to_uint64(value) == expected
 
-    def test_scalar_to_uint64_ctypes(self):
+    def test_python_float_loses_precision_where_c_double_does_not(self):
         from simpler.task_interface import scalar_to_uint64
 
-        assert scalar_to_uint64(ctypes.c_int64(42)) == 42
+        value = 0.1
+        assert scalar_to_uint64(value) == _f32_bits(value)
+        assert scalar_to_uint64(ctypes.c_double(value)) == _f64_bits(value)
+        assert scalar_to_uint64(value) != scalar_to_uint64(ctypes.c_double(value))
 
-    def test_scalar_to_uint64_float_ctypes(self):
+    def test_numpy_integer_is_accepted(self):
+        np = pytest.importorskip("numpy")
         from simpler.task_interface import scalar_to_uint64
 
-        bits = scalar_to_uint64(ctypes.c_float(1.5))
-        expected_bits = struct.unpack("I", struct.pack("f", 1.5))[0]
-        assert bits == expected_bits
+        assert scalar_to_uint64(np.int64(-1)) == 0xFFFFFFFFFFFFFFFF
+        assert scalar_to_uint64(np.uint32(7)) == 7
+
+    def test_numpy_float64_is_a_python_float_subclass(self):
+        np = pytest.importorskip("numpy")
+        from simpler.task_interface import scalar_to_uint64
+
+        assert scalar_to_uint64(np.float64(1.5)) == _f32_bits(1.5)
+
+    def test_rejects_narrower_numpy_float(self):
+        np = pytest.importorskip("numpy")
+        from simpler.task_interface import scalar_to_uint64
+
+        # np.float32 defines neither __index__ nor float inheritance, so it is refused
+        # rather than silently coerced through int().
+        with pytest.raises((TypeError, ValueError)):
+            scalar_to_uint64(np.float32(1.5))
+
+    def test_rejects_non_scalar(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        with pytest.raises((TypeError, ValueError)):
+            scalar_to_uint64("7")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            ctypes.c_void_p(0x1234),
+            ctypes.c_char_p(b"seven"),
+            ctypes.c_char(b"7"),
+            ctypes.c_wchar("7"),
+        ],
+        ids=["c_void_p", "c_char_p", "c_char", "c_wchar"],
+    )
+    def test_rejects_non_numeric_ctypes(self, value):
+        from simpler.task_interface import scalar_to_uint64
+
+        # These are _SimpleCData subclasses whose buffer holds an address or a character,
+        # not a number. Encoding one would put a host pointer into a device-bound slot.
+        with pytest.raises((TypeError, ValueError)):
+            scalar_to_uint64(value)
+
+    def test_accepts_a_subclass_of_an_admitted_ctypes_type(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        # Admission reads the buffer's format, which a subclass inherits from its base, so it
+        # is not decided by the type's own name.
+        class _MyInt8(ctypes.c_int8):
+            pass
+
+        assert scalar_to_uint64(_MyInt8(-1)) == 0xFF
+
+    @pytest.mark.parametrize(
+        ("foreign", "native"),
+        [
+            (_FOREIGN_ORDER(ctypes.c_uint32)(1), ctypes.c_uint32(1)),
+            (_FOREIGN_ORDER(ctypes.c_double)(1.5), ctypes.c_double(1.5)),
+        ],
+        ids=["c_uint32", "c_double"],
+    )
+    def test_rejects_a_foreign_byte_order_ctypes_scalar(self, foreign, native):
+        from simpler.task_interface import scalar_to_uint64
+
+        # A byte-order-qualified variant carries the *same* `_type_` as its native counterpart
+        # and differs only in the buffer format's prefix, so `_type_` alone cannot tell them
+        # apart. Its bytes are reversed, so copying them would encode c_uint32.__ctype_be__(1)
+        # as 0x01000000 where to_u64(uint32_t{1}) is 0x1 — a different number for the same
+        # value, which is exactly the bit-for-bit contract this encoder claims.
+        assert type(foreign)._type_ == type(native)._type_
+        assert bytes(memoryview(foreign)) == bytes(reversed(bytes(memoryview(native))))
+        with pytest.raises((TypeError, ValueError)):
+            scalar_to_uint64(foreign)
+
+    def test_accepts_the_host_byte_order_qualified_variant(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        # The qualifier naming the host's own order is not foreign, so it encodes like the
+        # unqualified type rather than being refused along with its sibling.
+        assert scalar_to_uint64(_HOST_ORDER(ctypes.c_uint32)(1)) == 1
+
+    @pytest.mark.parametrize(
+        "value",
+        [1e100, -1e100, 3.402823806667635e38, 1e308],
+        ids=["1e100", "-1e100", "just_above_flt_max", "1e308"],
+    )
+    def test_rejects_float_out_of_single_precision_range(self, value):
+        from simpler.task_interface import scalar_to_uint64
+
+        # struct.pack("<f", ...) raised OverflowError for these, and storing the infinity a
+        # narrowing conversion produces would silently be a different number.
+        assert _struct_pack_f_raises(value)
+        with pytest.raises((OverflowError, ValueError)):
+            scalar_to_uint64(value)
+
+    def test_float_range_boundary(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        # FLT_MAX itself is in range; the smallest double above it that does not round back
+        # down to it is not.
+        flt_max = 3.4028234663852886e38
+        assert scalar_to_uint64(flt_max) == _f32_bits(flt_max)
+        assert not _struct_pack_f_raises(flt_max)
+
+    @pytest.mark.parametrize("value", [float("inf"), float("-inf")], ids=["inf", "-inf"])
+    def test_non_finite_float_passes_through(self, value):
+        from simpler.task_interface import scalar_to_uint64
+
+        # An input that is already infinite is not a value that went out of range on the way
+        # in, so it encodes as itself rather than raising.
+        assert scalar_to_uint64(value) == _f32_bits(value)
+
+    def test_nan_float_passes_through(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        bits = scalar_to_uint64(float("nan"))
+        # Exponent all ones with a non-zero mantissa — the payload is not pinned down.
+        assert bits & 0x7F800000 == 0x7F800000
+        assert bits & 0x007FFFFF != 0
+
+    @pytest.mark.parametrize("value", [2**64, -(2**63) - 1, 2**70], ids=["above_u64", "below_i64", "far_above"])
+    def test_rejects_out_of_range_integer(self, value):
+        from simpler.task_interface import scalar_to_uint64
+
+        # Truncating to the low 64 bits would silently store a different number.
+        with pytest.raises((OverflowError, ValueError)):
+            scalar_to_uint64(value)
+
+    def test_propagates_an_exception_raised_by_index(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        # __index__ answering with an exception leaves PyNumber_Index at nullptr with that
+        # exception pending. The caller sees its own error, not a crash and not a substitute.
+        class BrokenIndex:
+            def __index__(self):
+                raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError, match="boom"):
+            scalar_to_uint64(BrokenIndex())
+
+        args = TaskArgs()
+        with pytest.raises(RuntimeError, match="boom"):
+            args.add_scalar(BrokenIndex())
+        assert args.scalar_count() == 0
+
+
+class TestAddScalarEncoding:
+    """add_scalar takes the value itself and encodes it exactly as scalar_to_uint64 does."""
+
+    @pytest.mark.parametrize(("value", "expected"), _ENCODING_PARAMS, ids=_ENCODING_IDS)
+    def test_task_args(self, value, expected):
+        args = TaskArgs()
+        args.add_scalar(value)
+        assert args.scalar(0) == expected
+
+    @pytest.mark.parametrize(("value", "expected"), _ENCODING_PARAMS, ids=_ENCODING_IDS)
+    def test_chip_storage_task_args(self, value, expected):
+        args = ChipStorageTaskArgs()
+        args.add_scalar(value)
+        assert args.scalar(0) == expected
+
+    def test_pre_encoded_uint64_still_round_trips(self):
+        from simpler.task_interface import scalar_to_uint64
+
+        # The pre-encoding spelling stays valid: its result is an int, which passes through.
+        args = TaskArgs()
+        args.add_scalar(scalar_to_uint64(ctypes.c_float(1.5)))
+        assert args.scalar(0) == _f32_bits(1.5)
+
+    def test_rejects_non_scalar(self):
+        args = TaskArgs()
+        with pytest.raises((TypeError, ValueError)):
+            args.add_scalar("7")
+        assert args.scalar_count() == 0
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- `Arg::scalar(i)` on host_build_graph and `TaskArgsTpl::scalar(i)` (TMR and every other `Arg` built on it) disagreed on what a caller writes for a static read, even though both slots are the same `uint64_t`. `scalar(i)` is now a template on both sides, with the parameter spelled `ScalarT` in both (`TaskArgsTpl`'s `T` is its tensor type): host_build_graph defaults it to `InheritableScalar` (a bare `scalar(i)` still forwards with its origin), `TaskArgsTpl` defaults it to `S`/`uint64_t` (unchanged), and either side accepts an explicit type for a static value read (`args.scalar<T>(i)`). `TaskArgsTpl` bounds that read by `sizeof(S)` — the slot it has to fit in — rather than by a hardcoded 8.
- Removes the deprecated `InheritableScalar::operator uint64_t()`. This is strictly stronger than the deprecation it replaces: with no conversion left to suppress, a value read is a **compile error** rather than a warning, which closes #2170's "known blind spot" — a read inside third-party template code (`EXPECT_EQ(args.scalar(i), v)`) no longer slips past GCC's system-header suppression.
- Migrates all 98 call sites (20 orchestration files) that were hitting the deprecation warning to the explicit-`T` spelling. Every one of them was already a value read (`uint64_t v = args.scalar(i)`, `static_cast<T>(...)`, `from_u64<T>(...)`, `.to<T>()`); no forwarding site is touched, so no call site changes meaning. Deciding which of these *should* become forwards is a separate change against the individual examples — see #2170.
- `InheritableScalar::to<T>()` stays. Removing it is what forced every value read to name its type while the call sites were migrated; now that they have been, it is the only way to read a handle that was passed on as a function argument, where `Arg::scalar<T>(i)` is unavailable because the `Arg` is not in hand.
- Python's `add_scalar` took a pre-encoded `uint64_t`; it now takes the value directly (int, float, bool, or a ctypes scalar) and encodes it natively in the bindings (`encode_scalar`, exposed to Python as `scalar_to_uint64`). `scene_test.py`'s three call sites drop their `scalar_to_uint64` wrapping accordingly. The encoder matches C++ `to_u64()` bit for bit (see Behavior changes) and reads a ctypes scalar through the buffer protocol, so it needs no per-type dispatch and handles subclasses correctly.

- The `tensormap_and_ringbuffer` orchestrations that read a slot as some type *other than* the slot's own move with them (15 files, 28 sites). Two reasons beyond consistency: it puts the same spelling in front of both runtimes in-tree, which is the claim this PR is named after, and it gives `TaskArgsTpl::scalar`'s non-`S` branch its first instantiations — a template body is only checked when instantiated, and until now every `scalar<T>` call site was `host_build_graph`, whose `Arg` hides the base's `scalar` with its own. A bare `uint64_t` read is deliberately left as `scalar(i)`: that is already what it answers, so naming the type would add nothing.

Progress on #2170 — this PR migrates the `simpler`-repo side only (the 98 sites above). #2170 also scopes a `pypto`-side change (the codegen templates that emit these value reads) that is not part of this PR; see the issue for the remaining work. Not closing the issue yet.

## Behavior changes

Five, all on the Python scalar-encoding boundary (`scalar_to_uint64` and `add_scalar`). The first three make the encoding agree with C++ `to_u64()`; the last two replace a silent wrong answer with an error:

1. **A ctypes scalar is zero-extended from its own width, not sign-extended.** `c_int8(-1)` now encodes to `0xFF`, matching `to_u64(int8_t{-1})`; it was `0xFFFF_FFFF_FFFF_FFFF`. Same for `c_int16` / `c_int32`. Reading the slot back at the matching width (`scalar<int8_t>`) yields `-1` either way, so this is only observable by reading a narrow-signed slot as `scalar<int64_t>`, which is already a width mismatch. This makes a slot written from Python and one written from orchestration identical for the same value.
2. **`scalar_to_uint64` no longer accepts an object that only implements `__int__`** (e.g. `numpy.float32`, `Decimal`). The old fallback was `int(value) & 0xFFFF…`, which silently truncated. `bool`, `IntEnum` members and numpy integer scalars are still accepted, via `__index__`.
3. **An integer outside the 64-bit two's-complement range raises** instead of being truncated to its low 64 bits.
4. **A finite `float` outside IEEE-754 single-precision range raises** (`1e100`) instead of being stored as an infinity. This matches the old `struct.pack("<f", ...)`, which raised `OverflowError` for the same set; the tests assert against `struct.pack`'s own verdict rather than hardcoding a range. `inf` and `NaN` pass through as themselves.
5. **A ctypes scalar not in host byte order is refused** — `c_uint32.__ctype_be__` on a little-endian host, and `__ctype_le__` on a big-endian one. The old `.value` path read the number and so was order-blind; reading raw bytes is not. A refusal, rather than a byte swap, because `to_u64` has no reversed-order form for such a value to agree with. Pointer and character types (`c_void_p`, `c_char_p`, `c_char`, `c_wchar`) and `c_longdouble` are refused for the same "no number a slot can carry" reason; `c_char_p` already raised.

A native Python `float` still narrows to IEEE-754 single precision. It is the one encoding that cannot align with its C++ counterpart — a Python float carries no width, where `to_u64(1.5)` in orchestration is a double. Pass `ctypes.c_double` for full precision.

## Test plan

- [x] `pip install --no-build-isolation -e .` — full rebuild across all 4 `host_build_graph` variants (a2a3/a5 × onboard/sim), no compile errors or warnings.
- [x] ut-py: 2350 passed, 11 skipped. Includes 96 new cases in `test_task_interface.py` pinning every encoding across `scalar_to_uint64`, `TaskArgs.add_scalar` and `ChipStorageTaskArgs.add_scalar`. Regression anchors, one per behavior above: `c_int8(-1)` → `0xFF`, a `c_double` subclass, both byte-order qualifiers (the foreign one refused, the host one accepted), the single-precision boundary checked against `struct.pack`'s own verdict, out-of-range integers, and an `__index__` that raises.
- [x] ut-cpp: `ctest -LE requires_hardware` — 140/140 passed.
- [x] a2a3sim: `predicated_dispatch`, `paged_attention`, `batch_paged_attention`, `host_build_graph_validation` — 0 failed.
- [x] a2a3 **onboard** (`task-submit`, device 7): the TMR files no sim platform reaches — `alternating_matmul_add`, `fanin_lookup_perf`, `paged_attention_unroll`, `dfx/chip_swimlane` — 6 passed, 0 failed.
- [x] TMR sim: `sliding_window_deps` (a2a3+a5), `benchmark_bgemm` (a5), `dfx` — 0 failed.
- [x] The 7 changed files no test on this host reaches (a5 `alternating_matmul_add` / `fanin_lookup_perf` / `chip_swimlane` / `sdma` / `urma`, a2a3 `sdma` / `decode_fwd`) syntax-checked against each arch's own `compile_commands.json` include set — all clean. a5 onboard is not runnable here (host is a2a3 silicon); CI's `st-onboard-a5` covers them.
- [x] a5sim: `predicated_dispatch`, `single_core_dag`, `multi_core_dag`, `paged_attention`, `alternating_matmul_add`, `benchmark_bgemm`, `host_build_graph_validation` — 0 failed.
- [x] `pre-commit run` on all changed files — all hooks pass.
- [ ] Remaining hardware-only files (no sim platform variant) are not exercised by this test plan: `deepseek_v4_flash_decode`, `spmd_paged_attention` (a2a3+a5), `worker_async_fifo`, `alternating_matmul_add` (a2a3), `paged_attention_unroll` (a2a3+a5), `paged_attention_unroll_manual_scope` (a2a3+a5) — covered by the onboard CI jobs on this PR.
