### PR TITLE
Hold host-orchestration phase state per pipeline slot

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -391,7 +391,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         cleanup_execution(prepared, /*retire_aicore=*/true);
     });
 
-    int rc = reap_run(prepared.dfx);
+    int rc = reap_run(prepared.dfx, prepared.pipeline_slot);
     if (rc != 0) {
         // The device/sync error remains authoritative over teardown errors.
         return rc;
@@ -553,7 +553,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
                 activate_launch_shape(runtime);
                 (void)arm_device_wall_buffer(prepared.kernel_args);
                 if (int arm_rc = arm_collectors_for_run(runtime, prepared); arm_rc != 0) return arm_rc;
-                start_shared_collectors_for_run(prepared.dfx);
+                start_shared_collectors_for_run(prepared.dfx, prepared.pipeline_slot);
                 if (prepared.dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
@@ -624,7 +624,7 @@ LaunchTransactionResult DeviceRunner::launch_run(PreparedExecution &prepared, La
     return result;
 }
 
-int DeviceRunner::reap_run(const DfxRunConfig &dfx) {
+int DeviceRunner::reap_run(const DfxRunConfig &dfx, uint32_t pipeline_slot) {
     if (!run_streams_.ready()) {
         LOG_ERROR("reap_run: the run stream pair is not ready");
         return PTO_RUNTIME_ERR_INTERNAL;
@@ -645,7 +645,7 @@ int DeviceRunner::reap_run(const DfxRunConfig &dfx) {
         // JSON manifest, i.e. unusable for triage. reconcile/export are not
         // idempotent, so this runs only on the error return; the success path
         // still exports exactly once below.
-        teardown_shared_collectors_after_run(dfx, false);
+        teardown_shared_collectors_after_run(dfx, pipeline_slot, false);
         return rc;
     }
 
@@ -653,7 +653,7 @@ int DeviceRunner::reap_run(const DfxRunConfig &dfx) {
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
-    teardown_shared_collectors_after_run(dfx, true);
+    teardown_shared_collectors_after_run(dfx, pipeline_slot, true);
 
     // a2a3-only dep_gen teardown, device-orch shape: the collector stops, the
     // ring reconciles, and the records replay. The host-orch shape emits at the
@@ -1088,6 +1088,12 @@ int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &pr
         finalize_collectors();
     }
     latch_collector_shape(num_aicore, aicpu_thread_num, launch_aicpu_num);
+
+    // Between the stale-shape release and the init: finalize() resets
+    // host_orchestrated_ and the collector's clock session, and initialize()
+    // reads host_orchestrated_ when it decides whether to size a device orch
+    // phase pool. Publishing before the release would lose both.
+    publish_host_phase_run_to_collector(prepared.pipeline_slot);
 
     int rc = 0;
     if (dfx.chip_swimlane_enabled()) {

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -257,7 +257,7 @@ private:
     // The kernel submission boundary is separate from the stream wait and
     // post-run teardown: launch_run() submits and drain_execution() reaps.
     LaunchTransactionResult launch_run(PreparedExecution &prepared, LaunchPermit permit);
-    int reap_run(const DfxRunConfig &dfx);
+    int reap_run(const DfxRunConfig &dfx, uint32_t pipeline_slot);
 
     // On an AICore launch/sync error, best-effort drain the device so a later
     // enqueue on the same DeviceRunner can recover in place; if the drain itself

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -502,7 +502,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 set_scope_stats_enabled_func_(prepared->dfx.scope_stats_enabled);
                 set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-                start_shared_collectors_for_run(prepared->dfx);
+                start_shared_collectors_for_run(prepared->dfx, prepared->pipeline_slot);
                 if (prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
@@ -629,11 +629,11 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
-        finish_clock_correlation_session(false);
+        finish_clock_correlation_session(active.prepared->pipeline_slot, false);
         return runtime_rc;
     }
 
-    teardown_shared_collectors_after_run(dfx, true);
+    teardown_shared_collectors_after_run(dfx, active.prepared->pipeline_slot, true);
 
     // Device-orch shape: the collector stops, the ring reconciles, and the
     // records replay. The host-orch shape emits at the end of bind instead, where
@@ -792,6 +792,12 @@ int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &pr
         finalize_collectors();
     }
     latch_collector_shape(num_aicore, aicpu_thread_num, launch_aicpu_num);
+
+    // Between the stale-shape release and the init: finalize() resets
+    // host_orchestrated_ and the collector's clock session, and initialize()
+    // reads host_orchestrated_ when it decides whether to size a device orch
+    // phase pool. Publishing before the release would lose both.
+    publish_host_phase_run_to_collector(prepared.pipeline_slot);
 
     int rc = 0;
     if (dfx.chip_swimlane_enabled()) {

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -440,7 +440,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 activate_launch_shape(runtime);
                 (void)arm_device_wall_buffer(prepared->kernel_args);
                 if (int arm_rc = arm_collectors_for_run(runtime, *prepared); arm_rc != 0) return arm_rc;
-                start_shared_collectors_for_run(prepared->dfx);
+                start_shared_collectors_for_run(prepared->dfx, prepared->pipeline_slot);
                 if (prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
@@ -576,7 +576,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         if (prepared.dfx.chip_swimlane_enabled() && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
             LOG_WARN("Runtime chip-swimlane extension publication failed");
         }
-        teardown_shared_collectors_after_run(prepared.dfx, false);
+        teardown_shared_collectors_after_run(prepared.dfx, prepared.pipeline_slot, false);
         return rc;
     }
 
@@ -584,7 +584,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     if (prepared.dfx.chip_swimlane_enabled() && !publish_runtime_chip_swimlane_extensions(prepared.runtime)) {
         LOG_WARN("Runtime chip-swimlane extension publication failed");
     }
-    teardown_shared_collectors_after_run(prepared.dfx, true);
+    teardown_shared_collectors_after_run(prepared.dfx, prepared.pipeline_slot, true);
 
     // a5-specific dep_gen teardown, device-orch shape: the collector stops, the
     // ring reconciles, and the records replay. The host-orch shape emits at the
@@ -981,6 +981,12 @@ int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &pr
         finalize_collectors();
     }
     latch_collector_shape(num_aicore, aicpu_thread_num, active_aicpu_num);
+
+    // Between the stale-shape release and the init: finalize() resets
+    // host_orchestrated_ and the collector's clock session, and initialize()
+    // reads host_orchestrated_ when it decides whether to size a device orch
+    // phase pool. Publishing before the release would lose both.
+    publish_host_phase_run_to_collector(prepared.pipeline_slot);
 
     int rc = 0;
     if (dfx.chip_swimlane_enabled()) {

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -481,7 +481,7 @@ DeviceRunner::launch_execution(std::unique_ptr<PreparedExecution> prepared, Laun
                 set_scope_stats_enabled_func_(prepared->dfx.scope_stats_enabled);
                 set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
-                start_shared_collectors_for_run(prepared->dfx);
+                start_shared_collectors_for_run(prepared->dfx, prepared->pipeline_slot);
                 if (prepared->dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
                     auto thread_factory = [this](std::function<void()> fn) {
                         return create_thread(std::move(fn));
@@ -609,11 +609,11 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
-        finish_clock_correlation_session(false);
+        finish_clock_correlation_session(active.prepared->pipeline_slot, false);
         return runtime_rc;
     }
 
-    teardown_shared_collectors_after_run(dfx, true);
+    teardown_shared_collectors_after_run(dfx, active.prepared->pipeline_slot, true);
 
     // Device-orch shape: the collector stops, the ring reconciles, and the
     // records replay. The host-orch shape emits at the end of bind instead, where
@@ -790,6 +790,12 @@ int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &pr
         finalize_collectors();
     }
     latch_collector_shape(num_aicore, aicpu_thread_num, launch_aicpu_num);
+
+    // Between the stale-shape release and the init: finalize() resets
+    // host_orchestrated_ and the collector's clock session, and initialize()
+    // reads host_orchestrated_ when it decides whether to size a device orch
+    // phase pool. Publishing before the release would lose both.
+    publish_host_phase_run_to_collector(prepared.pipeline_slot);
 
     int rc = 0;
     if (dfx.chip_swimlane_enabled()) {

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -540,15 +540,6 @@ void Scheduler::dispatch_preparable_next_level_singles() {
             cfg_.enqueue_ready_cb(slot);
             continue;
         }
-        // A host-orchestrating runtime arms its clock-correlation session on the
-        // resident swimlane collector from inside bind, so a level-4 run starts
-        // only after it reaches the active FIFO lane. Every other diagnostics
-        // config may use the prepared lane: what its preparation would arm is
-        // built and reset under the execution claim.
-        if (state.config.captures_host_orchestration_phases()) {
-            cfg_.enqueue_ready_cb(slot);
-            continue;
-        }
         if (cfg_.before_claim_cb) cfg_.before_claim_cb(slot);
         if (!claim_for_dispatch(state)) continue;
         dispatch_claimed(worker, WorkerDispatch{slot, 0}, /*prepared=*/true);

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -145,8 +145,10 @@ struct HostApiOps {
     // chip-swimlane level, `producer_wants_records` carries the producer's own
     // (a runtime knob the platform does not read).
     uint32_t (*get_chip_swimlane_level)(void *runner_ctx);
-    void *(*host_phase_pool_arm)(void *runner_ctx, int producer_wants_records);
-    void (*host_phase_pool_finish)(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id);
+    void *(*host_phase_pool_arm)(void *runner_ctx, uint32_t pipeline_slot, int producer_wants_records);
+    void (*host_phase_pool_finish)(
+        void *runner_ctx, uint32_t pipeline_slot, uint64_t submitted_tasks, uint64_t invocation_id
+    );
     bool (*publish_chip_swimlane_extension)(
         void *runner_ctx, ChipSwimlaneExtensionSection section, const char *json_value, size_t json_size
     );
@@ -243,6 +245,11 @@ public:
     /**
      * Arm this pass's host phase pool.
      *
+     * The pool is one per pipeline slot, not one per runner: a host-orchestrating
+     * bind is preparation, and a prepared successor prepares while its
+     * predecessor is still executing. `pipeline_slot_` is this run's, so the
+     * hook needs no argument for it.
+     *
      * @param producer_wants_records  the producer's own enabling condition; the
      *                                runner ORs it with the chip-swimlane level
      * @return HostPhaseRecordPool* to record into, or nullptr when this pass
@@ -251,11 +258,11 @@ public:
      */
     void *host_phase_pool_arm(bool producer_wants_records) const noexcept {
         if (ops_->host_phase_pool_arm == nullptr) return nullptr;
-        return ops_->host_phase_pool_arm(runner_ctx_, producer_wants_records ? 1 : 0);
+        return ops_->host_phase_pool_arm(runner_ctx_, pipeline_slot_, producer_wants_records ? 1 : 0);
     }
     void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) const noexcept {
         if (ops_->host_phase_pool_finish != nullptr) {
-            ops_->host_phase_pool_finish(runner_ctx_, submitted_tasks, invocation_id);
+            ops_->host_phase_pool_finish(runner_ctx_, pipeline_slot_, submitted_tasks, invocation_id);
         }
     }
     bool publish_chip_swimlane_extension(

--- a/src/common/platform/include/host/dfx_run_config.h
+++ b/src/common/platform/include/host/dfx_run_config.h
@@ -18,14 +18,6 @@
 #include "common/chip_swimlane_profiling.h"
 #include "host/pmu_collector.h"
 
-// CallConfig::captures_host_orchestration_phases() spells this level as a bare
-// literal, because the task-interface ABI header cannot include the profiling
-// headers. This is the only place that sees both.
-static_assert(
-    static_cast<int32_t>(ChipSwimlaneLevel::ORCH_PHASES) == 4,
-    "CallConfig::captures_host_orchestration_phases() hardcodes the ORCH_PHASES level"
-);
-
 /**
  * One run's diagnostics configuration, resolved from its own CallConfig.
  *

--- a/src/common/platform/include/host/host_phase_run_state.h
+++ b/src/common/platform/include/host/host_phase_run_state.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/chip_swimlane_profiling.h"
+#include "host/clock_correlation.h"
+#include "host/dfx_run_config.h"
+#include "host/host_phase_records.h"
+
+/**
+ * One run's host-orchestration phase state, held per pipeline slot.
+ *
+ * A host-orchestrating runtime records these during its bind, which is
+ * preparation — and a prepared successor prepares while its predecessor is
+ * still executing. So unlike the collector pools, which `arm_collectors_for_run`
+ * builds under the execution claim, this cannot be deferred to launch: the
+ * records describe the bind, and the `HostOrchestrationBegin` anchor means the
+ * instant host orchestration began. What it gets instead is one of these per
+ * concurrently-live run, so a successor's bind writes its own.
+ *
+ * The collector on the far side is still resident and single, so everything
+ * destined for it is captured here and published in `publish_to_collector()`,
+ * from the launch arming, under the claim.
+ */
+struct HostPhaseRunState {
+    /** Per-event records for this run's bind. Non-copyable and non-movable. */
+    simpler::dfx::HostPhaseRecordStore records;
+
+    /**
+     * This run's configuration, stamped by `begin_host_phase_run()` before its
+     * bind. The runner's own members describe whichever run last held the
+     * execution claim, which on an overlapping prepare is the predecessor.
+     */
+    ChipSwimlaneLevel chip_swimlane_level{ChipSwimlaneLevel::DISABLED};
+    std::string output_prefix;
+
+    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation;
+    /** Sampled during bind; replayed into the collector at launch. */
+    std::vector<simpler::dfx::ClockAnchorSample> orchestration_begin_anchors;
+    std::string clock_provider_name;
+    std::string clock_provider_unit;
+    /**
+     * Whether this run's orchestrator phase records come from the host rather
+     * than the AICPU, which decides whether the collector sizes a device orch
+     * phase pool for it. Only a host-orchestrating bind sets it.
+     */
+    bool host_orchestrated{false};
+
+    bool wants_records(bool producer_wants_records) const {
+        return (producer_wants_records && !output_prefix.empty()) || host_orchestrated;
+    }
+
+    /** Forget the previous run in this slot, before a new one binds into it. */
+    void begin(const DfxRunConfig &dfx) {
+        chip_swimlane_level = dfx.chip_swimlane_level;
+        output_prefix = dfx.output_prefix;
+        host_orchestrated = false;
+        orchestration_begin_anchors.clear();
+        clock_provider_name.clear();
+        clock_provider_unit.clear();
+    }
+};

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -62,23 +62,6 @@ extern "C" int dlog_setlevel(int moduleId, int level, int enableEvent);
 extern "C" bool dep_gen_host_graph_active();
 extern "C" int dep_gen_host_graph_emit(const char *deps_json_path);
 
-/**
- * Whether a host-orchestrating bind arms the runner's host-phase record store.
- *
- * Strong in the host_build_graph runtime, where it reads the
- * SIMPLER_HBG_HOST_PHASE_RECORDS_ENABLE opt-in once; weak `false` below for the
- * device-orchestrating runtimes, whose bind never touches that store. The
- * pipeline admission reads it because the store is one per runner, not one per
- * run, so an opted-in run cannot carry a prepared successor.
- *
- * Declared with C++ linkage to match `host_phase_trace.h`. Giving it C linkage
- * here would mangle to a different symbol, which the weak definition would then
- * satisfy unconditionally — the opt-in would read `false` even where the strong
- * one is linked, and nothing would say so.
- */
-bool host_phase_records_enabled();
-__attribute__((weak)) bool host_phase_records_enabled() { return false; }
-
 using OnboardNativeRunContext = NativeRunContext<DeviceRunnerBase>;
 // Phase entry points validate raw caller storage before beginning object
 // lifetime, so the on-storage magic must remain the leading bytes.
@@ -263,14 +246,15 @@ static bool publish_chip_swimlane_extension(
            static_cast<DeviceRunnerBase *>(runner_ctx)->publish_chip_swimlane_extension(section, json_value, json_size);
 }
 
-static void *host_phase_pool_arm(void *runner_ctx, int producer_wants_records) {
+static void *host_phase_pool_arm(void *runner_ctx, uint32_t pipeline_slot, int producer_wants_records) {
     if (runner_ctx == nullptr) return nullptr;
-    return static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(producer_wants_records != 0);
+    return static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(pipeline_slot, producer_wants_records != 0);
 }
 
-static void host_phase_pool_finish(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id) {
+static void
+host_phase_pool_finish(void *runner_ctx, uint32_t pipeline_slot, uint64_t submitted_tasks, uint64_t invocation_id) {
     if (runner_ctx == nullptr) return;
-    static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_finish(submitted_tasks, invocation_id);
+    static_cast<DeviceRunnerBase *>(runner_ctx)->host_phase_pool_finish(pipeline_slot, submitted_tasks, invocation_id);
 }
 
 static int setup_static_arena_wrapper(
@@ -721,7 +705,9 @@ static int cleanup_failed_prepare(OnboardNativeRunContext *state, int execution_
     char trace_attrs[sizeof(state->trace_attrs)];
     std::memcpy(trace_attrs, state->trace_attrs, sizeof(trace_attrs));
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
-    state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
+    state->runner->finish_clock_correlation_session(
+        state->descriptor.pipeline_slot, false, !state->runner->can_accept_run()
+    );
     int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
@@ -811,17 +797,7 @@ int simpler_prepare_run(
             static_cast<unsigned long long>(state->descriptor.generation),
             static_cast<unsigned long long>(state->descriptor.run_epoch)
         );
-        // Level-4 swimlane and the host-phase record opt-in both make a
-        // host-orchestrating bind arm state that is not per-run — a
-        // clock-correlation session and anchor samples on the resident swimlane
-        // collector, and the runner's single host-phase record store. A prepared
-        // successor binds while its predecessor is still executing, so a run
-        // under either keeps the pipeline at depth one. Every other diagnostics
-        // config overlaps: what its preparation would arm is built and reset
-        // under the execution claim.
-        const bool allow_prepared_successor = concurrent_native_prepare_supported_impl() != 0 &&
-                                              !config->captures_host_orchestration_phases() &&
-                                              !host_phase_records_enabled();
+        const bool allow_prepared_successor = concurrent_native_prepare_supported_impl() != 0;
         if (!runner->try_reserve_native_run(
                 state, state->descriptor.pipeline_slot, state->descriptor.arena_bank, allow_prepared_successor
             )) {
@@ -889,6 +865,10 @@ int simpler_prepare_run(
         // ahead of its bind whether or not it overlaps a predecessor. It writes
         // nothing the two runs share.
         runner->arm_host_dep_gen_capture(config->enable_dep_gen != 0);
+        // Same reason, different state: a host-orchestrating bind records phase
+        // events and samples its clock anchor, and both belong to the run doing
+        // the binding rather than to whichever run last held the claim.
+        runner->begin_host_phase_run(state->descriptor.pipeline_slot, DfxRunConfig::from(*config));
 
         {
             STRACE("chip.run.bind");
@@ -927,7 +907,7 @@ int simpler_launch_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         // The host phase records describe the bind path this variable exists to
         // measure, so they are written here as well as in the device-run
         // teardown. Skipping the device must not skip the artifact.
-        state->runner->write_host_phase_records_artifact(state->config.output_prefix);
+        state->runner->write_host_phase_records_artifact(state->config.output_prefix, state->descriptor.pipeline_slot);
         state->completion_rc = 0;
         state->phase.store(NativeRunPhase::Complete, std::memory_order_release);
         return 0;
@@ -1106,10 +1086,12 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
         state->runner_resources_owned = false;
     }
 
-    // Correlation state is runner-wide. Finish it before releasing either
-    // ownership token, after which a successor may begin capture and replace
-    // the provider/session.
-    state->runner->finish_clock_correlation_session(false, !state->runner->can_accept_run());
+    // The collector's session is still resident even though the provider and the
+    // anchors are per-run, so finish it before releasing either ownership token,
+    // after which a successor may publish its own.
+    state->runner->finish_clock_correlation_session(
+        state->descriptor.pipeline_slot, false, !state->runner->can_accept_run()
+    );
     if (state->runner_claimed) {
         // The point a successor's launch becomes admissible. Ordering a
         // successor's device work against this boundary is what separates a

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -1278,89 +1278,134 @@ void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_output_prefix(config.output_prefix);
 }
 
-HostPhaseRecordPool *DeviceRunnerBase::host_phase_pool_arm(bool producer_wants_records) noexcept {
-    if (clock_correlation_provider_ != nullptr) {
-        clock_correlation_provider_->release(false);
-        clock_correlation_provider_.reset();
-    }
-    const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
-    const bool artifact_wants_records = producer_wants_records && !output_prefix_.empty();
-    chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
+void DeviceRunnerBase::begin_host_phase_run(uint32_t pipeline_slot, const DfxRunConfig &dfx) {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    host_phase_runs_[pipeline_slot].begin(dfx);
+}
+
+HostPhaseRecordPool *
+DeviceRunnerBase::host_phase_pool_arm(uint32_t pipeline_slot, bool producer_wants_records) noexcept {
+    if (pipeline_slot >= host_phase_runs_.size()) return nullptr;
+    HostPhaseRunState &run = host_phase_runs_[pipeline_slot];
+    // Only a host-orchestrating bind reaches this, so arriving here is what
+    // makes the run's orchestrator phases host-produced.
+    run.host_orchestrated = run.chip_swimlane_level == ChipSwimlaneLevel::ORCH_PHASES;
+
     // arm() allocates the pool's buffers, so it can throw; this path is noexcept,
     // where an escaping exception is std::terminate. A pass that cannot get its
     // storage collects no records and says so by handing back nullptr.
     HostPhaseRecordPool *pool = nullptr;
     try {
-        pool = host_phase_records_.arm(artifact_wants_records || swimlane_wants_records);
+        pool = run.records.arm(run.wants_records(producer_wants_records));
     } catch (...) {
         LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
     }
-    if (!swimlane_wants_records) return pool;
+    if (!run.host_orchestrated) return pool;
 
-    begin_clock_correlation_session_if_needed();
+    capture_clock_correlation_begin(run);
     return pool;
 }
 
-void DeviceRunnerBase::begin_clock_correlation_session_if_needed() noexcept {
-    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES || chip_swimlane_collector_.clock_correlation_active()) {
-        return;
-    }
+void DeviceRunnerBase::capture_clock_correlation_begin(HostPhaseRunState &run) noexcept {
+    // Sampled here, in the bind, because the anchor means the instant host
+    // orchestration began — the one thing about this state that cannot wait for
+    // the execution claim. It reaches the resident collector at launch, in
+    // publish_host_phase_run_to_collector().
+    if (run.clock_correlation != nullptr) return;
     try {
-        clock_correlation_provider_ = simpler::dfx::make_clock_correlation_provider();
-        chip_swimlane_collector_.begin_clock_correlation_session(
-            clock_correlation_provider_->name(), clock_correlation_provider_->raw_device_timestamp_unit()
-        );
-        chip_swimlane_collector_.record_clock_anchor_samples(
-            simpler::dfx::capture_clock_anchor_group(
-                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
-            )
+        run.clock_correlation = simpler::dfx::make_clock_correlation_provider();
+        run.clock_provider_name = run.clock_correlation->name();
+        run.clock_provider_unit = run.clock_correlation->raw_device_timestamp_unit();
+        run.orchestration_begin_anchors = simpler::dfx::capture_clock_anchor_group(
+            *run.clock_correlation, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
         );
     } catch (...) {
-        clock_correlation_provider_.reset();
-        try {
-            chip_swimlane_collector_.begin_clock_correlation_session("unavailable", "unknown");
-        } catch (...) {
-            // begin() stores diagnostic strings and can still fail under
-            // allocation pressure. Keep this noexcept path fail-closed.
-            chip_swimlane_collector_.finish_clock_correlation_session();
-        }
+        run.clock_correlation.reset();
+        run.orchestration_begin_anchors.clear();
+        run.clock_provider_name = "unavailable";
+        run.clock_provider_unit = "unknown";
     }
 }
 
-void DeviceRunnerBase::publish_host_phase_records_to_swimlane() {
-    if (!host_phase_records_.finished()) return;
+void DeviceRunnerBase::publish_host_phase_run_to_collector(uint32_t pipeline_slot) noexcept {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    HostPhaseRunState &run = host_phase_runs_[pipeline_slot];
+    // Read by the collector's initialize() when it sizes the orch phase pool, so
+    // this has to precede it — both now run from the launch arming.
+    chip_swimlane_collector_.set_host_orchestrated(run.host_orchestrated);
+    if (!run.host_orchestrated || chip_swimlane_collector_.clock_correlation_active()) return;
+    try {
+        chip_swimlane_collector_.begin_clock_correlation_session(
+            run.clock_provider_name.c_str(), run.clock_provider_unit.c_str()
+        );
+        if (!run.orchestration_begin_anchors.empty()) {
+            chip_swimlane_collector_.record_clock_anchor_samples(run.orchestration_begin_anchors);
+        }
+        clock_correlation_session_slot_ = pipeline_slot;
+    } catch (...) {
+        // begin() stores diagnostic strings and can still fail under allocation
+        // pressure. Keep this noexcept path fail-closed.
+        chip_swimlane_collector_.finish_clock_correlation_session();
+    }
+}
+
+void DeviceRunnerBase::begin_clock_correlation_session_if_needed(uint32_t pipeline_slot) noexcept {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    HostPhaseRunState &run = host_phase_runs_[pipeline_slot];
+    if (run.chip_swimlane_level != ChipSwimlaneLevel::ORCH_PHASES) return;
+    // The device-orchestrating path has no bind-time capture, so both halves run
+    // here, under the execution claim.
+    run.host_orchestrated = true;
+    capture_clock_correlation_begin(run);
+    publish_host_phase_run_to_collector(pipeline_slot);
+}
+
+void DeviceRunnerBase::publish_host_phase_records_to_swimlane(uint32_t pipeline_slot) {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    const simpler::dfx::HostPhaseRecordStore &records = host_phase_runs_[pipeline_slot].records;
+    if (!records.finished()) return;
     chip_swimlane_collector_.set_host_phase_records(
-        host_phase_records_.submit_records(), host_phase_records_.device_upload_records(),
-        host_phase_records_.submitted_tasks(), host_phase_records_.total_records(),
-        host_phase_records_.dropped_records()
+        records.submit_records(), records.device_upload_records(), records.submitted_tasks(), records.total_records(),
+        records.dropped_records()
     );
 }
 
 void DeviceRunnerBase::finish_clock_correlation_session(
-    bool capture_device_complete, bool abandon_device_resources
+    uint32_t pipeline_slot, bool capture_device_complete, bool abandon_device_resources
 ) noexcept {
-    if (!chip_swimlane_collector_.clock_correlation_active()) {
-        if (clock_correlation_provider_ != nullptr) {
-            clock_correlation_provider_->release(abandon_device_resources);
-            clock_correlation_provider_.reset();
+    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> *provider = nullptr;
+    if (pipeline_slot < host_phase_runs_.size()) {
+        provider = &host_phase_runs_[pipeline_slot].clock_correlation;
+    }
+    auto release_provider = [&]() {
+        if (provider != nullptr && *provider != nullptr) {
+            (*provider)->release(abandon_device_resources);
+            provider->reset();
         }
+    };
+    // The providers are per slot but the collector holds one session, so only
+    // the slot that opened it may end it. A prepared successor that fails while
+    // its predecessor is executing reaches here for its own slot; ending the
+    // session there would cost the predecessor its DeviceExecutionComplete
+    // anchor and export a correlation with no closing edge.
+    if (!chip_swimlane_collector_.clock_correlation_active() || clock_correlation_session_slot_ != pipeline_slot) {
+        release_provider();
         return;
     }
-
-    if (capture_device_complete && clock_correlation_provider_ != nullptr) {
+    if (capture_device_complete && provider != nullptr && *provider != nullptr) {
         try {
             chip_swimlane_collector_.record_clock_anchor_samples(
                 simpler::dfx::capture_clock_anchor_group(
-                    *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
+                    **provider, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
                 )
             );
-        } catch (...) {}
+        } catch (...) {
+            LOG_WARN("Device-complete clock anchors could not be sampled");
+        }
     }
     chip_swimlane_collector_.finish_clock_correlation_session();
-    if (clock_correlation_provider_ != nullptr) {
-        clock_correlation_provider_->release(abandon_device_resources);
-        clock_correlation_provider_.reset();
-    }
+    clock_correlation_session_slot_ = PTO_PIPELINE_MAX_DEPTH;
+    release_provider();
 }
 
 // =============================================================================
@@ -1393,7 +1438,11 @@ int DeviceRunnerBase::finalize_common_impl(bool abandon_device_resources) {
         if (err != 0 && rc == 0) rc = err;
     };
 
-    finish_clock_correlation_session(false, abandon_device_resources);
+    // Every slot: finalize releases the runner's device-owning resources, and a
+    // provider that never reached a drain is one of them.
+    for (uint32_t slot = 0; slot < host_phase_runs_.size(); ++slot) {
+        finish_clock_correlation_session(slot, false, abandon_device_resources);
+    }
 
     // Teardown invariant: finalize_common() is the single place that releases
     // every RTS/device-owning resource, and the subclass runs it BEFORE its
@@ -1878,7 +1927,7 @@ int DeviceRunnerBase::init_runtime_args_with_metadata(Runtime &runtime, KernelAr
     return 0;
 }
 
-void DeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx) {
+void DeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx, uint32_t pipeline_slot) {
     // Open each enabled collector's window and start its mgmt + poll threads
     // now, just before kernels launch. Both halves belong here: begin_run()
     // drops the previous run's records and republishes the device level, which
@@ -1890,7 +1939,7 @@ void DeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx) 
     };
     if (dfx.chip_swimlane_enabled()) {
         chip_swimlane_collector_.begin_run(dfx.output_prefix, dfx.chip_swimlane_level);
-        if (dfx.capture_clock_anchors) begin_clock_correlation_session_if_needed();
+        if (dfx.capture_clock_anchors) begin_clock_correlation_session_if_needed(pipeline_slot);
         chip_swimlane_collector_.start(thread_factory);
     }
     if (dfx.dump_args_enabled()) {
@@ -1907,7 +1956,9 @@ void DeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx) 
     }
 }
 
-void DeviceRunnerBase::write_host_phase_records_artifact(const std::string &output_prefix) {
+void DeviceRunnerBase::write_host_phase_records_artifact(const std::string &output_prefix, uint32_t pipeline_slot) {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    simpler::dfx::HostPhaseRecordStore &records = host_phase_runs_[pipeline_slot].records;
     // Per-event view of the prepare path. Every phase it records is produced on
     // the host during bind, and the store is finished before launch, so this
     // touches no device state and is callable from any point after bind --
@@ -1916,26 +1967,28 @@ void DeviceRunnerBase::write_host_phase_records_artifact(const std::string &outp
     // artifacts, and on the store having finished a pass, which is what a
     // host-orchestrating runtime leaves behind. The store writes a pass at most
     // once, so every path that can end a run calls this unconditionally.
-    if (!output_prefix.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix));
+    if (!output_prefix.empty() && records.finished()) {
+        (void)records.write_records_jsonl(make_host_phase_records_path(output_prefix));
     }
 }
 
-void DeviceRunnerBase::teardown_shared_collectors_after_run(const DfxRunConfig &dfx, bool device_execution_complete) {
+void DeviceRunnerBase::teardown_shared_collectors_after_run(
+    const DfxRunConfig &dfx, uint32_t pipeline_slot, bool device_execution_complete
+) {
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     // Diagnostic exports use the per-task output prefix the user set on
     // CallConfig (CallConfig::validate() enforces non-empty upstream).
-    finish_clock_correlation_session(device_execution_complete, !can_accept_run());
+    finish_clock_correlation_session(pipeline_slot, device_execution_complete, !can_accept_run());
     if (dfx.chip_swimlane_enabled()) {
         chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
-        publish_host_phase_records_to_swimlane();
+        publish_host_phase_records_to_swimlane(pipeline_slot);
         chip_swimlane_collector_.export_swimlane_json();
     }
 
-    write_host_phase_records_artifact(dfx.output_prefix);
+    write_host_phase_records_artifact(dfx.output_prefix, pipeline_slot);
 
     if (dfx.dump_args_enabled()) {
         dump_collector_.quiesce();

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -66,6 +66,7 @@
 #include "host/chip_swimlane_collector.h"
 #include "host/dfx_run_config.h"
 #include "host/host_phase_records.h"
+#include "host/host_phase_run_state.h"
 #include "host/memory_allocator.h"
 #include "host/pmu_collector.h"
 #include "host/runtime_timeout_config.h"
@@ -756,25 +757,49 @@ public:
         return json_value != nullptr &&
                chip_swimlane_collector_.set_json_extension(section, std::string(json_value, json_size));
     }
-    HostPhaseRecordPool *host_phase_pool_arm(bool producer_wants_records) noexcept;
-    void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
-        host_phase_records_.finish(submitted_tasks, invocation_id);
-    }
-    const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
-    /** Hand this pass's records to the swimlane reader, just before its export. */
-    void publish_host_phase_records_to_swimlane();
-    /** Start the level-4 Host/Device clock correlation once per run. */
-    void begin_clock_correlation_session_if_needed() noexcept;
     /**
-     * Write this pass's per-event host phase records to `output_prefix_`.
+     * Hand one pipeline slot's host-phase state to the run about to bind into
+     * it, from that run's own config. Called before every bind, because the
+     * runner's members describe whichever run last held the execution claim.
+     */
+    void begin_host_phase_run(uint32_t pipeline_slot, const DfxRunConfig &dfx);
+    HostPhaseRecordPool *host_phase_pool_arm(uint32_t pipeline_slot, bool producer_wants_records) noexcept;
+    void host_phase_pool_finish(uint32_t pipeline_slot, uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
+        if (pipeline_slot >= host_phase_runs_.size()) return;
+        host_phase_runs_[pipeline_slot].records.finish(submitted_tasks, invocation_id);
+    }
+    /** Hand this pass's records to the swimlane reader, just before its export. */
+    void publish_host_phase_records_to_swimlane(uint32_t pipeline_slot);
+    /**
+     * Hand this run's captured clock-correlation session to the resident
+     * collector, under the execution claim.
+     *
+     * Its `HostOrchestrationBegin` anchor was sampled during bind, where the
+     * position's meaning lives; this is the first point at which writing the
+     * collector cannot land on a predecessor's session. `set_host_orchestrated`
+     * rides along because the collector's initialize() reads it when it sizes
+     * the orch phase pool, and that now runs from the same launch arming.
+     */
+    void publish_host_phase_run_to_collector(uint32_t pipeline_slot) noexcept;
+    /**
+     * Capture and publish in one step, for the device-orchestrating path that
+     * has no bind-time hook and reaches this already under the claim.
+     */
+    void begin_clock_correlation_session_if_needed(uint32_t pipeline_slot) noexcept;
+    /**
+     * Write this pass's per-event host phase records under `output_prefix`.
      *
      * Host-only: every phase recorded is produced on the host during bind and the
      * store is finished before launch, so a caller that never reaches the device
      * can still produce the artifact. The store writes a pass at most once, so
      * every path that can end a run may call this unconditionally.
      */
-    void write_host_phase_records_artifact(const std::string &output_prefix);
-    void finish_clock_correlation_session(bool capture_device_complete, bool abandon_device_resources) noexcept;
+    void write_host_phase_records_artifact(const std::string &output_prefix, uint32_t pipeline_slot);
+    void finish_clock_correlation_session(
+        uint32_t pipeline_slot, bool capture_device_complete, bool abandon_device_resources
+    ) noexcept;
+    /** Create this run's provider and sample its HostOrchestrationBegin anchors. */
+    void capture_clock_correlation_begin(HostPhaseRunState &run) noexcept;
 
     /**
      * Latch the part of this run's config a device-context query answers from.
@@ -986,7 +1011,7 @@ protected:
      * this helper and then open and start their own. The sim base carries the
      * same split.
      */
-    void start_shared_collectors_for_run(const DfxRunConfig &dfx);
+    void start_shared_collectors_for_run(const DfxRunConfig &dfx, uint32_t pipeline_slot);
 
     /**
      * Tear down the four shared diagnostics collectors after the launched
@@ -1001,7 +1026,9 @@ protected:
      * `dep_gen_replay_emit_deps_json` export) inline their own teardown after
      * calling this helper. The sim base carries the same split.
      */
-    void teardown_shared_collectors_after_run(const DfxRunConfig &dfx, bool device_execution_complete);
+    void teardown_shared_collectors_after_run(
+        const DfxRunConfig &dfx, uint32_t pipeline_slot, bool device_execution_complete
+    );
 
     /**
      * The core and AICPU-thread counts a resident collector's pools were built
@@ -1350,11 +1377,16 @@ protected:
     // on the base. `DepGenCollector` is not shared — each arch that
     // implements dep_gen (a2a3, a5) keeps it on its own subclass.
     ChipSwimlaneCollector chip_swimlane_collector_;
-    // Not a collector: the pool the runtime's prepare path writes into, read by
+    // Not a collector: the state the runtime's bind writes into, read by
     // whichever per-event views the run enabled. Its two readers are gated
-    // independently, so it belongs to neither.
-    simpler::dfx::HostPhaseRecordStore host_phase_records_;
-    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation_provider_{};
+    // independently, so it belongs to neither. One per pipeline slot, because a
+    // bind is preparation and a prepared successor prepares while its
+    // predecessor still owns the collectors — see host_phase_run_state.h.
+    std::array<HostPhaseRunState, PTO_PIPELINE_MAX_DEPTH> host_phase_runs_{};
+    // Which slot's session the resident collector currently holds, or
+    // PTO_PIPELINE_MAX_DEPTH for none. The providers are per slot but the
+    // collector's session is not, so only its opener may end it.
+    uint32_t clock_correlation_session_slot_{PTO_PIPELINE_MAX_DEPTH};
     ArgsDumpCollector dump_collector_;
     PmuCollector pmu_collector_;
     ScopeStatsCollector scope_stats_collector_;

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -229,14 +229,17 @@ static bool publish_chip_swimlane_extension(
                                         ->publish_chip_swimlane_extension(section, json_value, json_size);
 }
 
-static void *host_phase_pool_arm(void *runner_ctx, int producer_wants_records) {
+static void *host_phase_pool_arm(void *runner_ctx, uint32_t pipeline_slot, int producer_wants_records) {
     if (runner_ctx == nullptr) return nullptr;
-    return static_cast<SimDeviceRunnerBase *>(runner_ctx)->host_phase_pool_arm(producer_wants_records != 0);
+    return static_cast<SimDeviceRunnerBase *>(runner_ctx)
+        ->host_phase_pool_arm(pipeline_slot, producer_wants_records != 0);
 }
 
-static void host_phase_pool_finish(void *runner_ctx, uint64_t submitted_tasks, uint64_t invocation_id) {
+static void
+host_phase_pool_finish(void *runner_ctx, uint32_t pipeline_slot, uint64_t submitted_tasks, uint64_t invocation_id) {
     if (runner_ctx == nullptr) return;
-    static_cast<SimDeviceRunnerBase *>(runner_ctx)->host_phase_pool_finish(submitted_tasks, invocation_id);
+    static_cast<SimDeviceRunnerBase *>(runner_ctx)
+        ->host_phase_pool_finish(pipeline_slot, submitted_tasks, invocation_id);
 }
 
 static int setup_static_arena_wrapper(
@@ -670,7 +673,7 @@ static int cleanup_failed_prepare(SimNativeRunContext *state, int execution_rc, 
     const uint64_t trace_hid = state->trace_hid;
     const long long trace_start_ns = state->trace_start_ns;
     if (clear_gm_sm) state->runtime.set_gm_sm_ptr(nullptr);
-    state->runner->finish_clock_correlation_session(false);
+    state->runner->finish_clock_correlation_session(state->descriptor.pipeline_slot, false);
     int validation_rc = PTO_RUNTIME_ERR_INTERNAL;
     try {
         validation_rc = validate_runtime_impl(&state->runtime, &state->host_api, execution_rc);
@@ -749,6 +752,8 @@ int simpler_prepare_run(
         if (rc != 0) return cleanup_failed_prepare(state, rc, true);
 
         runner->apply_call_config(state->config);
+        // This run's host-phase state, before its bind records into it.
+        runner->begin_host_phase_run(state->descriptor.pipeline_slot, DfxRunConfig::from(state->config));
         // Armed from this run's own config on the thread that is about to bind:
         // a host-orchestrating runtime keeps the capture in thread-local state
         // between orchestration and emit. Mirrors the onboard c_api.
@@ -923,7 +928,7 @@ int simpler_finalize_run(DeviceContextHandle ctx, RuntimeHandle runtime) {
 
     // Correlation state is runner-wide. Finish it before releasing the claim,
     // after which a successor may begin capture and replace the provider/session.
-    state->runner->finish_clock_correlation_session(false);
+    state->runner->finish_clock_correlation_session(state->descriptor.pipeline_slot, false);
     if (state->runner_claimed) {
         state->runner->release_native_run(state);
         state->runner_claimed = false;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -760,65 +760,89 @@ void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
     set_output_prefix(config.output_prefix);
 }
 
-HostPhaseRecordPool *SimDeviceRunnerBase::host_phase_pool_arm(bool producer_wants_records) noexcept {
-    if (clock_correlation_provider_ != nullptr) {
-        clock_correlation_provider_->release(false);
-        clock_correlation_provider_.reset();
-    }
-    const bool swimlane_wants_records = chip_swimlane_level_ == ChipSwimlaneLevel::ORCH_PHASES;
-    const bool artifact_wants_records = producer_wants_records && !output_prefix_.empty();
-    chip_swimlane_collector_.set_host_orchestrated(swimlane_wants_records);
+void SimDeviceRunnerBase::begin_host_phase_run(uint32_t pipeline_slot, const DfxRunConfig &dfx) {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    host_phase_runs_[pipeline_slot].begin(dfx);
+}
+
+HostPhaseRecordPool *
+SimDeviceRunnerBase::host_phase_pool_arm(uint32_t pipeline_slot, bool producer_wants_records) noexcept {
+    if (pipeline_slot >= host_phase_runs_.size()) return nullptr;
+    HostPhaseRunState &run = host_phase_runs_[pipeline_slot];
+    run.host_orchestrated = run.chip_swimlane_level == ChipSwimlaneLevel::ORCH_PHASES;
     // arm() allocates the pool's buffers, so it can throw; this path is noexcept,
     // where an escaping exception is std::terminate. A pass that cannot get its
     // storage collects no records and says so by handing back nullptr.
     HostPhaseRecordPool *pool = nullptr;
     try {
-        pool = host_phase_records_.arm(artifact_wants_records || swimlane_wants_records);
+        pool = run.records.arm(run.wants_records(producer_wants_records));
     } catch (...) {
         LOG_WARN("Host phase pool could not be armed; this pass collects no per-event records");
     }
-    if (!swimlane_wants_records) return pool;
+    if (!run.host_orchestrated) return pool;
 
-    begin_clock_correlation_session_if_needed();
+    capture_clock_correlation_begin(run);
     return pool;
 }
 
-void SimDeviceRunnerBase::begin_clock_correlation_session_if_needed() noexcept {
-    if (chip_swimlane_level_ != ChipSwimlaneLevel::ORCH_PHASES || chip_swimlane_collector_.clock_correlation_active()) {
-        return;
-    }
+void SimDeviceRunnerBase::capture_clock_correlation_begin(HostPhaseRunState &run) noexcept {
+    // Sampled in the bind, where HostOrchestrationBegin means what it says; it
+    // reaches the resident collector at launch. Mirrors the onboard base.
+    if (run.clock_correlation != nullptr) return;
     try {
-        clock_correlation_provider_ = simpler::dfx::make_clock_correlation_provider();
-        chip_swimlane_collector_.begin_clock_correlation_session(
-            clock_correlation_provider_->name(), clock_correlation_provider_->raw_device_timestamp_unit()
-        );
-        chip_swimlane_collector_.record_clock_anchor_samples(
-            simpler::dfx::capture_clock_anchor_group(
-                *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
-            )
+        run.clock_correlation = simpler::dfx::make_clock_correlation_provider();
+        run.clock_provider_name = run.clock_correlation->name();
+        run.clock_provider_unit = run.clock_correlation->raw_device_timestamp_unit();
+        run.orchestration_begin_anchors = simpler::dfx::capture_clock_anchor_group(
+            *run.clock_correlation, simpler::dfx::ClockAnchorPosition::HostOrchestrationBegin
         );
     } catch (...) {
-        clock_correlation_provider_.reset();
-        try {
-            chip_swimlane_collector_.begin_clock_correlation_session("unavailable", "unknown");
-        } catch (...) {
-            // begin() stores diagnostic strings and can still fail under
-            // allocation pressure. Keep this noexcept path fail-closed.
-            chip_swimlane_collector_.finish_clock_correlation_session();
-        }
+        run.clock_correlation.reset();
+        run.orchestration_begin_anchors.clear();
+        run.clock_provider_name = "unavailable";
+        run.clock_provider_unit = "unknown";
     }
 }
 
-void SimDeviceRunnerBase::publish_host_phase_records_to_swimlane() {
-    if (!host_phase_records_.finished()) return;
+void SimDeviceRunnerBase::publish_host_phase_run_to_collector(uint32_t pipeline_slot) noexcept {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    HostPhaseRunState &run = host_phase_runs_[pipeline_slot];
+    chip_swimlane_collector_.set_host_orchestrated(run.host_orchestrated);
+    if (!run.host_orchestrated || chip_swimlane_collector_.clock_correlation_active()) return;
+    try {
+        chip_swimlane_collector_.begin_clock_correlation_session(
+            run.clock_provider_name.c_str(), run.clock_provider_unit.c_str()
+        );
+        if (!run.orchestration_begin_anchors.empty()) {
+            chip_swimlane_collector_.record_clock_anchor_samples(run.orchestration_begin_anchors);
+        }
+        clock_correlation_session_slot_ = pipeline_slot;
+    } catch (...) {
+        chip_swimlane_collector_.finish_clock_correlation_session();
+    }
+}
+
+void SimDeviceRunnerBase::begin_clock_correlation_session_if_needed(uint32_t pipeline_slot) noexcept {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    HostPhaseRunState &run = host_phase_runs_[pipeline_slot];
+    if (run.chip_swimlane_level != ChipSwimlaneLevel::ORCH_PHASES) return;
+    // No bind-time capture on this path, so both halves run here.
+    run.host_orchestrated = true;
+    capture_clock_correlation_begin(run);
+    publish_host_phase_run_to_collector(pipeline_slot);
+}
+
+void SimDeviceRunnerBase::publish_host_phase_records_to_swimlane(uint32_t pipeline_slot) {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    const simpler::dfx::HostPhaseRecordStore &records = host_phase_runs_[pipeline_slot].records;
+    if (!records.finished()) return;
     chip_swimlane_collector_.set_host_phase_records(
-        host_phase_records_.submit_records(), host_phase_records_.device_upload_records(),
-        host_phase_records_.submitted_tasks(), host_phase_records_.total_records(),
-        host_phase_records_.dropped_records()
+        records.submit_records(), records.device_upload_records(), records.submitted_tasks(), records.total_records(),
+        records.dropped_records()
     );
 }
 
-void SimDeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx) {
+void SimDeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &dfx, uint32_t pipeline_slot) {
     // Opening a resident collector's window drops the previous run's records and
     // republishes the device level, so it belongs with the start, at launch.
     auto thread_factory = [this](std::function<void()> fn) {
@@ -826,7 +850,7 @@ void SimDeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &df
     };
     if (dfx.chip_swimlane_enabled()) {
         chip_swimlane_collector_.begin_run(dfx.output_prefix, dfx.chip_swimlane_level);
-        if (dfx.capture_clock_anchors) begin_clock_correlation_session_if_needed();
+        if (dfx.capture_clock_anchors) begin_clock_correlation_session_if_needed(pipeline_slot);
         chip_swimlane_collector_.start(thread_factory);
     }
     if (dfx.dump_args_enabled()) {
@@ -843,19 +867,21 @@ void SimDeviceRunnerBase::start_shared_collectors_for_run(const DfxRunConfig &df
     }
 }
 
-void SimDeviceRunnerBase::write_host_phase_records_artifact(const std::string &output_prefix) {
+void SimDeviceRunnerBase::write_host_phase_records_artifact(const std::string &output_prefix, uint32_t pipeline_slot) {
+    if (pipeline_slot >= host_phase_runs_.size()) return;
+    simpler::dfx::HostPhaseRecordStore &records = host_phase_runs_[pipeline_slot].records;
     // Every phase this records is produced on the host during bind and the store
     // is finished before launch, so it touches no device state and is callable
     // from any point after bind — including a path that never launched. The run's
     // output prefix is non-empty exactly when it produces diagnostic artifacts,
     // and the store writes a pass at most once.
-    if (!output_prefix.empty() && host_phase_records_.finished()) {
-        (void)host_phase_records_.write_records_jsonl(make_host_phase_records_path(output_prefix));
+    if (!output_prefix.empty() && records.finished()) {
+        (void)records.write_records_jsonl(make_host_phase_records_path(output_prefix));
     }
 }
 
 void SimDeviceRunnerBase::teardown_shared_collectors_after_run(
-    const DfxRunConfig &dfx, bool device_execution_complete
+    const DfxRunConfig &dfx, uint32_t pipeline_slot, bool device_execution_complete
 ) {
     // The order is fixed by three couplings, not by preference: the clock
     // correlation session closes before the swimlane export reads it, the host
@@ -863,17 +889,17 @@ void SimDeviceRunnerBase::teardown_shared_collectors_after_run(
     // and each collector drains before it reconciles before it exports.
     // Diagnostic exports use the per-task output prefix the user set on
     // CallConfig (CallConfig::validate() enforces non-empty upstream).
-    finish_clock_correlation_session(device_execution_complete);
+    finish_clock_correlation_session(pipeline_slot, device_execution_complete);
     if (dfx.chip_swimlane_enabled()) {
         chip_swimlane_collector_.quiesce();
         chip_swimlane_collector_.read_phase_header_metadata();
         chip_swimlane_collector_.reconcile_counters();
-        publish_host_phase_records_to_swimlane();
+        publish_host_phase_records_to_swimlane(pipeline_slot);
         publish_chip_swimlane_runtime_extensions();
         chip_swimlane_collector_.export_swimlane_json();
     }
 
-    write_host_phase_records_artifact(dfx.output_prefix);
+    write_host_phase_records_artifact(dfx.output_prefix, pipeline_slot);
 
     if (dfx.dump_args_enabled()) {
         dump_collector_.quiesce();
@@ -893,24 +919,37 @@ void SimDeviceRunnerBase::teardown_shared_collectors_after_run(
     }
 }
 
-void SimDeviceRunnerBase::finish_clock_correlation_session(bool capture_device_complete) noexcept {
-    if (!chip_swimlane_collector_.clock_correlation_active()) {
-        if (clock_correlation_provider_ != nullptr) clock_correlation_provider_->release(false);
-        clock_correlation_provider_.reset();
+void SimDeviceRunnerBase::finish_clock_correlation_session(
+    uint32_t pipeline_slot, bool capture_device_complete
+) noexcept {
+    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> *provider = nullptr;
+    if (pipeline_slot < host_phase_runs_.size()) {
+        provider = &host_phase_runs_[pipeline_slot].clock_correlation;
+    }
+    auto release_provider = [&]() {
+        if (provider != nullptr && *provider != nullptr) {
+            (*provider)->release(false);
+            provider->reset();
+        }
+    };
+    // Only the slot that opened the collector's session may end it; see the
+    // onboard base for the interleaving that makes this load-bearing there.
+    if (!chip_swimlane_collector_.clock_correlation_active() || clock_correlation_session_slot_ != pipeline_slot) {
+        release_provider();
         return;
     }
-    if (capture_device_complete && clock_correlation_provider_ != nullptr) {
+    if (capture_device_complete && provider != nullptr && *provider != nullptr) {
         try {
             chip_swimlane_collector_.record_clock_anchor_samples(
                 simpler::dfx::capture_clock_anchor_group(
-                    *clock_correlation_provider_, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
+                    **provider, simpler::dfx::ClockAnchorPosition::DeviceExecutionComplete
                 )
             );
         } catch (...) {}
     }
     chip_swimlane_collector_.finish_clock_correlation_session();
-    if (clock_correlation_provider_ != nullptr) clock_correlation_provider_->release(false);
-    clock_correlation_provider_.reset();
+    clock_correlation_session_slot_ = PTO_PIPELINE_MAX_DEPTH;
+    release_provider();
 }
 
 uint64_t SimDeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *callable) {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -59,6 +59,7 @@
 #include "host/chip_swimlane_collector.h"
 #include "host/dfx_run_config.h"
 #include "host/host_phase_records.h"
+#include "host/host_phase_run_state.h"
 #include "host/args_dump_collector.h"
 #include "host/pmu_collector.h"
 #include "host/scope_stats_collector.h"
@@ -300,13 +301,19 @@ public:
         return json_value != nullptr &&
                chip_swimlane_collector_.set_json_extension(section, std::string(json_value, json_size));
     }
-    HostPhaseRecordPool *host_phase_pool_arm(bool producer_wants_records) noexcept;
-    void host_phase_pool_finish(uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
-        host_phase_records_.finish(submitted_tasks, invocation_id);
+    /** Hand one slot's host-phase state to the run about to bind into it. */
+    void begin_host_phase_run(uint32_t pipeline_slot, const DfxRunConfig &dfx);
+    HostPhaseRecordPool *host_phase_pool_arm(uint32_t pipeline_slot, bool producer_wants_records) noexcept;
+    void host_phase_pool_finish(uint32_t pipeline_slot, uint64_t submitted_tasks, uint64_t invocation_id) noexcept {
+        if (pipeline_slot >= host_phase_runs_.size()) return;
+        host_phase_runs_[pipeline_slot].records.finish(submitted_tasks, invocation_id);
     }
-    const simpler::dfx::HostPhaseRecordStore &host_phase_records() const { return host_phase_records_; }
+    /** Hand this run's captured clock session to the resident collector, at launch. */
+    void publish_host_phase_run_to_collector(uint32_t pipeline_slot) noexcept;
+    /** Create this run's provider and sample its HostOrchestrationBegin anchors. */
+    void capture_clock_correlation_begin(HostPhaseRunState &run) noexcept;
     /** Hand this pass's records to the swimlane reader, just before its export. */
-    void publish_host_phase_records_to_swimlane();
+    void publish_host_phase_records_to_swimlane(uint32_t pipeline_slot);
     /**
      * Publish arch-specific runtime metadata into the swimlane export, between
      * the host-phase handoff and the export itself — the only point at which the
@@ -323,9 +330,9 @@ public:
      * with arch-specific collectors (`dep_gen_collector_`) call this and then
      * open and start their own.
      */
-    void start_shared_collectors_for_run(const DfxRunConfig &dfx);
+    void start_shared_collectors_for_run(const DfxRunConfig &dfx, uint32_t pipeline_slot);
     /** Write this pass's per-event host phase records, if it collected any. */
-    void write_host_phase_records_artifact(const std::string &output_prefix);
+    void write_host_phase_records_artifact(const std::string &output_prefix, uint32_t pipeline_slot);
     /**
      * Tear down the four shared diagnostics collectors after the launched
      * kernels have synced, in the one order their couplings allow: the clock
@@ -337,10 +344,12 @@ public:
      * `dep_gen_replay_emit_deps_json` export) inline their own teardown after
      * calling this helper, as on onboard.
      */
-    void teardown_shared_collectors_after_run(const DfxRunConfig &dfx, bool device_execution_complete);
+    void teardown_shared_collectors_after_run(
+        const DfxRunConfig &dfx, uint32_t pipeline_slot, bool device_execution_complete
+    );
     /** Start the level-4 Host/Device clock correlation once per run. */
-    void begin_clock_correlation_session_if_needed() noexcept;
-    void finish_clock_correlation_session(bool capture_device_complete) noexcept;
+    void begin_clock_correlation_session_if_needed(uint32_t pipeline_slot) noexcept;
+    void finish_clock_correlation_session(uint32_t pipeline_slot, bool capture_device_complete) noexcept;
     // Diagnostic artifact root directory (CallConfig::validate() enforces non-empty
     // upstream when any diagnostic is enabled).
     void set_output_prefix(const char *prefix) { output_prefix_ = (prefix != nullptr) ? prefix : ""; }
@@ -553,8 +562,11 @@ protected:
     // Not a collector: the pool the runtime's prepare path writes into, read by
     // whichever per-event views the run enabled. Its two readers are gated
     // independently, so it belongs to neither.
-    simpler::dfx::HostPhaseRecordStore host_phase_records_;
-    std::unique_ptr<simpler::dfx::ClockCorrelationProvider> clock_correlation_provider_{};
+    // One per pipeline slot: a bind is preparation, and a prepared successor
+    // binds while its predecessor still owns the collectors.
+    std::array<HostPhaseRunState, PTO_PIPELINE_MAX_DEPTH> host_phase_runs_{};
+    // Which slot's session the resident collector holds; see the onboard base.
+    uint32_t clock_correlation_session_slot_{PTO_PIPELINE_MAX_DEPTH};
     ArgsDumpCollector dump_collector_;
     PmuCollector pmu_collector_;
     ScopeStatsCollector scope_stats_collector_;

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -130,20 +130,6 @@ struct CallConfig {
                enable_scope_stats != 0;
     }
 
-    /**
-     * Whether this run captures host-orchestration phase state, which a
-     * host-orchestrating runtime arms during its bind.
-     *
-     * Level 4 is the one that opens a clock-correlation session on the resident
-     * swimlane collector and samples its `HostOrchestrationBegin` anchor there,
-     * both from inside bind — i.e. from inside preparation, which a prepared
-     * successor performs while its predecessor is still executing. That state is
-     * not per-run, so such a run neither carries a prepared successor nor is one.
-     * The literal is `ChipSwimlaneLevel::ORCH_PHASES`, which this header cannot
-     * include without pulling the profiling headers into the task-interface ABI.
-     */
-    bool captures_host_orchestration_phases() const noexcept { return enable_chip_swimlane == 4; }
-
     bool output_prefix_set() const noexcept { return output_prefix[0] != '\0'; }
 
     // Throws if any diagnostic flag is enabled but `output_prefix` is empty,

--- a/src/common/worker/chip_run_lane.cpp
+++ b/src/common/worker/chip_run_lane.cpp
@@ -77,22 +77,12 @@ struct ChipRunLaneState {
      * pools and per-run state a preparation would otherwise have armed are built
      * and reset under the execution claim.
      *
-     * Level-4 chip swimlane is the exception, and it excludes a run from both
-     * roles. A host-orchestrating runtime opens a clock-correlation session on
-     * the resident swimlane collector, and samples its HostOrchestrationBegin
-     * anchor into it, from inside bind — so a successor preparing at that level
-     * would overwrite the session a predecessor is still running under, and a
-     * successor preparing behind such a predecessor would destroy it.
+     * The successor's own configuration does not enter, at any level: a bind's
+     * host-orchestration phase state is held per pipeline slot, and everything
+     * it hands to the resident collector is published under this claim.
      */
-    bool permits_native_successor(const ChipRunState &predecessor, const CallConfig &successor_config) const {
-        return worker->supports_concurrent_native_prepare() &&
-               !predecessor.config.captures_host_orchestration_phases() &&
-               !successor_config.captures_host_orchestration_phases() &&
-               predecessor.phase == ChipRunState::Phase::LAUNCHED;
-    }
-
-    bool permits_native_successor(const ChipRunState &predecessor, const ChipRunState &successor) const {
-        return permits_native_successor(predecessor, successor.config);
+    bool permits_native_successor(const ChipRunState &predecessor) const {
+        return worker->supports_concurrent_native_prepare() && predecessor.phase == ChipRunState::Phase::LAUNCHED;
     }
 
     void prepare(const std::shared_ptr<ChipRunState> &run) {
@@ -168,7 +158,7 @@ struct ChipRunLaneState {
     void prepare_successor_if_eligible(const std::shared_ptr<ChipRunState> &run) {
         if (fifo.size() != 2 || fifo.back() != run || fifo.front() == run) return;
         if (run->phase != ChipRunState::Phase::QUEUED || run->depth_one_fallback) return;
-        if (!permits_native_successor(*fifo.front(), *run)) return;
+        if (!permits_native_successor(*fifo.front())) return;
         try {
             prepare(run);
         } catch (const ChipWorker::PreparedRunIncompatible &) {
@@ -451,7 +441,7 @@ ChipRun ChipRunLane::submit(
     // minted or native preparation begins.
     while (!state_->fifo.empty()) {
         const bool has_successor_capacity =
-            state_->fifo.size() == 1 && state_->permits_native_successor(*state_->fifo.front(), config);
+            state_->fifo.size() == 1 && state_->permits_native_successor(*state_->fifo.front());
         if (has_successor_capacity) break;
         state_->drain_front();
         state_->require_usable();

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -657,8 +657,7 @@ ChipWorkerNativeRun ChipWorker::prepare_native_run_on_slot(
     }
     const uint64_t run_epoch = next_native_run_epoch();
     const ChipWorkerNativeRun run_identity{slot_id, generation, run_epoch, run_id, dispatch_id};
-    const bool allow_prepared_successor =
-        supports_concurrent_native_prepare() && !config.captures_host_orchestration_phases();
+    const bool allow_prepared_successor = supports_concurrent_native_prepare();
     {
         std::lock_guard<std::mutex> lk(native_run_mu_);
         NativeRunSlotState &state = native_run_states_[slot_id];

--- a/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
+++ b/tests/st/a2a3/host_build_graph/concurrent_prepare_stress/test_concurrent_prepare_stress.py
@@ -36,19 +36,18 @@ positive one in exactly one variable:
   A collector's pools and per-run state are built and reset under the execution
   claim, so a diagnostic flag no longer keeps a run and its successor on
   separate device windows.
-* ``inflight_limit=2`` at chip-swimlane level 4 — *rejected*, and the one
-  diagnostics config that still serializes. Its bind opens a clock-correlation
-  session on the resident swimlane collector and samples an anchor into it,
-  which is not per-run and cannot move under the claim without losing its
-  meaning.
+* ``inflight_limit=2`` at chip-swimlane level 4 — overlap is required here too.
+  Its bind records host-orchestration phase state, which cannot move under the
+  claim without losing its meaning, so it is held per pipeline slot and
+  published to the resident collector at launch.
 
-The last two are what hold that boundary in place. It is invisible from goldens:
-the lane declines to stage silently rather than raising, so a run that lost its
-overlap, or one that kept an overlap it should not have, looks identical from
-outside.
+The last two are what hold that open. It is invisible from goldens: the lane
+declines to stage silently rather than raising, so a run that lost its overlap
+looks identical from outside.
 """
 
 import contextlib
+import pathlib
 import tempfile
 
 import pytest
@@ -190,7 +189,7 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         # Distinct per-iteration data → a corrupted/aliased bank fails this.
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
-    def _drive_pipeline(self, chip_worker, callable_id, orch_sig, config, iters, inflight_limit):
+    def _drive_pipeline(self, chip_worker, callable_id, orch_sig, config, iters, inflight_limit, config_for=None):
         """Submit ``iters`` runs, never letting more than ``inflight_limit`` coexist.
 
         The direct-chip lane is the sole admission authority and follows the
@@ -201,10 +200,15 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         against the other bank, i.e. the overlaps_active_run path. At
         ``inflight_limit=1`` every run reaches terminal before the next is
         submitted, so no bind can coexist with a device window.
+
+        ``config_for`` gives each iteration its own config, which is what lets a
+        caller send every run's artifacts to a different directory and so read
+        back what each one produced rather than only the last.
         """
         inflight = []
         for iteration in range(iters):
-            inflight.append(self._submit_iteration(chip_worker, callable_id, orch_sig, config, iteration))
+            run_config = config_for(iteration) if config_for is not None else config
+            inflight.append(self._submit_iteration(chip_worker, callable_id, orch_sig, run_config, iteration))
             if len(inflight) >= inflight_limit:
                 self._retire(inflight.pop(0))
         while inflight:
@@ -308,24 +312,27 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
 
         assert_native_overlap(parse_spans(captured.splitlines()))
 
-    def test_orch_phase_swimlane_serializes_the_native_lane(self, st_platform, st_worker, capfd, drain_host_log):
-        """Level-4 swimlane is the one diagnostics config that still serializes.
+    def test_orch_phase_swimlane_overlaps_the_native_lane(self, st_platform, st_worker, capfd, drain_host_log):
+        """Level-4 swimlane overlaps too, now that its phase state is per-run.
 
-        A host-orchestrating runtime opens a clock-correlation session on the
-        *resident* swimlane collector, and samples its ``HostOrchestrationBegin``
-        anchor into it, from inside bind — that is, from inside preparation,
-        which a prepared successor performs while its predecessor is still
-        executing. Unlike the collector pools, that state cannot move under the
-        execution claim: the anchor's whole meaning is when host orchestration
-        began. Until it is per-run, a level-4 run neither carries a prepared
-        successor nor is one, and the verdict must be *rejected*.
+        A host-orchestrating bind records phase events and samples a
+        ``HostOrchestrationBegin`` clock anchor, and neither can move under the
+        execution claim: the records describe the bind, and the anchor means the
+        instant host orchestration began. They are held per pipeline slot
+        instead, and everything destined for the resident swimlane collector is
+        published from the launch arming — so a successor's bind writes its own
+        state rather than resetting the predecessor's.
 
-        This is the arm that would go quiet if the exclusion were dropped without
-        making the session per-run: the lane declines to stage rather than
-        raising, so the runs would still succeed and their goldens still pass
-        while the predecessor's clock anchors were destroyed by the successor's
-        bind. It retires when that state becomes per-run, and then it flips to
-        the same `assert_native_overlap` its sibling arm above already makes.
+        This arm previously required the opposite verdict, which is what made
+        the exclusion visible while it existed.
+
+        Overlap alone would not detect a regression here: collapsing the state
+        back to one store still overlaps, it just loses a run's records. So the
+        arm also gives every iteration its own output directory and requires
+        each one's swimlane artifact to carry ``orchestrator_source: host``.
+        That marker is written only when the run's own host-phase records
+        reached the collector, so a predecessor whose store a successor's bind
+        reset produces an artifact without it.
         """
         if st_platform != "a2a3":
             pytest.skip("concurrent native prepare / two-bank pipeline is an a2a3 onboard path")
@@ -335,14 +342,31 @@ class TestConcurrentPrepareStressHbg(SceneTestCase):
         chip_worker = self._chip_worker(st_worker)
         callable_id = _ARM_CALLABLE_ID
 
-        with tempfile.TemporaryDirectory(prefix="simpler-orch-phase-lane-") as output_dir:
-            # 4 is ChipSwimlaneLevel::ORCH_PHASES, the only level whose bind arms
-            # host-orchestration phase state on the resident collector.
-            config = self._build_config({}, enable_chip_swimlane=4, output_prefix=output_dir)
+        with tempfile.TemporaryDirectory(prefix="simpler-orch-phase-lane-") as output_root:
+            root = pathlib.Path(output_root)
+            run_dirs = [root / f"run{i}" for i in range(_CONTROL_ITERS)]
+            for run_dir in run_dirs:
+                run_dir.mkdir()
+
+            # 4 is ChipSwimlaneLevel::ORCH_PHASES, the only level whose bind
+            # records host-orchestration phase state at all.
+            def config_for(iteration):
+                return self._build_config({}, enable_chip_swimlane=4, output_prefix=str(run_dirs[iteration]))
+
             with self._registered_callable(chip_worker, callable_id, callable_obj):
                 drain_host_log(capfd)
-                self._drive_pipeline(chip_worker, callable_id, orch_sig, config, _CONTROL_ITERS, inflight_limit=2)
+                self._drive_pipeline(
+                    chip_worker, callable_id, orch_sig, None, _CONTROL_ITERS, inflight_limit=2, config_for=config_for
+                )
                 captured = drain_host_log(capfd)
 
-        with pytest.raises(NativeOverlapError, match="did not overlap"):
-            assert_native_overlap(parse_spans(captured.splitlines()))
+            for iteration, run_dir in enumerate(run_dirs):
+                artifact = run_dir / "chip_swimlane_records.json"
+                assert artifact.exists(), f"run {iteration}: {artifact} missing"
+                assert '"orchestrator_source": "host"' in artifact.read_text(), (
+                    f"run {iteration}: its host-orchestration phase records never reached the collector. "
+                    f"A successor's bind reset the store this run was still waiting to publish, which is "
+                    f"what per-pipeline-slot host-phase state exists to prevent."
+                )
+
+        assert_native_overlap(parse_spans(captured.splitlines()))


### PR DESCRIPTION
## Summary

The host-phase record store and the clock-correlation provider were **one per runner**, but their lifetime is **one per run**: armed during a host-orchestrating bind, read at that run's teardown. A bind is preparation, and a prepared successor prepares while its predecessor is still executing — so the successor's bind reset the store its predecessor had finished and was waiting to publish, and released the provider whose session that predecessor was still running under.

Closes #2203. Removes the exclusion #2201 put in place instead of fixing it.

## Why this could not follow #2163 / #2200

Those moved collector state under the execution claim. This cannot: the records **describe** the bind, and the `HostOrchestrationBegin` anchor means *the instant host orchestration began*. Deferring either to launch would record something else.

So the state is held per slot, and what reaches the resident collector is split from what is sampled:

| | |
| --- | --- |
| `begin_host_phase_run()` | stamps the run's own level + prefix into its slot **before its bind** — the runner's members describe whichever run last held the claim |
| `host_phase_pool_arm()`, `capture_clock_correlation_begin()` | write only that slot. **No collector writes during bind at all** |
| `publish_host_phase_run_to_collector()` | hands the session, the anchors and `set_host_orchestrated` to the collector **from the launch arming**, ahead of the collector `initialize()` that reads the last of them |

## The plumbing was already there

The two `HostApiOps` host-phase hooks take a `uint32_t pipeline_slot`, matching the **five sibling hooks that already do**. Nothing new was needed to supply it: `HostApi` is already constructed per run and already carries `pipeline_slot_`, and the teardown readers have it on `PreparedExecution`.

`HostPhaseRecordStore` deletes copy and move on purpose — `pool_` holds raw pointers into `buffers_` — so the array holds it in place rather than moving it onto `PreparedExecution`.

With that, the exclusion and its scaffolding go: `captures_host_orchestration_phases()`, its four gate sites, the weak `host_phase_records_enabled()` read, and the `static_assert` pinning the level literal. **Any diagnostics configuration now overlaps its predecessor.**

## The test needed more than the flip

The scene test's level-4 arm was written for this moment and flips from requiring `did not overlap` to requiring the overlap.

**That alone would not have detected a regression.** I checked: collapsing the state back to one store still overlaps — it just loses a run's records, and the overlap assertion is about span timing. So the arm now also gives each iteration its own output directory and requires every one to carry `orchestrator_source: host` in its swimlane artifact. That marker is written only when a run's own host-phase records reached the collector.

## Testing

Negative control on **a2a3 onboard**, indexing the array at `0` instead of the run's slot:

| assertion | result |
| --- | --- |
| overlap | still green — which is why it is not sufficient on its own |
| per-run artifact | **fails**: `run 0: its host-orchestration phase records never reached the collector` |

The whole a2a3 onboard `host_build_graph` suite is green in the per-PR CI shape.

Also green: 12 DFX channel runs over both sim platforms; full sim sweeps (**39** and **35** cases); pyut **2242 passed / 7 skipped**; cpput **140/140** from a cleared build dir.

Related: #2078, #2201, #2203, #2162