### PR TITLE
Fix: fail the run when a5 cannot set up the PMU collector

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -1076,7 +1076,7 @@ int DeviceRunner::finalize() {
 // `launch_aicpu_kernel` and `launch_aicore_kernel` live on `DeviceRunnerBase`.
 
 int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &prepared) {
-    DfxRunConfig &dfx = prepared.dfx;
+    const DfxRunConfig &dfx = prepared.dfx;
     const int num_aicore = prepared.num_aicore;
     const int launch_aicpu_num = prepared.launch_aicpu_num;
     const int aicpu_thread_num = runtime.get_aicpu_thread_num();

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -787,7 +787,7 @@ int DeviceRunner::finalize() {
 // =============================================================================
 
 int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &prepared) {
-    DfxRunConfig &dfx = prepared.dfx;
+    const DfxRunConfig &dfx = prepared.dfx;
     const int num_aicore = prepared.num_aicore;
     const int launch_aicpu_num = prepared.launch_aicpu_num;
     const int aicpu_thread_num = runtime.get_aicpu_thread_num();

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -969,7 +969,7 @@ void DeviceRunner::finalize_collectors(bool abandon_device_resources) {
 }
 
 int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &prepared) {
-    DfxRunConfig &dfx = prepared.dfx;
+    const DfxRunConfig &dfx = prepared.dfx;
     const int num_aicore = prepared.num_aicore;
     const int active_aicpu_num = prepared.launch_aicpu_num;
     const int aicpu_thread_num = runtime.get_aicpu_thread_num();
@@ -1012,12 +1012,8 @@ int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &pr
     if (dfx.pmu_enabled) {
         rc = init_pmu(num_aicore, active_aicpu_num, device_id_, prepared.kernel_args);
         if (rc != 0) {
-            LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
-            prepared.kernel_args.args.pmu_data_base = 0;
-            // Recorded on this run's own configuration, which the profiling flag
-            // below and the teardown both read. a2a3 fails the whole run on the
-            // same error instead of degrading it.
-            dfx.pmu_enabled = false;
+            LOG_ERROR("init_pmu failed: %d", rc);
+            return rc;
         }
     }
 

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -785,7 +785,7 @@ void DeviceRunner::finalize_collectors() {
 }
 
 int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &prepared) {
-    DfxRunConfig &dfx = prepared.dfx;
+    const DfxRunConfig &dfx = prepared.dfx;
     const int num_aicore = prepared.num_aicore;
     const int launch_aicpu_num = prepared.launch_aicpu_num;
     const int aicpu_thread_num = runtime.get_aicpu_thread_num();
@@ -833,12 +833,8 @@ int DeviceRunner::arm_collectors_for_run(Runtime &runtime, PreparedExecution &pr
     if (dfx.pmu_enabled) {
         rc = init_pmu(num_aicore, launch_aicpu_num, device_id_);
         if (rc != 0) {
-            LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
-            kernel_args_.pmu_data_base = 0;
-            // Recorded on this run's own configuration, which the profiling flag
-            // below and the teardown both read. a2a3 fails the whole run on the
-            // same error instead of degrading it.
-            dfx.pmu_enabled = false;
+            LOG_ERROR("init_pmu failed: %d", rc);
+            return rc;
         }
     }
 


### PR DESCRIPTION
## Summary

Both a5 runners degraded a run whose `init_pmu` failed — zeroed `pmu_data_base`, cleared `pmu_enabled` on the run's own config, and carried on. The caller got a **successful run that silently produced no PMU data**. Both a2a3 runners return the error.

PMU on a5 was the only exception in the whole set. The other four collectors already fail the run on every arch and both platforms:

| collector | a2a3 onboard | a2a3 sim | a5 onboard | a5 sim |
| --- | --- | --- | --- | --- |
| chip_swimlane | fail | fail | fail | fail |
| dump_args | fail | fail | fail | fail |
| **pmu** | **fail** | **fail** | **degrade** | **degrade** |
| dep_gen | fail | fail | fail | fail |
| scope_stats | fail | fail | fail | fail |

A caller that set `enable_pmu` asked for a measurement; a run that returns success without one is indistinguishable from a run that measured nothing interesting.

## The divergence was not a decision

`git log -S` puts its origin at #691 — a broad *"address review comments on a5 profiling collectors"* commit whose own stated theme was **"comment / style alignment with a2a3"**. Neither that message nor any comment since gave a reason for it. Nothing depends on it either: no test and no doc references the degrade.

## What changed

- a5 onboard and a5 sim return the error, with the same log line the other collectors and a2a3 use.
- `arm_collectors_for_run` takes `dfx` by **const** reference in all four runners. That mutation was the only non-const use of it in any of them, so the reference now describes what the function is — a reader of this run's DFX configuration.

The `const` is the regression barrier and is deliberate: `init_pmu` fails only on an allocation failure, which no scene test can reach without a fault-injection gate, so there is no repro test to leave behind. Reintroducing the degrade is instead a **compile error**.

## Testing

- [x] all four platforms build clean
- [x] PMU DFX channel — a2a3sim and a5sim
- [x] a2a3sim full sweep — 40 cases
- [x] a5sim full sweep — 36 cases
- [x] a2a3 onboard scene tests in the per-PR CI shape — 67 cases
- [x] pyut 2265 passed / 7 skipped
- [x] cpput 140/140 from a cleared build dir
- [x] clang-format, cpplint, clang-tidy

## Relation to #2162

This closes the one **behavioral** divergence #2162 lists. The shared-contract work that issue asks for — the two runner bases having no common ancestor despite 88/92 overlapping method names — is untouched and remains open.
