### PR TITLE
Fix: export a failed run's diagnostics instead of dropping them

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -646,6 +646,7 @@ int DeviceRunner::reap_run(const DfxRunConfig &dfx, uint32_t pipeline_slot) {
         // idempotent, so this runs only on the error return; the success path
         // still exports exactly once below.
         teardown_shared_collectors_after_run(dfx, pipeline_slot, false);
+        emit_device_dep_gen_graph(dfx);
         return rc;
     }
 
@@ -654,24 +655,26 @@ int DeviceRunner::reap_run(const DfxRunConfig &dfx, uint32_t pipeline_slot) {
     // Tear down collectors. stop() joins mgmt then collector in the only safe
     // order (mgmt's final-drain pass into L2 has poll as its consumer).
     teardown_shared_collectors_after_run(dfx, pipeline_slot, true);
-
-    // a2a3-only dep_gen teardown, device-orch shape: the collector stops, the
-    // ring reconciles, and the records replay. The host-orch shape emits at the
-    // end of bind instead, where its capture window closes — see
-    // `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
-        dep_gen_collector_.quiesce();
-        if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(dfx.output_prefix);
-            const auto &records = dep_gen_collector_.records();
-            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-            if (rc != 0) {
-                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
-            }
-        }
-    }
+    emit_device_dep_gen_graph(dfx);
 
     return 0;
+}
+
+void DeviceRunner::emit_device_dep_gen_graph(const DfxRunConfig &dfx) {
+    // The host-orch shape emits at the end of bind instead, where its capture
+    // window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (!dfx.dep_gen_enabled || dep_gen_host_graph_active()) return;
+    dep_gen_collector_.quiesce();
+    // reconcile_counters() is the completeness gate: an un-flushed device buffer
+    // or a dropped record makes it false and no deps.json is written, so a run
+    // that failed mid-flight yields a whole graph or none — never a partial one.
+    if (!dep_gen_collector_.reconcile_counters()) return;
+    const std::string deps = make_deps_json_path(dfx.output_prefix);
+    const auto &records = dep_gen_collector_.records();
+    int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+    if (rc != 0) {
+        LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
+    }
 }
 
 // `print_handshake_results`, `prepare_orch_so`, `register_callable`,

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -247,17 +247,21 @@ private:
     int retire_run_aicore_stream(const void *owner, RunStreamPair::CompletionStatus completion_status);
     int destroy_run_streams();
 
-    // Release execution-owned resources in collector, runtime-argument,
-    // register-buffer, then stream order. The collectors this releases were
-    // initialized by prepare_execution() for this run alone; an overlapping
-    // predecessor cannot own any, because a prepared successor is admitted only
-    // when both runs declare no diagnostics.
+    // Release the resources this run owns, in runtime-argument, register-buffer,
+    // then stream order. Collectors are not among them: their device resources
+    // belong to the worker's lifetime and are released in finalize().
     void cleanup_execution(PreparedExecution &prepared, bool retire_aicore) noexcept;
 
     // The kernel submission boundary is separate from the stream wait and
     // post-run teardown: launch_run() submits and drain_execution() reaps.
     LaunchTransactionResult launch_run(PreparedExecution &prepared, LaunchPermit permit);
     int reap_run(const DfxRunConfig &dfx, uint32_t pipeline_slot);
+
+    // Emit the device-orchestration dep_gen graph, on both the success and the
+    // error return of reap_run: the device flushes its dep_gen buffers during
+    // emergency_shutdown, so a failed run's graph is recoverable. Its own
+    // reconcile is the completeness gate — see the definition.
+    void emit_device_dep_gen_graph(const DfxRunConfig &dfx);
 
     // On an AICore launch/sync error, best-effort drain the device so a later
     // enqueue on the same DeviceRunner can recover in place; if the drain itself

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -629,26 +629,18 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
-        finish_clock_correlation_session(active.prepared->pipeline_slot, false);
+        // The AICPU threads are joined above, so every collector's producer has
+        // stopped and its records are as complete as the run made them. Export
+        // them: a failed run is the one whose swimlane, dumped tensors and
+        // dep_gen graph are worth reading. `false` withholds only the
+        // DeviceExecutionComplete clock anchor, which this run never reached.
+        teardown_shared_collectors_after_run(dfx, active.prepared->pipeline_slot, false);
+        emit_device_dep_gen_graph(dfx);
         return runtime_rc;
     }
 
     teardown_shared_collectors_after_run(dfx, active.prepared->pipeline_slot, true);
-
-    // Device-orch shape: the collector stops, the ring reconciles, and the
-    // records replay. The host-orch shape emits at the end of bind instead, where
-    // its capture window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
-        dep_gen_collector_.quiesce();
-        if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(dfx.output_prefix);
-            const auto &records = dep_gen_collector_.records();
-            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-            if (rc != 0) {
-                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
-            }
-        }
-    }
+    emit_device_dep_gen_graph(dfx);
 
     print_handshake_results();
 
