### PR TITLE
Let a diagnostics config overlap its predecessor

### DIFF
--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -490,7 +490,8 @@ from the positive arm in exactly one variable:
 | --- | -------------- | ---------------- |
 | overlap stress | — | accepted, one check per adjacent pair |
 | serial submission | one run in flight instead of two | rejected, `did not overlap` |
-| diagnostics config | `enable_scope_stats` set | rejected, `did not overlap` |
+| diagnostics config | `enable_scope_stats` set | accepted |
+| orch-phase swimlane | `enable_chip_swimlane` 4 | rejected, `did not overlap` |
 
 The second arm is what makes the first a detector rather than a formality.
 Between the pipeline and the verdict sits a chain — which spans are emitted,
@@ -500,14 +501,23 @@ intersection independent of real concurrency, the positive arm would still be
 green. Matching the message matters: it separates a real rejection from the
 vacuous "need at least two complete native runs" one.
 
-The third arm covers a fallback that is otherwise silent. `allow_prepared_successor`
-folds in `CallConfig::diagnostics_any()` — the OR of all five diagnostic flags —
-because a collector's setup mutates runner-global state that is not yet
-per-epoch, so *any* one of them keeps a run and its successor on separate device
-windows even at depth 2. The lane's own check declines to stage rather than
-raising, so the submissions still succeed and the goldens still pass; nothing
-else would notice. Which flag is set does not matter, only that
-`diagnostics_any()` becomes true, so the arm picks the lightest.
+The last two hold a boundary that is otherwise invisible.
+`allow_prepared_successor` once folded in `CallConfig::diagnostics_any()` — the
+OR of all five diagnostic flags — because a collector's setup wrote
+runner-global state during preparation, which a prepared successor would have
+done while its predecessor was still running against it. The pools and that
+per-run state are now built and reset under the execution claim, so a diagnostic
+configuration overlaps like any other.
+
+Level 4 is the exception, and the reason it is not simply the same case: a
+host-orchestrating bind opens a clock-correlation session on the *resident*
+swimlane collector and samples its `HostOrchestrationBegin` anchor into it. That
+cannot move under the claim — the anchor's meaning is when host orchestration
+began — so until the session is per-run, a level-4 run neither carries a
+prepared successor nor is one. Nothing else would notice either boundary
+moving: the lane declines to stage silently rather than raising, so a run that
+lost its overlap and one that kept an overlap it should not have look the same
+from outside.
 
 Staging has three inputs and only that one is reachable from a submission. The
 other two — the runtime PipelineContract's `pipeline_depth` and the runtime's

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -210,10 +210,10 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
 // live on `DeviceRunnerBase` — see
 // `src/common/platform/onboard/host/device_runner_base.cpp`.
 