@@ -666,6 +658,23 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     }
 
     return 0;
+}
+
+void DeviceRunner::emit_device_dep_gen_graph(const DfxRunConfig &dfx) {
+    // The host-orch shape emits at the end of bind instead, where its capture
+    // window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (!dfx.dep_gen_enabled || dep_gen_host_graph_active()) return;
+    dep_gen_collector_.quiesce();
+    // reconcile_counters() is the completeness gate: an un-flushed device buffer
+    // or a dropped record makes it false and no deps.json is written, so a run
+    // that failed mid-flight yields a whole graph or none — never a partial one.
+    if (!dep_gen_collector_.reconcile_counters()) return;
+    const std::string deps = make_deps_json_path(dfx.output_prefix);
+    const auto &records = dep_gen_collector_.records();
+    int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+    if (rc != 0) {
+        LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
+    }
 }
 
 void DeviceRunner::abandon_prepared_execution(PreparedExecution &) noexcept {

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -70,6 +70,12 @@ private:
     int init_dep_gen(int num_threads, int device_id);
     int init_scope_stats(int num_threads);
 
+    // Emit the device-orchestration dep_gen graph, on both the success and the
+    // error return of drain_execution: the AICPU threads are joined before
+    // either, so a failed run's records are as complete as the run made them.
+    // Its own reconcile is the completeness gate — see the definition.
+    void emit_device_dep_gen_graph(const DfxRunConfig &dfx);
+
     // Per-run collector teardown: releases shared memory back to mem_alloc_.
     // Idempotent. Mirrors the onboard helper.
     void finalize_collectors();

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -577,6 +577,7 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
             LOG_WARN("Runtime chip-swimlane extension publication failed");
         }
         teardown_shared_collectors_after_run(prepared.dfx, prepared.pipeline_slot, false);
+        emit_device_dep_gen_graph(prepared.dfx);
         return rc;
     }
 
@@ -585,26 +586,28 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
         LOG_WARN("Runtime chip-swimlane extension publication failed");
     }
     teardown_shared_collectors_after_run(prepared.dfx, prepared.pipeline_slot, true);
-
-    // a5-specific dep_gen teardown, device-orch shape: the collector stops, the
-    // ring reconciles, and the records replay. The host-orch shape emits at the
-    // end of bind instead, where its capture window closes — see
-    // `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (prepared.dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
-        dep_gen_collector_.quiesce();
-        if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(prepared.dfx.output_prefix);
-            const auto &records = dep_gen_collector_.records();
-            int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-            if (replay_rc != 0) {
-                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
-            }
-        }
-    }
+    emit_device_dep_gen_graph(prepared.dfx);
 
     // Reads device memory, so it must precede KernelArgs/runtime cleanup.
     print_handshake_results(prepared.kernel_args);
     return 0;