-void DeviceRunner::set_dep_gen_enabled(bool enable) {
-    enable_dep_gen_ = enable;
+void DeviceRunner::arm_host_dep_gen_capture(bool enable) {
     // Arms host-side capture for a host-orch runtime (no-op weak stub for the
-    // device-orch one). The c_api latches the CallConfig before bind, and the
+    // device-orch one). The capture is thread-local between orchestration and
+    // emit, so the c_api calls this on the binding thread before every bind; the
     // orchestration entry resets the graph before recording it.
     dep_gen_host_graph_set_enabled(enable);
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -123,7 +123,7 @@ public:
      * `set_output_prefix`, `output_prefix`, and `launch_aicpu_kernel` live on
      * `DeviceRunnerBase`.
      */
-    void set_dep_gen_enabled(bool enable) override;
+    void arm_host_dep_gen_capture(bool enable) override;
 
     /**
      * Cleanup all resources
@@ -372,5 +372,4 @@ private:
     // `pmu_event_type_`, `output_prefix_`) live on `DeviceRunnerBase`.
     //
     // dep_gen enablement is a2a3-only.
-    bool enable_dep_gen_{false};
 };

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -312,10 +312,10 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-void DeviceRunner::set_dep_gen_enabled(bool enable) {
-    enable_dep_gen_ = enable;
+void DeviceRunner::arm_host_dep_gen_capture(bool enable) {
     // Arms host-side capture for a host-orch runtime (no-op weak stub for the
-    // device-orch one). The c_api latches the CallConfig before bind, and the
+    // device-orch one). The capture is thread-local between orchestration and
+    // emit, so the c_api calls this on the binding thread before every bind; the
     // orchestration entry resets the graph before recording it.
     dep_gen_host_graph_set_enabled(enable);
 }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -46,7 +46,7 @@ public:
     // Also arms the loaded runtime's host-side graph capture, which a host-orch
     // runtime uses instead of the device collector. Defined in the .cpp so this
     // header stays free of the runtime-provided capture symbols.
-    void set_dep_gen_enabled(bool enable) override;
+    void arm_host_dep_gen_capture(bool enable) override;
 
 private:
     struct ActiveRun;
@@ -101,7 +101,6 @@ private:
     // dep_gen collector — captures orchestrator submit_task inputs for offline replay.
     // a2a3-only; a5 has no dep_gen.
     DepGenCollector dep_gen_collector_;
-    bool enable_dep_gen_{false};
     std::unique_ptr<ActiveRun> active_run_;
     simpler::common::sim_host::SimRunCompletion run_completion_;
 };

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -114,8 +114,7 @@ extern "C" const PipelineContract *get_pipeline_contract(void) {
 
 extern "C" int concurrent_native_prepare_supported_impl(void) {
     // HBG can materialize a complete graph into the lease-selected unpublished
-    // arena bank. The common C API keeps collector-bearing configurations on
-    // the sequential path until their state is per-epoch.
+    // arena bank.
     return 1;
 }
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -250,10 +250,10 @@ void DeviceRunner::clear_aicpu_topology_cache() {
     aicpu_topology_ = {};
 }
 
-void DeviceRunner::set_dep_gen_enabled(bool enable) {
-    enable_dep_gen_ = enable;
+void DeviceRunner::arm_host_dep_gen_capture(bool enable) {
     // Arms host-side capture for a host-orch runtime (no-op weak stub for the
-    // device-orch one). The c_api latches the CallConfig before bind, and the
+    // device-orch one). The capture is thread-local between orchestration and
+    // emit, so the c_api calls this on the binding thread before every bind; the
     // orchestration entry resets the graph before recording it.
     dep_gen_host_graph_set_enabled(enable);
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -108,7 +108,7 @@ public:
      * instead of the device collector. Defined in the .cpp so this header stays
      * free of the runtime-provided capture symbols.
      */
-    void set_dep_gen_enabled(bool enable) override;
+    void arm_host_dep_gen_capture(bool enable) override;
 
     /**
      * Cleanup all resources
@@ -291,7 +291,6 @@ private:
     // `pmu_event_type_`, `output_prefix_`) live on `DeviceRunnerBase`.
     //
     // dep_gen enablement is a5-specific (a2a3 carries its own copy).
-    bool enable_dep_gen_{false};
 
     int query_aicpu_device_occupancy(pto::a5::AicpuDeviceOccupancy &out);
     int query_aicpu_topology(pto::a5::AicpuTopology &out);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -317,10 +317,10 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-void DeviceRunner::set_dep_gen_enabled(bool enable) {
-    enable_dep_gen_ = enable;
+void DeviceRunner::arm_host_dep_gen_capture(bool enable) {
     // Arms host-side capture for a host-orch runtime (no-op weak stub for the
-    // device-orch one). The c_api latches the CallConfig before bind, and the
+    // device-orch one). The capture is thread-local between orchestration and
+    // emit, so the c_api calls this on the binding thread before every bind; the
     // orchestration entry resets the graph before recording it.
     dep_gen_host_graph_set_enabled(enable);
 }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -47,7 +47,7 @@ public:
     // capture, which a host-orch runtime uses instead of the device collector.
     // Defined in the .cpp so this header stays free of the runtime-provided
     // capture symbols.
-    void set_dep_gen_enabled(bool enable) override;
+    void arm_host_dep_gen_capture(bool enable) override;
 
 private:
     struct ActiveRun;
@@ -106,7 +106,6 @@ private:
 
     // dep_gen collector — captures orchestrator submit_task inputs for offline replay.
     DepGenCollector dep_gen_collector_;
-    bool enable_dep_gen_{false};
     std::unique_ptr<ActiveRun> active_run_;
     simpler::common::sim_host::SimRunCompletion run_completion_;
 };

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -127,8 +127,7 @@ extern "C" const PipelineContract *get_pipeline_contract(void) {
 
 extern "C" int concurrent_native_prepare_supported_impl(void) {
     // HBG can materialize a complete graph into the lease-selected unpublished
-    // arena bank. The common C API keeps collector-bearing configurations on
-    // the sequential path until their state is per-epoch.
+    // arena bank.
     return 1;
 }
 

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -540,10 +540,12 @@ void Scheduler::dispatch_preparable_next_level_singles() {
             cfg_.enqueue_ready_cb(slot);
             continue;
         }
-        // Diagnostic setup mutates runner-global state, so it starts only
-        // after this run reaches the active FIFO lane. Ordinary tasks may use
-        // the prepared lane because their backend preparation is run-local.
-        if (state.config.diagnostics_any()) {
+        // A host-orchestrating runtime arms its clock-correlation session on the
+        // resident swimlane collector from inside bind, so a level-4 run starts
+        // only after it reaches the active FIFO lane. Every other diagnostics
+        // config may use the prepared lane: what its preparation would arm is
+        // built and reset under the execution claim.
+        if (state.config.captures_host_orchestration_phases()) {
             cfg_.enqueue_ready_cb(slot);
             continue;
         }

--- a/src/common/platform/include/host/dfx_run_config.h
+++ b/src/common/platform/include/host/dfx_run_config.h
@@ -18,6 +18,14 @@
 #include "common/chip_swimlane_profiling.h"
 #include "host/pmu_collector.h"
 
+// CallConfig::captures_host_orchestration_phases() spells this level as a bare
+// literal, because the task-interface ABI header cannot include the profiling
+// headers. This is the only place that sees both.
+static_assert(
+    static_cast<int32_t>(ChipSwimlaneLevel::ORCH_PHASES) == 4,
+    "CallConfig::captures_host_orchestration_phases() hardcodes the ORCH_PHASES level"
+);
+
 /**
  * One run's diagnostics configuration, resolved from its own CallConfig.
  *

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -62,6 +62,23 @@ extern "C" int dlog_setlevel(int moduleId, int level, int enableEvent);
 extern "C" bool dep_gen_host_graph_active();
 extern "C" int dep_gen_host_graph_emit(const char *deps_json_path);
 
+/**
+ * Whether a host-orchestrating bind arms the runner's host-phase record store.
+ *
+ * Strong in the host_build_graph runtime, where it reads the
+ * SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE opt-in once; weak `false` below for the
+ * device-orchestrating runtimes, whose bind never touches that store. The
+ * pipeline admission reads it because the store is one per runner, not one per
+ * run, so an opted-in run cannot carry a prepared successor.
+ *
+ * Declared with C++ linkage to match `host_phase_trace.h`. Giving it C linkage
+ * here would mangle to a different symbol, which the weak definition would then
+ * satisfy unconditionally — the opt-in would read `false` even where the strong
+ * one is linked, and nothing would say so.
+ */
+bool host_phase_records_enabled();
+__attribute__((weak)) bool host_phase_records_enabled() { return false; }
+
 using OnboardNativeRunContext = NativeRunContext<DeviceRunnerBase>;
 // Phase entry points validate raw caller storage before beginning object
 // lifetime, so the on-storage magic must remain the leading bytes.
@@ -794,8 +811,17 @@ int simpler_prepare_run(
             static_cast<unsigned long long>(state->descriptor.generation),
             static_cast<unsigned long long>(state->descriptor.run_epoch)
         );
-        const bool allow_prepared_successor =
-            concurrent_native_prepare_supported_impl() != 0 && !config->diagnostics_any();
+        // Level-4 swimlane and the host-phase record opt-in both make a
+        // host-orchestrating bind arm state that is not per-run — a
+        // clock-correlation session and anchor samples on the resident swimlane
+        // collector, and the runner's single host-phase record store. A prepared
+        // successor binds while its predecessor is still executing, so a run
+        // under either keeps the pipeline at depth one. Every other diagnostics
+        // config overlaps: what its preparation would arm is built and reset
+        // under the execution claim.
+        const bool allow_prepared_successor = concurrent_native_prepare_supported_impl() != 0 &&
+                                              !config->captures_host_orchestration_phases() &&
+                                              !host_phase_records_enabled();
         if (!runner->try_reserve_native_run(
                 state, state->descriptor.pipeline_slot, state->descriptor.arena_bank, allow_prepared_successor
             )) {
@@ -852,10 +878,17 @@ int simpler_prepare_run(
         rc = runner->prepare_launch_shape(state->runtime, state->config);
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
 
-        // Diagnostic binding reads runner-global collector configuration. It
-        // is depth-one, while concurrent HBG preparation must leave the active
-        // run's configuration untouched until launch.
+        // Latches what a device-context query answers from. Skipped for a
+        // successor prepared against an active predecessor, whose configuration
+        // is the one that query must keep reporting until it retires.
         if (!overlaps_active_run) runner->apply_call_config(state->config);
+
+        // Unconditional, and from this run's own config: a host-orchestrating
+        // runtime holds the captured graph in thread-local state between
+        // orchestration and emit, so the arming has to happen on this thread
+        // ahead of its bind whether or not it overlaps a predecessor. It writes
+        // nothing the two runs share.
+        runner->arm_host_dep_gen_capture(config->enable_dep_gen != 0);
 
         {
             STRACE("chip.run.bind");

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1275,9 +1275,6 @@ extern "C" __attribute__((weak)) int prewarm_config_impl(
 
 void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_chip_swimlane_enabled(config.enable_chip_swimlane);
-    // Virtual: a2a3 and a5 wire through to their enable_dep_gen_; an arch
-    // without dep_gen falls through to the base no-op.
-    set_dep_gen_enabled(config.enable_dep_gen != 0);
     set_output_prefix(config.output_prefix);
 }
 

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -654,11 +654,16 @@ public:
     virtual int finalize() = 0;
 
     /**
-     * dep_gen enablement setter. The shared c_api `simpler_run` calls this
-     * unconditionally; a2a3 and a5 override it to capture submit_task inputs.
-     * The base default is a no-op for any arch that does not implement dep_gen.
+     * Arm or disarm this thread's host-side dep_gen capture, from the run's own
+     * config, before it binds.
+     *
+     * A host-orchestrating runtime holds the captured graph in thread-local
+     * state between orchestration and emit, so this has to run on the thread
+     * that is about to bind, for every prepare — including one that overlaps an
+     * active predecessor, which skips `apply_call_config`. It writes nothing the
+     * runner shares between runs. An arch without dep_gen keeps the no-op.
      */
-    virtual void set_dep_gen_enabled(bool /*enable*/) {}
+    virtual void arm_host_dep_gen_capture(bool /*enable*/) {}
 
     /**
      * Launch an AICPU kernel. Internal helper used by the subclass's
@@ -1022,17 +1027,11 @@ protected:
      *
      * The release frees device memory the collectors are holding, so it is only
      * safe while no other run is executing against them. Nothing here enforces
-     * that. What guarantees it today is the diagnostics depth-1 gate: with any
-     * diagnostic on, `allow_prepared_successor` is false, so a successor cannot
-     * even reserve while a predecessor is in flight, and a stale shape is only
-     * ever seen between runs.
-     *
-     * **Whoever lifts that gate must move this rebuild inside the execution
-     * claim.** Do not reach for `native_run_active()` as the guard — it is not a
-     * usable predicate at this point: onboard takes the claim in
-     * `simpler_launch_run`, but sim takes it in `simpler_prepare_run`, so on sim
-     * it is already true for the run being prepared and the check fires on its
-     * own run.
+     * that. What guarantees it is the caller: `arm_collectors_for_run()` is the
+     * sole user, and it runs from the launch arming, under the execution claim.
+     * Do not move the call back into preparation — a prepared successor overlaps
+     * its predecessor's device window, so this would free pools that predecessor
+     * is still writing into.
      */
     bool collector_shape_is_stale(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) const {
         return collector_shape_.latched &&

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -749,6 +749,10 @@ int simpler_prepare_run(
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
 
         runner->apply_call_config(state->config);
+        // Armed from this run's own config on the thread that is about to bind:
+        // a host-orchestrating runtime keeps the capture in thread-local state
+        // between orchestration and emit. Mirrors the onboard c_api.
+        runner->arm_host_dep_gen_capture(state->config.enable_dep_gen != 0);
 
         {
             STRACE("chip.run.bind");

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -757,8 +757,6 @@ extern "C" __attribute__((weak)) int prewarm_config_impl(
 
 void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_chip_swimlane_enabled(config.enable_chip_swimlane);
-    // a2a3 and a5 override set_dep_gen_enabled; an arch without dep_gen no-ops.
-    set_dep_gen_enabled(config.enable_dep_gen != 0);
     set_output_prefix(config.output_prefix);
 }
 

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -172,8 +172,11 @@ public:
     /** Wait for completion, publish DFX, and release per-run resources. */
     virtual int drain_execution(ActiveExecution &active) = 0;
     virtual int finalize() = 0;
-    // a2a3 and a5 both override; an arch without dep_gen leaves the no-op.
-    virtual void set_dep_gen_enabled(bool /*enable*/) {}
+    // Arms this thread's host-side dep_gen capture from the run's own config,
+    // before it binds. a2a3 and a5 both override; an arch without dep_gen leaves
+    // the no-op. See the onboard base for why it is not part of
+    // apply_call_config().
+    virtual void arm_host_dep_gen_capture(bool /*enable*/) {}
 
     /** Reserve the runner's single active native execution through finalize. */
     bool try_acquire_native_run(const void *owner, const NativeRunIdentity &identity, LaunchPermit *permit);
@@ -580,17 +583,11 @@ protected:
      *
      * The release frees device memory the collectors are holding, so it is only
      * safe while no other run is executing against them. Nothing here enforces
-     * that. What guarantees it today is the diagnostics depth-1 gate: with any
-     * diagnostic on, `allow_prepared_successor` is false, so a successor cannot
-     * even reserve while a predecessor is in flight, and a stale shape is only
-     * ever seen between runs.
-     *
-     * **Whoever lifts that gate must move this rebuild inside the execution
-     * claim.** Do not reach for `native_run_active()` as the guard — it is not a
-     * usable predicate at this point: onboard takes the claim in
-     * `simpler_launch_run`, but sim takes it in `simpler_prepare_run`, so on sim
-     * it is already true for the run being prepared and the check fires on its
-     * own run.
+     * that. What guarantees it is the caller: `arm_collectors_for_run()` is the
+     * sole user, and it runs from the launch arming, under the execution claim.
+     * A simulated context takes that claim at prepare and never overlaps two
+     * runs, so this holds here by construction; the call stays in the launch
+     * arming anyway, because the two runner shapes are kept identical.
      */
     bool collector_shape_is_stale(int num_aicore, int aicpu_thread_num, int launch_aicpu_num) const {
         return collector_shape_.latched &&

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -130,6 +130,20 @@ struct CallConfig {
                enable_scope_stats != 0;
     }
 
+    /**
+     * Whether this run captures host-orchestration phase state, which a
+     * host-orchestrating runtime arms during its bind.
+     *
+     * Level 4 is the one that opens a clock-correlation session on the resident
+     * swimlane collector and samples its `HostOrchestrationBegin` anchor there,
+     * both from inside bind — i.e. from inside preparation, which a prepared
+     * successor performs while its predecessor is still executing. That state is
+     * not per-run, so such a run neither carries a prepared successor nor is one.
+     * The literal is `ChipSwimlaneLevel::ORCH_PHASES`, which this header cannot
+     * include without pulling the profiling headers into the task-interface ABI.
+     */
+    bool captures_host_orchestration_phases() const noexcept { return enable_chip_swimlane == 4; }
+
     bool output_prefix_set() const noexcept { return output_prefix[0] != '\0'; }
 
     // Throws if any diagnostic flag is enabled but `output_prefix` is empty,

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -70,9 +70,25 @@ struct ChipRunLaneState {
         std::rethrow_exception(run->error);
     }
 
+    /**
+     * Whether the predecessor at the FIFO head can carry a prepared successor.
+     *
+     * A diagnostics config is no longer disqualifying on its own: the collector
+     * pools and per-run state a preparation would otherwise have armed are built
+     * and reset under the execution claim.
+     *
+     * Level-4 chip swimlane is the exception, and it excludes a run from both
+     * roles. A host-orchestrating runtime opens a clock-correlation session on
+     * the resident swimlane collector, and samples its HostOrchestrationBegin
+     * anchor into it, from inside bind — so a successor preparing at that level
+     * would overwrite the session a predecessor is still running under, and a
+     * successor preparing behind such a predecessor would destroy it.
+     */
     bool permits_native_successor(const ChipRunState &predecessor, const CallConfig &successor_config) const {
-        return worker->supports_concurrent_native_prepare() && !predecessor.config.diagnostics_any() &&
-               !successor_config.diagnostics_any() && predecessor.phase == ChipRunState::Phase::LAUNCHED;
+        return worker->supports_concurrent_native_prepare() &&
+               !predecessor.config.captures_host_orchestration_phases() &&
+               !successor_config.captures_host_orchestration_phases() &&
+               predecessor.phase == ChipRunState::Phase::LAUNCHED;
     }
 
     bool permits_native_successor(const ChipRunState &predecessor, const ChipRunState &successor) const {

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -657,7 +657,8 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     }
     const uint64_t run_epoch = next_native_run_epoch();
     const ChipWorkerNativeRun run_identity{slot_id, generation, run_epoch, run_id, dispatch_id};
-    const bool allow_prepared_successor = supports_concurrent_native_prepare() && !config.diagnostics_any();
+    const bool allow_prepared_successor =
+        supports_concurrent_native_prepare() && !config.captures_host_orchestration_phases();
     {
         std::lock_guard<std::mutex> lk(native_run_mu_);
         NativeRunSlotState &state = native_run_states_[slot_id];

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
@@ -21,7 +21,7 @@ orchestrator) would corrupt a result and fail the golden check. The point is to
 exercise the concurrent-prepare bind path under many alternating-bank
 iterations, not to measure anything.
 
-Three arms drive the same pipeline through :meth:`_drive_pipeline` and read the
+Four arms drive the same pipeline through :meth:`_drive_pipeline` and read the
 same ``assert_native_overlap`` verdict, so each negative arm differs from the
 positive one in exactly one variable:
 
@@ -32,12 +32,20 @@ positive one in exactly one variable:
   the pipeline and the verdict (which spans are emitted, where their endpoints
   land, ``bind`` standing in for preparation, ``runner_run`` being a host wall
   span) could otherwise report an intersection independent of real concurrency.
-* ``inflight_limit=2`` with a diagnostics config — staging is off because
-  ``allow_prepared_successor`` folds in ``CallConfig::diagnostics_any()``, so the
-  lane admits one run at a time and the verdict must again be rejected. Of the
-  three inputs that can disable staging, this is the only one a submission can
-  reach: the other two are the runtime's contract depth and its capability
-  symbol, both compile-time properties of the runtime.
+* ``inflight_limit=2`` with a diagnostics config — overlap is required here too.
+  A collector's pools and per-run state are built and reset under the execution
+  claim, so a diagnostic flag no longer keeps a run and its successor on
+  separate device windows.
+* ``inflight_limit=2`` at chip-swimlane level 4 — *rejected*, and the one
+  diagnostics config that still serializes. Its bind opens a clock-correlation
+  session on the resident swimlane collector and samples an anchor into it,
+  which is not per-run and cannot move under the claim without losing its
+  meaning.
+
+The last two are what hold that boundary in place. It is invisible from goldens:
+the lane declines to stage silently rather than raising, so a run that lost its
+overlap, or one that kept an overlap it should not have, looks identical from
+outside.
 """
 
 import contextlib
@@ -261,33 +269,24 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         with pytest.raises(NativeOverlapError, match="did not overlap"):
             assert_native_overlap(parse_spans(captured.splitlines()))
 
-    def test_diagnostics_config_serializes_the_native_lane(self, st_platform, st_worker, capfd, drain_host_log):
-        """A diagnostic flag turns staging off, and the log must then be rejected.
+    def test_diagnostics_config_still_overlaps_the_native_lane(self, st_platform, st_worker, capfd, drain_host_log):
+        """A diagnostic flag does not serialize the lane, and the log must overlap.
 
-        ``allow_prepared_successor`` folds in ``CallConfig::diagnostics_any()`` —
-        the OR of all five diagnostic flags — because a collector's setup mutates
-        runner-global state that is not yet per-epoch, so two overlapping runs
-        would tread on each other. Any one flag therefore keeps a run and its
-        successor on separate device windows even at depth 2.
+        ``allow_prepared_successor`` used to fold in ``CallConfig::diagnostics_any()``
+        — the OR of all five diagnostic flags — because a collector's setup wrote
+        runner-global state during preparation, which a prepared successor would
+        have done while its predecessor was still running against it. The pools
+        and that per-run state are now built and reset by
+        ``arm_collectors_for_run()`` under the execution claim, so the successor's
+        preparation touches neither and the configuration overlaps like any other.
 
-        Unlike the depth and capability inputs, this one is reachable from a
-        submission, which is what makes it the literal control for "staging
-        disabled". The lane's own check is the polite one: it declines to stage
-        rather than raising, so the submissions still succeed and the goldens
-        still pass and nothing else in the suite would notice.
+        This arm is the only thing holding that open. The property is invisible
+        from goldens — the lane declines to stage silently rather than raising, so
+        a regression would let every diagnostic run fall back to depth one with
+        the whole suite still green.
 
         Host spans are gated separately (compile-time ``SIMPLER_HOST_STRACE``),
         so the trace still comes out with device diagnostics on.
-
-        **This arm retires with the fallback it covers.** The serialization is
-        temporary by design — ``concurrent_native_prepare_supported_impl`` in
-        ``runtime_maker.cpp`` keeps collector-bearing configurations sequential
-        only *until their state is per-epoch*. Once it is and
-        ``diagnostics_any()`` leaves ``allow_prepared_successor``, a diagnostic
-        config will overlap like any other and this arm turns red with the same
-        ``did not overlap`` it currently demands. The fix at that point is to
-        delete this test, not to restore the serialization: its value and its
-        lifetime come from the same place, the fallback being silent.
         """
         if st_platform != "a2a3":
             pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
@@ -297,11 +296,49 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         chip_worker = self._chip_worker(st_worker)
         callable_id = _ARM_CALLABLE_ID
 
-        with tempfile.TemporaryDirectory(prefix="simpler-serialized-lane-") as output_dir:
+        with tempfile.TemporaryDirectory(prefix="simpler-diagnostics-lane-") as output_dir:
             # scope_stats is the lightest of the five flags; which one is set does
             # not matter, only that diagnostics_any() becomes true. output_prefix
             # is required by CallConfig::validate() whenever one of them is.
             config = self._build_config({}, enable_scope_stats=True, output_prefix=output_dir)
+            with self._registered_callable(chip_worker, callable_id, callable_obj):
+                drain_host_log(capfd)
+                self._drive_pipeline(chip_worker, callable_id, orch_sig, config, _CONTROL_ITERS, inflight_limit=2)
+                captured = drain_host_log(capfd)
+
+        assert_native_overlap(parse_spans(captured.splitlines()))
+
+    def test_orch_phase_swimlane_serializes_the_native_lane(self, st_platform, st_worker, capfd, drain_host_log):
+        """Level-4 swimlane is the one diagnostics config that still serializes.
+
+        A host-orchestrating runtime opens a clock-correlation session on the
+        *resident* swimlane collector, and samples its ``HostOrchestrationBegin``
+        anchor into it, from inside bind — that is, from inside preparation,
+        which a prepared successor performs while its predecessor is still
+        executing. Unlike the collector pools, that state cannot move under the
+        execution claim: the anchor's whole meaning is when host orchestration
+        began. Until it is per-run, a level-4 run neither carries a prepared
+        successor nor is one, and the verdict must be *rejected*.
+
+        This is the arm that would go quiet if the exclusion were dropped without
+        making the session per-run: the lane declines to stage rather than
+        raising, so the runs would still succeed and their goldens still pass
+        while the predecessor's clock anchors were destroyed by the successor's
+        bind. It retires when that state becomes per-run, and then it flips to
+        the same `assert_native_overlap` its sibling arm above already makes.
+        """
+        if st_platform != "a2a3":
+            pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
+
+        orch_sig = self.CALLABLE["orchestration"]["signature"]
+        callable_obj = self.build_callable(st_platform)
+        chip_worker = self._chip_worker(st_worker)
+        callable_id = _ARM_CALLABLE_ID
+
+        with tempfile.TemporaryDirectory(prefix="simpler-orch-phase-lane-") as output_dir:
+            # 4 is ChipSwimlaneLevel::ORCH_PHASES, the only level whose bind arms
+            # host-orchestration phase state on the resident collector.
+            config = self._build_config({}, enable_chip_swimlane=4, output_prefix=output_dir)
             with self._registered_callable(chip_worker, callable_id, callable_obj):
                 drain_host_log(capfd)
                 self._drive_pipeline(chip_worker, callable_id, orch_sig, config, _CONTROL_ITERS, inflight_limit=2)

--- a/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
+++ b/tests/st/a2a3/host_build_graph/native_run_lifecycle/test_native_run_lifecycle.py
@@ -73,9 +73,10 @@ class TestNativeRunLifecycle(SceneTestCase):
 
         spans = list(parse_spans(drain_host_log(capfd).splitlines()))
         invocations = [inv for inv in group_invocations(spans) if "chip.run" in inv.by_name()]
-        # Two of these are the abandoned diagnostic prepares below, which record a
-        # chip.run invocation without ever reaching chip.run.runner_run.
-        expected_invocations = 5 if st_platform.endswith("sim") else 9
+        # The onboard count includes the two diagnostic-config pairs below, each
+        # of which now runs an active predecessor and a prepared successor to
+        # completion rather than having its successor refused.
+        expected_invocations = 5 if st_platform.endswith("sim") else 11
         assert len(invocations) == expected_invocations
 
         common_depths = {
@@ -104,7 +105,7 @@ class TestNativeRunLifecycle(SceneTestCase):
             for name in expected_depths.keys() - {"chip.run", "chip.run.runner_run.device_wall"}:
                 stage = by_name[name]
                 assert root.ts <= stage.ts <= stage.ts + stage.dur <= root_end
-        expected_launched = 2 if st_platform.endswith("sim") else 6
+        expected_launched = 2 if st_platform.endswith("sim") else 8
         assert launched_count == expected_launched
         if not st_platform.endswith("sim"):
             root_attrs = [inv.by_name()["chip.run"].attrs for inv in invocations]
@@ -276,37 +277,47 @@ class TestNativeRunLifecycle(SceneTestCase):
                     diagnostic_config.enable_dep_gen = True
                     diagnostic_config.output_prefix = output_dir
 
-                    # A diagnostic successor cannot overlap an ordinary active
-                    # run, even though the predecessor otherwise permits one.
+                    # A diagnostic successor overlaps an ordinary active run like
+                    # any other: its collector pools and per-run state are built
+                    # and reset under the execution claim, so its preparation
+                    # touches nothing the predecessor is using.
                     active_args, active_chip_args, active_outputs, active_golden = build_run_args()
                     native_run = chip_worker._prepare_native_run_with_pipeline_lease(
                         _SLOT, active_chip_args, 0, _GENERATION + 2, config=config
                     )
                     chip_worker._launch_native_run(native_run)
-                    with pytest.raises(RuntimeError, match="active predecessor"):
-                        chip_worker._prepare_native_run_with_pipeline_lease(
-                            _SLOT, successor_chip_args, 1, _GENERATION + 1, config=diagnostic_config
-                        )
+                    successor_run = chip_worker._prepare_native_run_with_pipeline_lease(
+                        _SLOT, successor_chip_args, 1, _GENERATION + 1, config=diagnostic_config
+                    )
                     chip_worker._wait_native_run(native_run)
                     chip_worker._finalize_native_run(native_run)
                     native_run = None
                     _compare_outputs(active_args, active_golden, active_outputs, self.RTOL, self.ATOL)
+                    chip_worker._launch_native_run(successor_run)
+                    chip_worker._wait_native_run(successor_run)
+                    chip_worker._finalize_native_run(successor_run)
+                    successor_run = None
 
-                    # A diagnostic predecessor also cannot admit an ordinary
-                    # successor while it owns the execution claim.
+                    # And a diagnostic predecessor admits an ordinary successor
+                    # while it owns the execution claim, for the same reason.
+                    successor_args, successor_chip_args, successor_outputs, successor_golden = build_run_args()
                     active_args, active_chip_args, active_outputs, active_golden = build_run_args()
                     native_run = chip_worker._prepare_native_run_with_pipeline_lease(
                         _SLOT, active_chip_args, 0, _GENERATION + 3, config=diagnostic_config
                     )
                     chip_worker._launch_native_run(native_run)
-                    with pytest.raises(RuntimeError, match="active predecessor"):
-                        chip_worker._prepare_native_run_with_pipeline_lease(
-                            _SLOT, successor_chip_args, 1, _GENERATION + 1, config=config
-                        )
+                    successor_run = chip_worker._prepare_native_run_with_pipeline_lease(
+                        _SLOT, successor_chip_args, 1, _GENERATION + 1, config=config
+                    )
                     chip_worker._wait_native_run(native_run)
                     chip_worker._finalize_native_run(native_run)
                     native_run = None
                     _compare_outputs(active_args, active_golden, active_outputs, self.RTOL, self.ATOL)
+                    chip_worker._launch_native_run(successor_run)
+                    chip_worker._wait_native_run(successor_run)
+                    chip_worker._finalize_native_run(successor_run)
+                    successor_run = None
+                    _compare_outputs(successor_args, successor_golden, successor_outputs, self.RTOL, self.ATOL)
         finally:
             for unfinished_run in (successor_run, native_run):
                 if unfinished_run is None:

--- a/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
+++ b/tests/ut/cpp/hierarchical/test_chip_run_lane.cpp
@@ -176,7 +176,12 @@ TEST(ChipRunLaneTest, OwnsFifoPreparationAndLaunch) {
     worker.finalize();
 }
 
-TEST(ChipRunLaneTest, ValidationOnlySuccessorPreparesAfterPromotion) {
+// A diagnostics config is not special-cased by the lane: its collector pools and
+// per-run state are built and reset under the execution claim, so its
+// preparation touches nothing the predecessor is using. The lane declines to
+// stage silently rather than raising, so a reinstated special case would only
+// show up as lost pipeline depth.
+TEST(ChipRunLaneTest, DiagnosticSuccessorPreparesLikeAnyOther) {
     ChipWorker worker;
     prime_worker(worker);
     ChipRunLane lane(worker);
@@ -187,14 +192,14 @@ TEST(ChipRunLaneTest, ValidationOnlySuccessorPreparesAfterPromotion) {
 
     ChipRun first = submit(lane, 101, 0);
     ChipRun second = lane.submit(1, args, diagnostic, PipelineSlotLease{1, 0, 102}, 102, 102, nullptr, 0, false);
-    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::VALIDATED_ONLY);
-    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0"}));
+    EXPECT_EQ(second.preparation_disposition(), ChipRunPreparationDisposition::NATIVE_PREPARED);
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1"}));
 
     second.activate();
     g_complete[0] = true;
     EXPECT_TRUE(first.done());
     EXPECT_FALSE(second.done());
-    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "finalize0", "prepare1", "launch1"}));
+    EXPECT_EQ(g_events, (std::vector<std::string>{"prepare0", "launch0", "prepare1", "finalize0", "launch1"}));
     lane.close();
     worker.finalize();
 }

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -2182,7 +2182,13 @@ TEST_F(ProgressSchedulerFixture, SuccessorStagesButActivatesOnlyAfterFifoPromoti
     if (orchestrator.run_done(second_run)) orchestrator.release_run(second_run);
 }
 
-TEST_F(ProgressSchedulerFixture, DiagnosticSuccessorWaitsForActiveLaneInsteadOfStaging) {
+// A diagnostics config once took the active FIFO lane instead of the prepared
+// one, because collector setup wrote runner-global state during preparation.
+// That state is now built and reset under the execution claim, so a diagnostic
+// successor stages like any other. Nothing user-visible reports the difference —
+// the run still completes and its artifacts still land — so without this the
+// special case could come back unnoticed.
+TEST_F(ProgressSchedulerFixture, DiagnosticSuccessorStagesLikeAnyOther) {
     RunId first_run = orchestrator.begin_run();
     SubmitResult first =
         orchestrator.submit_next_level(C(1), single_tensor_args(0x1100, TensorArgType::OUTPUT), config, 0);
@@ -2200,22 +2206,27 @@ TEST_F(ProgressSchedulerFixture, DiagnosticSuccessorWaitsForActiveLaneInsteadOfS
         orchestrator.submit_next_level(C(2), single_tensor_args(0x2200, TensorArgType::OUTPUT), diagnostic_config, 0);
     orchestrator.close_run_submission(second_run);
 
-    EXPECT_FALSE(endpoint0->wait_submitted(2, std::chrono::milliseconds(50)));
-    std::vector<WorkerDispatch> submitted = endpoint0->submitted();
-    ASSERT_EQ(submitted.size(), 1u);
-    EXPECT_EQ(submitted[0].task_slot, first.task_slot);
-    EXPECT_FALSE(submitted[0].prepare_only);
-
-    endpoint0->emit(WorkerProgressKind::ACCEPTED, submitted[0]);
-    endpoint0->emit(WorkerProgressKind::COMPLETED, submitted[0]);
     ASSERT_TRUE(endpoint0->wait_submitted(2));
-    submitted = endpoint0->submitted();
+    std::vector<WorkerDispatch> submitted = endpoint0->submitted();
     ASSERT_EQ(submitted.size(), 2u);
-    EXPECT_EQ(submitted[1].task_slot, second.task_slot);
-    EXPECT_FALSE(submitted[1].prepare_only);
+    auto first_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == first.task_slot;
+    });
+    auto second_dispatch = std::find_if(submitted.begin(), submitted.end(), [&](const WorkerDispatch &dispatch) {
+        return dispatch.task_slot == second.task_slot;
+    });
+    ASSERT_NE(first_dispatch, submitted.end());
+    ASSERT_NE(second_dispatch, submitted.end());
+    EXPECT_FALSE(first_dispatch->prepare_only);
+    EXPECT_TRUE(second_dispatch->prepare_only);
+    EXPECT_EQ(orchestrator.active_run_id(), first_run);
+    EXPECT_EQ(orchestrator.preparable_run_id(), second_run);
 
-    endpoint0->emit(WorkerProgressKind::ACCEPTED, submitted[1]);
-    endpoint0->emit(WorkerProgressKind::COMPLETED, submitted[1]);
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, *first_dispatch);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, *first_dispatch);
+    ASSERT_TRUE(endpoint0->wait_activated(second_run));
+    endpoint0->emit(WorkerProgressKind::ACCEPTED, *second_dispatch);
+    endpoint0->emit(WorkerProgressKind::COMPLETED, *second_dispatch);
     EXPECT_TRUE(orchestrator.wait_run_for(first_run, 3.0));
     EXPECT_TRUE(orchestrator.wait_run_for(second_run, 3.0));
     if (orchestrator.run_done(first_run)) orchestrator.release_run(first_run);


### PR DESCRIPTION
## Summary

`allow_prepared_successor` folded in `CallConfig::diagnostics_any()` — the OR of all five diagnostic flags — so **enabling any one of them dropped the pipeline back to depth one**. The reason was that a collector's setup wrote runner-global state during preparation, which a prepared successor would have done while its predecessor was still executing against it.

#2163 moved the per-run arming and #2200 moved the pool construction, the profiling flag and the shape-driven rebuild into `arm_collectors_for_run()`, which runs under the execution claim. So the broad term comes out of all four sites: the c_api's prepare admission, the L3 scheduler's prepared-lane dispatch, the chip run lane's staging predicate, and ChipWorker's slot admission.

## One configuration keeps its serialization

**Not** `diagnostics_any()` — a narrow term. A host-orchestrating bind calls `host_phase_pool_arm`, which:

- opens a clock-correlation session on the **resident** swimlane collector and samples its `HostOrchestrationBegin` anchor into it, and
- arms the runner's single host-phase record store.

Neither is per-run, and — unlike the collector pools — neither can move under the claim: the anchor's meaning is *when host orchestration began*, and host orchestration **is** the bind. So a run at chip-swimlane level 4, or under the `SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE` opt-in that arms the same store, neither carries a prepared successor nor is one.

`CallConfig::captures_host_orchestration_phases()` names the condition once. `dfx_run_config.h` is the only header that sees both it and `ChipSwimlaneLevel`, so the `static_assert` tying the two lives there.

The opt-in is read through a weak `host_phase_records_enabled()` whose strong definition is in the HBG runtime, matching the dep_gen stubs beside it. **It is declared with C++ linkage on purpose** — `extern "C"` would mangle to a different symbol that the weak definition satisfies unconditionally, so the opt-in would read `false` even where the strong one is linked and nothing would say so. Verified with `nm`: `T` in the HBG `.so`, `W` in the tmr one.

## A per-run setup that was riding on the skipped path

`apply_call_config` is skipped when a prepare overlaps an active predecessor, and it still carried `set_dep_gen_enabled`, whose only surviving effect is `dep_gen_host_graph_set_enabled`. A host-orchestrating runtime holds the captured graph in **thread-local** state between orchestration and emit, so an overlapping prepare that never armed it bound with no capture and emitted no `deps.json`. **CI caught this** as `TestDepGenHostGraphThreadAffinity`.

Now armed unconditionally from the run's own config, on the thread about to bind, by `arm_host_dep_gen_capture`. The rename is not cosmetic: setting an enable flag was the half that had already gone dead — `enable_dep_gen_` was write-only on all four runners and is removed with the setter.

## Tests converted, plus one new arm for the boundary that remains

- `concurrent_prepare_stress` diagnostics arm (a2a3 **onboard**) — successor's `bind` must overlap the predecessor's `runner_run`
- **new** fourth arm at chip-swimlane level 4 — must be *rejected*; retires when that state becomes per-run
- `native_run_lifecycle` — both diagnostic pairs run to completion instead of expecting refusal; its two span counters move with the two runs that now launch
- `ChipRunLaneTest.DiagnosticSuccessorPreparesLikeAnyOther` — `NATIVE_PREPARED` and the staged event order
- `ProgressSchedulerFixture.DiagnosticSuccessorStagesLikeAnyOther` — `prepare_only` on the successor's dispatch

The scene-test arm's own docstring said to *delete* it when the fallback retired. Converting is worth more: the lane declines to stage **silently** rather than raising, so a run that lost its overlap and one that kept an overlap it should not have look identical from outside — goldens pass and artifacts land either way.

## Testing

Two negative controls on a2a3 onboard:

| Control | Result |
| --- | --- |
| restore the old `diagnostics_any()` term in the lane | **exactly one** arm red — the diagnostics one |
| remove the new level-4 term | **three** red — that arm plus two siblings, because they share a class-scoped worker and an overlapping level-4 bind corrupts it rather than merely flipping a verdict |

The whole a2a3 onboard `host_build_graph` suite is green in the per-PR CI shape. Running only the arm that asserts the property is what let the dep_gen defect and the lifecycle assertions reach CI; my DFX gate additionally runs HBG swimlane at level 3, which is why the level-4 hazard was invisible to it.

Also green: 12 DFX channel runs over both sim platforms; full sim sweeps (**39** and **35** cases); pyut **2242 passed / 7 skipped**; cpput **140/140** from a cleared build dir.

## Follow-up

Making the clock-correlation session and the host-phase record store per-run is what retires the level-4 exclusion. The record store is tractable — `HostApi` already carries `pipeline_slot_`, so the two hooks need only pass it through and the runner indexes by slot. The session is the harder half: the anchor is sampled into the resident collector during bind, so it needs the same capture-then-publish shape the host-phase records already use.

## One unrelated failure, recorded not waved away

The a5sim `chip_swimlane` suite segfaulted **once in six runs** inside the L2 native wait (`worker.py::_wait_run_handle` → `chip_run.wait`). Logged to `KNOWN_ISSUES.md`. Not reachable from this change, by construction: the gate sits behind `supports_concurrent_native_prepare()`, which sim hardcodes to `0`, and the scheduler hunk is on the L3 orchestrator path while this crash is on the L2 `chip_run.wait` path.

Related: #2078, #2162