+}
+
+void DeviceRunner::emit_device_dep_gen_graph(const DfxRunConfig &dfx) {
+    // The host-orch shape emits at the end of bind instead, where its capture
+    // window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (!dfx.dep_gen_enabled || dep_gen_host_graph_active()) return;
+    dep_gen_collector_.quiesce();
+    // reconcile_counters() is the completeness gate: an un-flushed device buffer
+    // or a dropped record makes it false and no deps.json is written, so a run
+    // that failed mid-flight yields a whole graph or none — never a partial one.
+    if (!dep_gen_collector_.reconcile_counters()) return;
+    const std::string deps = make_deps_json_path(dfx.output_prefix);
+    const auto &records = dep_gen_collector_.records();
+    int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+    if (replay_rc != 0) {
+        LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
+    }
 }
 
 void DeviceRunner::cleanup_execution(PreparedExecution &prepared, bool launched) noexcept {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -217,9 +217,9 @@ private:
 
     // Release execution-owned per-run resources. Idempotent so prepare rollback
     // and drain share one path. `launched` publishes the sticky terminal poll
-    // state, which only a run that reached the streams may claim; the collectors
-    // are released either way, since prepare_execution() initialized them for
-    // this run alone.
+    // state, which only a run that reached the streams may claim. Collectors are
+    // not released here: their device resources belong to the worker's lifetime
+    // and are released in finalize().
     void cleanup_execution(PreparedExecution &prepared, bool launched) noexcept;
 
     // On an AICore launch/sync error, best-effort drain the device so a later
@@ -315,6 +315,12 @@ private:
      * kernel_args.dep_gen_data_base.
      */
     int init_dep_gen(int num_threads, int device_id, KernelArgsHelper &kernel_args);
+
+    // Emit the device-orchestration dep_gen graph, on both the success and the
+    // error return of drain_execution: the device flushes its dep_gen buffers
+    // during emergency_shutdown, so a failed run's graph is recoverable. Its own
+    // reconcile is the completeness gate — see the definition.
+    void emit_device_dep_gen_graph(const DfxRunConfig &dfx);
 
     // Per-run collector teardown: stops mgmt + poll threads on every collector
     // whose init succeeded, in the only safe order (stop() joins mgmt before

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -609,26 +609,18 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     int runtime_rc = run_completion_.first_error();
     if (runtime_rc != 0) {
         LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
-        finish_clock_correlation_session(active.prepared->pipeline_slot, false);
+        // The AICPU threads are joined above, so every collector's producer has
+        // stopped and its records are as complete as the run made them. Export
+        // them: a failed run is the one whose swimlane, dumped tensors and
+        // dep_gen graph are worth reading. `false` withholds only the
+        // DeviceExecutionComplete clock anchor, which this run never reached.
+        teardown_shared_collectors_after_run(dfx, active.prepared->pipeline_slot, false);
+        emit_device_dep_gen_graph(dfx);
         return runtime_rc;
     }
 
     teardown_shared_collectors_after_run(dfx, active.prepared->pipeline_slot, true);
-
-    // Device-orch shape: the collector stops, the ring reconciles, and the
-    // records replay. The host-orch shape emits at the end of bind instead, where
-    // its capture window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
-    if (dfx.dep_gen_enabled && !dep_gen_host_graph_active()) {
-        dep_gen_collector_.quiesce();
-        if (dep_gen_collector_.reconcile_counters()) {
-            const std::string deps = make_deps_json_path(dfx.output_prefix);
-            const auto &records = dep_gen_collector_.records();
-            int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
-            if (replay_rc != 0) {
-                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
-            }
-        }
-    }
+    emit_device_dep_gen_graph(dfx);
 
     print_handshake_results();
 
@@ -643,6 +635,23 @@ int DeviceRunner::drain_execution(ActiveExecution &active) {
     }
 
     return 0;
+}
+
+void DeviceRunner::emit_device_dep_gen_graph(const DfxRunConfig &dfx) {
+    // The host-orch shape emits at the end of bind instead, where its capture
+    // window closes — see `emit_host_dep_gen_graph` in c_api_shared.cpp.
+    if (!dfx.dep_gen_enabled || dep_gen_host_graph_active()) return;
+    dep_gen_collector_.quiesce();
+    // reconcile_counters() is the completeness gate: an un-flushed device buffer
+    // or a dropped record makes it false and no deps.json is written, so a run
+    // that failed mid-flight yields a whole graph or none — never a partial one.
+    if (!dep_gen_collector_.reconcile_counters()) return;
+    const std::string deps = make_deps_json_path(dfx.output_prefix);
+    const auto &records = dep_gen_collector_.records();
+    int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+    if (replay_rc != 0) {
+        LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
+    }
 }
 
 void DeviceRunner::abandon_prepared_execution(PreparedExecution &) noexcept {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -71,6 +71,12 @@ private:
     int init_scope_stats(int num_threads);
     int init_dep_gen(int num_threads, int device_id);
 
+    // Emit the device-orchestration dep_gen graph, on both the success and the
+    // error return of drain_execution: the AICPU threads are joined before
+    // either, so a failed run's records are as complete as the run made them.
+    // Its own reconcile is the completeness gate — see the definition.
+    void emit_device_dep_gen_graph(const DfxRunConfig &dfx);
+
     // Per-run collector teardown: stop + release shm so a session-scoped Worker
     // can re-init collectors on the next enqueue. Matches a2a3 sim.
     void finalize_collectors();

--- a/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
+++ b/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
@@ -380,3 +380,43 @@ def test_device_error_class_reaches_host_log(st_platform, st_device_ids, case_na
         _assert_annotated(log, case)
     finally:
         worker.close()
+
+
+# The orchestrator fatals before any task completes, so this case leaves the
+# swimlane collector empty and only the two collectors asserted below hold
+# anything. That is deliberate: the point is the teardown, not the volume.
+_DFX_ON_FAILURE_CASE = "scope_deadlock"
+
+
+@pytest.mark.platforms(["a5sim", "a2a3sim", "a2a3"])
+@pytest.mark.device_count(1)
+@pytest.mark.runtime(RUNTIME)
+def test_failed_run_exports_its_diagnostics(st_platform, st_device_ids, monkeypatch, tmp_path):
+    """A run that fails still exports the collectors it armed."""
+    configure_logging("error")
+    worker, handle, config = _make_worker(st_platform, int(st_device_ids[0]), _DFX_ON_FAILURE_CASE, monkeypatch)
+    out = tmp_path / "fatal_dfx"
+    config.output_prefix = str(out)
+    # chip_swimlane is enabled but not asserted: it exports nothing when a run
+    # holds no task records, so its artifact cannot witness the teardown. It is
+    # on so the failure path drives its export too.
+    config.enable_chip_swimlane = 1
+    config.enable_scope_stats = True
+    config.enable_dep_gen = True
+    try:
+        with pytest.raises(RuntimeError):
+            worker.run(handle, None, config)
+    finally:
+        worker.close()
+
+    produced = sorted(str(p.relative_to(out)) for p in out.rglob("*")) if out.is_dir() else []
+    # scope_stats writes whenever its collector initialized, so it carries no
+    # record-count precondition, and it is written last in the teardown: its
+    # absence means the teardown did not run, or did not run to the end.
+    assert (out / "scope_stats" / "scope_stats.jsonl").is_file(), (
+        f"the failed run exported no scope_stats; {out} holds {produced}"
+    )
+    # The dep_gen emit follows the teardown and has its own completeness gate,
+    # so it needs its own assertion. The device flushes its dep_gen buffers
+    # during emergency shutdown, which is what lets the gate pass here.
+    assert (out / "deps.json").is_file(), f"the failed run emitted no deps.json; {out} holds {produced}"


### PR DESCRIPTION
## Summary

A run that fails is the run whose swimlane, dumped tensors and dependency graph someone actually wants to read, and on **sim** it was the one run that exported none of them. `drain_execution`'s `runtime_rc != 0` return closed the clock-correlation session and left immediately, skipping the whole collector teardown. The AICPU threads are joined before that check, so the records were already there and simply never written.

**Onboard** already ran the teardown on its error path — for the reason its own comment gives: emergency shutdown flushes the device's diagnostic buffers before the timeout rc comes back, so without the export the dumped tensors reach `.bin` with no manifest. But `dep_gen` sat outside that reasoning for no reason, inline *after* the error return, so the dependency graph of a run that deadlocked was discarded.

| | before | after |
| --- | --- | --- |
| sim failure path | `finish_clock_correlation_session` only | full teardown + dep_gen |
| onboard failure path | full teardown | + dep_gen |

## What changed

- Both sim runners call the same `teardown_shared_collectors_after_run` the success path runs, with `device_execution_complete=false`. That argument withholds exactly one thing — the `DeviceExecutionComplete` clock anchor, which a failed run never reached — and it subsumes the `finish_clock_correlation_session` call it replaces, since the teardown opens with it.
- All four runners emit dep_gen from both paths, extracted as `emit_device_dep_gen_graph` so the two cannot drift.
- Two header comments claimed `cleanup_execution` releases the run's collectors; both files' own bodies say the opposite (*"not per-run: they are released in `finalize()`"*). The a2a3 one also still justified itself with the diagnostics-based overlap exclusion that #2204 removed. Corrected to match the code.

Emitting dep_gen on a failure path is safe because its own reconcile is a completeness gate: an un-flushed device buffer, a dropped record or a count mismatch makes `reconcile_counters()` false and nothing is written — a run that failed mid-flight yields a whole graph or none, never a partial one. Its `quiesce()` adds no new exposure on a poisoned card either; that error path already quiesces the four other collectors through the shared teardown.

## Testing

`test_failed_run_exports_its_diagnostics` drives the `scope_deadlock` case with scope_stats, dep_gen and chip_swimlane on, and requires the artifacts after the run raises. scope_stats is the witness for the teardown (no record-count precondition, written last in the sequence); deps.json needs its own assertion because the emit follows the teardown and has its own gate; swimlane is enabled but not asserted, since this case fatals in the orchestrator before any task completes.

**Negative control**, reverted and rebuilt, separates the two halves exactly as the table above predicts:

| platform | failing assertion | directory contents |
| --- | --- | --- |
| a2a3sim | scope_stats | `[]` |
| a2a3 onboard | deps.json | `['scope_stats', 'scope_stats/scope_stats.jsonl']` |

Both pass with the change; a5sim passes too.

- [x] a2a3sim full sweep — 40 cases
- [x] a5sim full sweep — 36 cases
- [x] 15 sim DFX channel runs in the `include_dfx_smokes` shape
- [x] a2a3 onboard scene tests in the per-PR CI shape — 67 cases (the new test runs here too)
- [x] pyut 2242 passed / 7 skipped
- [x] cpput 140/140 from a cleared build dir
- [x] ruff, pyright, clang-format, clang-tidy, cpplint, check_retired_names

## Not covered

The four `emit_device_dep_gen_graph` bodies are near-duplicates, as the four inline blocks they replace were: `dep_gen_collector_` is a member of each runner and the two runner bases are unrelated types, so there is nowhere shared to put it until #2162.
